### PR TITLE
[PER-128] Add mesh diagnostics surface

### DIFF
--- a/.omx/plans/PER-128-mesh-diagnostics.md
+++ b/.omx/plans/PER-128-mesh-diagnostics.md
@@ -1,0 +1,30 @@
+# PER-128 Mesh Diagnostics Plan
+
+## Requirements Summary
+
+- Source issue: PER-128 `[MESH][P0-T02] Add mesh status and route diagnostic surface`.
+- The referenced committed `.omx/specs/deep-interview-mesh-distributed-integration.md` and mesh task bundle are not present on the checked-out feature branch; scope is therefore constrained to the Multica issue body and existing mesh implementation.
+- Add a read-only diagnostic surface that explains local mesh state, peers, negotiated services, compatibility failures, route decisions, capacity, active calls, and recent ping/latency state.
+- Preserve privacy-first defaults: do not expose tokens, credentials, MQTT passwords, WebRTC room passwords, API keys, or raw secrets.
+
+## Implementation Steps
+
+1. Extend `app/shared/contracts/models/gateway.py` with `Gateway.GetMeshStatus` and typed response models for local state, peers, services, compatibility, capacity, and route diagnostics.
+2. Implement `GatewayService.get_mesh_status` in `app/services/gateway/service.py` using existing mesh components only: `PeerRegistry`, `RoutingTable`, mesh config, local peer id, and live manifest ACK generation.
+3. Include route diagnostics for configured modules and peer-provided modules so operators can see whether Tooling/DB/TTS route local, remote, none, or error, and why.
+4. Document the dynamic HTTP/API usage in `docs/GATEWAY.md`.
+5. Add focused unit tests for serialization, disabled mesh state, peer diagnostics, route decisions, compatibility failures, capacity, and secret redaction.
+
+## Acceptance Criteria
+
+- `Gateway.GetMeshStatus` returns JSON that answers which peer provides a configured module and why the route goes local, remote, none, or error.
+- Peer lifecycle states include authenticated, negotiated, and stale.
+- Compatibility failures are visible from both the locally generated ACK and the remote ACK stored on peer state.
+- Capacity and active calls are visible per peer service.
+- The response contains no token/password/secret/API-key fields or raw credentials.
+- Targeted tests pass.
+
+## Verification
+
+- `uv run pytest tests/unit/gateway/test_mesh_diagnostics.py -q`
+- If practical after the focused tests pass: targeted mesh/gateway tests that touch routing, negotiation, and gateway service behavior.

--- a/app/services/gateway/service.py
+++ b/app/services/gateway/service.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import math
 import os
+import time
 from typing import Any
 
 from app.helpers.aurora_logger import log_debug, log_error, log_info, log_warning
@@ -18,6 +20,19 @@ from app.shared.config.models import (
     MeshSharing,
 )
 from app.shared.contracts.models.auth import AuthMethods
+from app.shared.contracts.models.common import EmptyInput
+from app.shared.contracts.models.gateway import (
+    GatewayMethods,
+    GetMeshStatusResponse,
+    MeshCompatibilityFailure,
+    MeshLocalStatus,
+    MeshPeerCompatibilityDiagnostic,
+    MeshPeerDiagnostic,
+    MeshPeerServiceDiagnostic,
+    MeshRouteDiagnostic,
+    MeshRouteProviderDiagnostic,
+)
+from app.shared.contracts.registry import method_contract
 from app.shared.services.base_service import BaseService
 
 
@@ -27,6 +42,98 @@ def _config_secret_plain(val: Any) -> Any:
     if hasattr(val, "get_secret_value"):
         return val.get_secret_value()
     return val
+
+
+def _finite_float(value: float | None) -> float | None:
+    if value is None:
+        return None
+    if not math.isfinite(value):
+        return None
+    return float(value)
+
+
+def _age_seconds(now: float, timestamp: float | None) -> float | None:
+    if not timestamp or timestamp <= 0:
+        return None
+    return max(now - timestamp, 0.0)
+
+
+def _peer_service(peer: Any, module: str) -> Any | None:
+    manifest = getattr(peer, "manifest", None)
+    if not manifest:
+        return None
+    for svc in manifest.shared_services:
+        if svc.module == module:
+            return svc
+    return None
+
+
+def _provider_eligibility(
+    peer: Any,
+    service: Any,
+    routing_config: Any | None,
+    mesh_config: Any,
+) -> tuple[bool, str]:
+    if routing_config is None:
+        return False, "no local routing config for this module"
+    if peer.status != "negotiated":
+        return False, f"peer status is {peer.status}"
+    if (
+        routing_config.allowed_peers is not None
+        and peer.peer_id not in routing_config.allowed_peers
+    ):
+        return False, "peer is not in allowed_peers"
+    if routing_config.min_version:
+        from app.services.gateway.mesh.version_compat import is_compatible
+
+        if not is_compatible(
+            routing_config.min_version,
+            service.version,
+            mesh_config.version_policy,
+            routing_config.min_version,
+        ):
+            return False, (
+                f"version {service.version} does not satisfy "
+                f"{routing_config.min_version} under {mesh_config.version_policy} policy"
+            )
+    missing_caps = [
+        cap for cap in routing_config.required_capabilities if cap not in service.capabilities
+    ]
+    if missing_caps:
+        return False, f"missing capabilities: {', '.join(missing_caps)}"
+    if service.max_concurrent > 0 and peer.active_calls >= service.max_concurrent:
+        return False, "peer service is at capacity"
+    return True, "eligible"
+
+
+def _route_reason(
+    *,
+    module: str,
+    config: Any | None,
+    decision_target: str,
+    providers: list[MeshRouteProviderDiagnostic],
+    selected_peer_id: str | None,
+    peer_selection: str,
+) -> str:
+    if config is None:
+        return "no mesh routing config; local delivery is used"
+    if config.prefer == "local_only":
+        return "configured local_only"
+    if config.prefer == "local":
+        return "configured local preference"
+    if decision_target == "remote" and selected_peer_id:
+        return f"selected peer {selected_peer_id} using {peer_selection} policy"
+    if decision_target == "local":
+        if not providers:
+            return f"no peer advertises {module}; fallback={config.fallback} selected local"
+        rejected = [p.reason for p in providers if not p.eligible]
+        detail = "; ".join(sorted(set(rejected))) if rejected else "no eligible remote provider"
+        return f"{detail}; fallback={config.fallback} selected local"
+    if decision_target == "error":
+        return "no eligible remote provider and fallback=error"
+    if decision_target == "none":
+        return "no eligible remote provider and local fallback is disabled"
+    return f"route target is {decision_target}"
 
 
 class GatewayService(BaseService):
@@ -57,6 +164,7 @@ class GatewayService(BaseService):
         self._mesh_latency_monitor = None
         self._mesh_announcer = None
         self._mesh_bus = None
+        self._mesh_peer_id = None
 
     async def on_start(self) -> None:
         """Service-specific startup logic."""
@@ -81,6 +189,194 @@ class GatewayService(BaseService):
             await self._reload_gateway_config()
             await self._reload_auth_config()
             await self._reload_mesh_config()
+
+    @method_contract(
+        method_id=GatewayMethods.GET_MESH_STATUS,
+        summary="Get read-only mesh status and routing diagnostics",
+        input_model=EmptyInput,
+        output_model=GetMeshStatusResponse,
+        exposure="external",
+        method_type="manage",
+        required_perms=["Gateway.manage"],
+    )
+    async def get_mesh_status(self, data: EmptyInput) -> GetMeshStatusResponse:
+        """Return a redacted diagnostic snapshot of mesh state and routing."""
+        settings = await self._get_gateway_config()
+        mesh_config = settings.mesh
+        registry = self._mesh_peer_registry
+        routing_table = self._mesh_routing_table
+
+        shared_modules = sorted(
+            module for module, service in mesh_config.services.items() if service.share
+        )
+        routed_modules = sorted(
+            module
+            for module, service in mesh_config.services.items()
+            if service.prefer not in ("local", "local_only")
+        )
+
+        peers = registry.get_all_peers() if registry else []
+        local = MeshLocalStatus(
+            mesh_enabled=mesh_config.enabled,
+            mesh_started=self._mesh_bus is not None,
+            webrtc_started=self._rtc_client is not None,
+            peer_id=self._mesh_peer_id,
+            node_name=mesh_config.node_name,
+            peer_selection=mesh_config.peer_selection,
+            version_policy=mesh_config.version_policy,
+            shared_modules=shared_modules,
+            routed_modules=routed_modules,
+        )
+
+        peer_diagnostics = [
+            self._build_peer_diagnostic(peer, mesh_config)
+            for peer in sorted(peers, key=lambda p: p.peer_id)
+        ]
+
+        route_modules = set(mesh_config.services.keys())
+        for peer in peers:
+            if peer.manifest:
+                route_modules.update(svc.module for svc in peer.manifest.shared_services)
+
+        route_diagnostics = [
+            self._build_route_diagnostic(module, mesh_config, registry, routing_table)
+            for module in sorted(route_modules)
+        ]
+
+        compatibility_failures: list[MeshCompatibilityFailure] = []
+        for peer in peer_diagnostics:
+            for module in peer.compatibility.local_incompatible:
+                compatibility_failures.append(
+                    MeshCompatibilityFailure(
+                        peer_id=peer.peer_id,
+                        module=module,
+                        direction="local_view_of_remote",
+                        reason="remote service failed local version/capability requirements",
+                    )
+                )
+            for module in peer.compatibility.remote_incompatible:
+                compatibility_failures.append(
+                    MeshCompatibilityFailure(
+                        peer_id=peer.peer_id,
+                        module=module,
+                        direction="remote_view_of_local",
+                        reason="local service failed remote version/capability requirements",
+                    )
+                )
+
+        return GetMeshStatusResponse(
+            local=local,
+            peers=peer_diagnostics,
+            routes=route_diagnostics,
+            compatibility_failures=compatibility_failures,
+            secrets_redacted=True,
+        )
+
+    def _build_peer_diagnostic(self, peer: Any, mesh_config: Any) -> MeshPeerDiagnostic:
+        """Serialize peer state without credential-bearing fields."""
+        from app.services.gateway.mesh.negotiation import generate_manifest_ack
+
+        now = time.monotonic()
+        manifest = peer.manifest
+        local_ack = generate_manifest_ack(manifest, mesh_config) if manifest else None
+
+        services: list[MeshPeerServiceDiagnostic] = []
+        if manifest:
+            for svc in manifest.shared_services:
+                available_capacity = None
+                if svc.max_concurrent > 0:
+                    available_capacity = max(svc.max_concurrent - peer.active_calls, 0)
+                services.append(
+                    MeshPeerServiceDiagnostic(
+                        module=svc.module,
+                        version=svc.version,
+                        capabilities=list(svc.capabilities),
+                        method_names=sorted(m.name for m in svc.methods),
+                        max_concurrent=svc.max_concurrent,
+                        active_calls=peer.active_calls,
+                        available_capacity=available_capacity,
+                        digest=svc.digest,
+                    )
+                )
+
+        return MeshPeerDiagnostic(
+            peer_id=peer.peer_id,
+            node_name=peer.node_name,
+            status=peer.status,
+            latency_ms=_finite_float(peer.latency_ms),
+            last_ping_age_s=_age_seconds(now, peer.last_ping),
+            last_manifest_age_s=_age_seconds(now, peer.last_manifest),
+            active_calls=peer.active_calls,
+            services=services,
+            compatibility=MeshPeerCompatibilityDiagnostic(
+                local_compatible=list(local_ack.compatible_services) if local_ack else [],
+                local_incompatible=list(local_ack.incompatible_services) if local_ack else [],
+                local_unused=list(local_ack.unused_services) if local_ack else [],
+                remote_compatible=list(peer.remote_compatible),
+                remote_incompatible=list(peer.remote_incompatible),
+                remote_unused=list(peer.remote_unused),
+            ),
+        )
+
+    def _build_route_diagnostic(
+        self,
+        module: str,
+        mesh_config: Any,
+        registry: Any,
+        routing_table: Any,
+    ) -> MeshRouteDiagnostic:
+        """Explain the current route decision and peer eligibility for a module."""
+        config = mesh_config.services.get(module)
+        route = None
+        if routing_table:
+            route = routing_table.resolve(f"{module}.Diagnostic")
+
+        providers: list[MeshRouteProviderDiagnostic] = []
+        if registry:
+            for peer in sorted(registry.get_all_peers(), key=lambda p: p.peer_id):
+                svc = _peer_service(peer, module)
+                if not svc:
+                    continue
+                eligible, reason = _provider_eligibility(peer, svc, config, mesh_config)
+                providers.append(
+                    MeshRouteProviderDiagnostic(
+                        peer_id=peer.peer_id,
+                        node_name=peer.node_name,
+                        status=peer.status,
+                        version=svc.version,
+                        latency_ms=_finite_float(peer.latency_ms),
+                        active_calls=peer.active_calls,
+                        max_concurrent=svc.max_concurrent,
+                        eligible=eligible,
+                        reason=reason,
+                    )
+                )
+
+        decision_target = route.target if route else "local"
+        reason = _route_reason(
+            module=module,
+            config=config,
+            decision_target=decision_target,
+            providers=providers,
+            selected_peer_id=route.peer_id if route else None,
+            peer_selection=mesh_config.peer_selection,
+        )
+
+        return MeshRouteDiagnostic(
+            module=module,
+            configured=config is not None,
+            share=bool(config.share) if config else False,
+            prefer=config.prefer if config else "",
+            fallback=config.fallback if config else "",
+            min_version=config.min_version if config else None,
+            required_capabilities=list(config.required_capabilities) if config else [],
+            decision_target=decision_target,
+            decision_peer_id=route.peer_id if route else None,
+            decision_version=route.version if route else "",
+            decision_latency_ms=_finite_float(route.latency_ms) if route else None,
+            reason=reason,
+            providers=providers,
+        )
 
     async def _get_gateway_config(self) -> Any:
         """Get gateway configuration from ConfigService.
@@ -488,6 +784,7 @@ class GatewayService(BaseService):
 
             # ── Fix 1: Stable peer_id from DB ────────────────────────────
             peer_id = await self._get_or_create_peer_id(mesh_config)
+            self._mesh_peer_id = peer_id
 
             # Create mesh components
             self._mesh_peer_registry = PeerRegistry(mesh_config)
@@ -762,6 +1059,7 @@ class GatewayService(BaseService):
                 set_bus(inner)
                 set_shared_bus(inner)
                 self._mesh_bus = None
+                self._mesh_peer_id = None
 
             # Stop background tasks
             if self._mesh_announcer:

--- a/app/shared/contracts/models/gateway.py
+++ b/app/shared/contracts/models/gateway.py
@@ -42,6 +42,7 @@ class GatewayMethods:
     GET_REGISTRY = f"{GatewayModule.NAME}.GetRegistry"
     GET_SERVICES = f"{GatewayModule.NAME}.GetServices"
     GET_SERVICE_HEALTH = f"{GatewayModule.NAME}.GetServiceHealth"
+    GET_MESH_STATUS = f"{GatewayModule.NAME}.GetMeshStatus"
 
 
 # =============================================================================
@@ -163,6 +164,111 @@ class GetServiceHealthResponse(IOModel):
     checks: dict[str, str] = Field(default_factory=dict)  # Component name -> status
     timestamp: str = ""
     error: str | None = None
+
+
+class MeshLocalStatus(IOModel):
+    """Local mesh identity and runtime status."""
+
+    mesh_enabled: bool = False
+    mesh_started: bool = False
+    webrtc_started: bool = False
+    peer_id: str | None = None
+    node_name: str = ""
+    peer_selection: str = ""
+    version_policy: str = ""
+    shared_modules: list[str] = Field(default_factory=list)
+    routed_modules: list[str] = Field(default_factory=list)
+
+
+class MeshPeerServiceDiagnostic(IOModel):
+    """Diagnostic view of a service advertised by a mesh peer."""
+
+    module: str
+    version: str = ""
+    capabilities: list[str] = Field(default_factory=list)
+    method_names: list[str] = Field(default_factory=list)
+    max_concurrent: int = 0
+    active_calls: int = 0
+    available_capacity: int | None = None
+    digest: str = ""
+
+
+class MeshPeerCompatibilityDiagnostic(IOModel):
+    """Compatibility reports for a peer's manifest negotiation."""
+
+    local_compatible: list[str] = Field(default_factory=list)
+    local_incompatible: list[str] = Field(default_factory=list)
+    local_unused: list[str] = Field(default_factory=list)
+    remote_compatible: list[str] = Field(default_factory=list)
+    remote_incompatible: list[str] = Field(default_factory=list)
+    remote_unused: list[str] = Field(default_factory=list)
+
+
+class MeshPeerDiagnostic(IOModel):
+    """Runtime diagnostic view of one mesh peer."""
+
+    peer_id: str
+    node_name: str = ""
+    status: str = "unknown"
+    latency_ms: float | None = None
+    last_ping_age_s: float | None = None
+    last_manifest_age_s: float | None = None
+    active_calls: int = 0
+    services: list[MeshPeerServiceDiagnostic] = Field(default_factory=list)
+    compatibility: MeshPeerCompatibilityDiagnostic = Field(
+        default_factory=MeshPeerCompatibilityDiagnostic
+    )
+
+
+class MeshRouteProviderDiagnostic(IOModel):
+    """Why one peer is or is not eligible to provide a module."""
+
+    peer_id: str
+    node_name: str = ""
+    status: str = "unknown"
+    version: str = ""
+    latency_ms: float | None = None
+    active_calls: int = 0
+    max_concurrent: int = 0
+    eligible: bool = False
+    reason: str = ""
+
+
+class MeshRouteDiagnostic(IOModel):
+    """Diagnostic view of routing for one service module."""
+
+    module: str
+    configured: bool = False
+    share: bool = False
+    prefer: str = ""
+    fallback: str = ""
+    min_version: str | None = None
+    required_capabilities: list[str] = Field(default_factory=list)
+    decision_target: str = "local"
+    decision_peer_id: str | None = None
+    decision_version: str = ""
+    decision_latency_ms: float | None = None
+    reason: str = ""
+    providers: list[MeshRouteProviderDiagnostic] = Field(default_factory=list)
+
+
+class MeshCompatibilityFailure(IOModel):
+    """Flattened compatibility failure for operator scanning."""
+
+    peer_id: str
+    module: str
+    direction: str
+    reason: str = ""
+
+
+class GetMeshStatusResponse(IOModel):
+    """Read-only mesh status and route diagnostic dump."""
+
+    local: MeshLocalStatus = Field(default_factory=MeshLocalStatus)
+    peers: list[MeshPeerDiagnostic] = Field(default_factory=list)
+    routes: list[MeshRouteDiagnostic] = Field(default_factory=list)
+    compatibility_failures: list[MeshCompatibilityFailure] = Field(default_factory=list)
+    secrets_redacted: bool = True
 
 
 class ServiceCountInfo(IOModel):

--- a/docs/GATEWAY.md
+++ b/docs/GATEWAY.md
@@ -191,6 +191,33 @@ Returns all available API routes grouped by service.
 }
 ```
 
+#### Mesh Status and Route Diagnostics
+```
+POST /api/Gateway/GetMeshStatus
+```
+Returns a read-only, redacted diagnostic snapshot of mesh state. The response includes local
+mesh identity, whether WebRTC/mesh components are started, connected peer lifecycle state,
+negotiated peer services, capacity and active calls, recent ping/latency age, compatibility
+ACK results, and per-module route decisions.
+
+The diagnostic output is designed to answer questions such as which peer provides `Tooling`,
+`DB`, or `TTS`, why a route selected local or remote delivery, and which version/capability
+checks made a peer ineligible. Credential-bearing configuration is not included; the response
+does not expose tokens, API keys, MQTT passwords, WebRTC room passwords, or raw secrets.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/api/Gateway/GetMeshStatus \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Key fields:
+- `local`: local mesh enable/start state, stable peer id, node name, shared modules, and routed modules.
+- `peers`: peer status, negotiated services, service capacity, active calls, latency, and compatibility reports.
+- `routes`: configured route preference/fallback plus the current decision and provider eligibility reasons.
+- `compatibility_failures`: flattened local/remote compatibility failures for quick scanning.
+
 ### Service Endpoints
 
 All service methods with `exposure="external"` or `exposure="both"` are automatically exposed as:
@@ -670,4 +697,3 @@ Gateway components are tested in `tests/unit/app/test_gateway.py`:
 - [Peer Pairing Flow](../docs/PEER_PAIRING_FLOW.md)
 - [Mesh Pairing Fix Plan](../docs/MESH_PAIRING_FIX_PLAN.md)
 - [Service Contracts](../app/shared/contracts/README.md)
-

--- a/tests/unit/gateway/test_mesh_diagnostics.py
+++ b/tests/unit/gateway/test_mesh_diagnostics.py
@@ -1,0 +1,155 @@
+"""Unit tests for Gateway mesh diagnostics."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.gateway.config import MeshConfig, MeshServiceConfig, Settings
+from app.services.gateway.mesh.models import ManifestAck, PeerManifest, PeerServiceInfo
+from app.services.gateway.mesh.peer_registry import PeerRegistry
+from app.services.gateway.mesh.routing_table import RoutingTable
+from app.services.gateway.service import GatewayService
+from app.shared.contracts.models.common import EmptyInput
+from app.shared.contracts.models.gateway import MethodInfo
+
+
+def _service_with_settings(settings: Settings) -> GatewayService:
+    service = GatewayService()
+    service._get_gateway_config = AsyncMock(return_value=settings)
+    return service
+
+
+def _peer_service(module: str, version: str = "1.2.0", max_concurrent: int = 4):
+    return PeerServiceInfo(
+        module=module,
+        version=version,
+        capabilities=["tools", "basic"],
+        methods=[
+            MethodInfo(
+                name="Execute",
+                summary="execute",
+                bus_topic=f"{module}.Execute",
+                exposure="external",
+            )
+        ],
+        max_concurrent=max_concurrent,
+        digest=f"digest-{module}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_mesh_status_reports_disabled_state_without_components():
+    service = _service_with_settings(Settings(mesh=MeshConfig(enabled=False, node_name="local")))
+
+    response = await service.get_mesh_status(EmptyInput())
+
+    assert response.local.mesh_enabled is False
+    assert response.local.mesh_started is False
+    assert response.local.webrtc_started is False
+    assert response.local.node_name == "local"
+    assert response.peers == []
+    assert response.routes == []
+    assert response.secrets_redacted is True
+
+
+@pytest.mark.asyncio
+async def test_mesh_status_reports_route_provider_capacity_and_compatibility():
+    mesh_config = MeshConfig(
+        enabled=True,
+        node_name="local-node",
+        services={
+            "Tooling": MeshServiceConfig(
+                share=True,
+                prefer="network",
+                fallback="local",
+                min_version="1.0.0",
+                required_capabilities=["tools"],
+            ),
+            "DB": MeshServiceConfig(prefer="network_only", fallback="error"),
+        },
+    )
+    registry = PeerRegistry(mesh_config)
+    routing_table = RoutingTable(mesh_config, registry)
+
+    await registry.register_peer("peer-old", "old-node")
+    await registry.update_manifest(
+        "peer-old",
+        PeerManifest(
+            peer_id="peer-old",
+            node_name="old-node",
+            shared_services=[_peer_service("Tooling", version="0.9.0")],
+        ),
+    )
+    await registry.update_latency("peer-old", 10.0)
+
+    await registry.register_peer("peer-good", "good-node")
+    await registry.update_manifest(
+        "peer-good",
+        PeerManifest(
+            peer_id="peer-good",
+            node_name="good-node",
+            shared_services=[_peer_service("Tooling", version="1.2.0", max_concurrent=4)],
+        ),
+    )
+    await registry.update_latency("peer-good", 25.0)
+    await registry.increment_active_calls("peer-good")
+    await registry.update_manifest_ack(
+        "peer-good",
+        ManifestAck(incompatible_services=["DB"], compatible_services=["Tooling"]),
+    )
+
+    service = _service_with_settings(Settings(mesh=mesh_config))
+    service._mesh_peer_registry = registry
+    service._mesh_routing_table = routing_table
+    service._mesh_bus = object()
+    service._rtc_client = object()
+    service._mesh_peer_id = "local-peer"
+
+    response = await service.get_mesh_status(EmptyInput())
+
+    assert response.local.mesh_enabled is True
+    assert response.local.mesh_started is True
+    assert response.local.webrtc_started is True
+    assert response.local.peer_id == "local-peer"
+    assert response.local.shared_modules == ["Tooling"]
+    assert response.local.routed_modules == ["DB", "Tooling"]
+
+    tooling_route = next(route for route in response.routes if route.module == "Tooling")
+    assert tooling_route.decision_target == "remote"
+    assert tooling_route.decision_peer_id == "peer-good"
+    assert tooling_route.reason == "selected peer peer-good using lowest_latency policy"
+
+    providers = {provider.peer_id: provider for provider in tooling_route.providers}
+    assert providers["peer-good"].eligible is True
+    assert providers["peer-good"].active_calls == 1
+    assert providers["peer-good"].max_concurrent == 4
+    assert providers["peer-old"].eligible is False
+    assert "does not satisfy" in providers["peer-old"].reason
+
+    good_peer = next(peer for peer in response.peers if peer.peer_id == "peer-good")
+    tooling = next(svc for svc in good_peer.services if svc.module == "Tooling")
+    assert tooling.available_capacity == 3
+    assert tooling.active_calls == 1
+    assert tooling.method_names == ["Execute"]
+    assert good_peer.compatibility.remote_incompatible == ["DB"]
+
+    failures = {
+        (failure.peer_id, failure.module, failure.direction)
+        for failure in response.compatibility_failures
+    }
+    assert ("peer-old", "Tooling", "local_view_of_remote") in failures
+    assert ("peer-good", "DB", "remote_view_of_local") in failures
+
+
+@pytest.mark.asyncio
+async def test_mesh_status_output_does_not_include_secret_field_names():
+    mesh_config = MeshConfig(enabled=True, node_name="local")
+    service = _service_with_settings(Settings(mesh=mesh_config))
+
+    response = await service.get_mesh_status(EmptyInput())
+    payload = response.model_dump_json().lower()
+
+    assert "password" not in payload
+    assert "token" not in payload
+    assert "api_key" not in payload
+    assert response.secrets_redacted is True


### PR DESCRIPTION
## Summary

Adds a read-only Gateway mesh diagnostics contract surface via `Gateway.GetMeshStatus` / `POST /api/Gateway/GetMeshStatus`.

The diagnostic response reports local mesh identity/start state, peer lifecycle state, negotiated peer services, capacity and active calls, latency/ping ages, local and remote compatibility ACK failures, and per-module route decisions with provider eligibility reasons.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python UV_LINK_MODE=copy /tmp/uv-bootstrap/bin/uv run --python 3.11 --extra dev ruff check app/shared/contracts/models/gateway.py app/services/gateway/service.py tests/unit/gateway/test_mesh_diagnostics.py`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python UV_LINK_MODE=copy /tmp/uv-bootstrap/bin/uv run --python 3.11 --extra test-unit --with aiosqlite pytest tests/unit/gateway/test_mesh_diagnostics.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python UV_LINK_MODE=copy /tmp/uv-bootstrap/bin/uv run --python 3.11 --extra test-unit --with aiosqlite pytest tests/unit/gateway/test_negotiation.py tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_peer_registry.py tests/unit/gateway/test_mesh_diagnostics.py -q`

## Notes

`uv` was not installed in the runtime and the default Python was 3.14, so validation bootstrapped `uv` into `/tmp` and installed Python 3.11 with `UV_CACHE_DIR` / `UV_PYTHON_INSTALL_DIR` redirected to writable paths.

The referenced committed `.omx/specs/deep-interview-mesh-distributed-integration.md` and mesh task bundle were not present on this checked-out branch, so the implementation was scoped to the Multica issue body and existing mesh code.
