### PR TITLE
PER-130: Scope saved WebRTC mesh tokens by peer

### DIFF
--- a/.omx/plans/PER-130-peer-scoped-webrtc-tokens.md
+++ b/.omx/plans/PER-130-peer-scoped-webrtc-tokens.md
@@ -1,0 +1,24 @@
+# PER-130 Peer-Scoped WebRTC Token Plan
+
+## Sources
+- Multica issue PER-130 and empty comment history.
+- Repo guidance: root, services, gateway, auth, and tests AGENTS files.
+- Available mesh context: `.omx/plans/PER-129-stable-mesh-identity.md`; the issue-named mesh roadmap files are not present in this checkout.
+- Code paths: `app/services/gateway/webrtc/rtc_client.py`, `app/services/gateway/service.py`, `app/services/gateway/auth_proxy.py`, `app/services/auth/service.py`, `tests/unit/gateway/test_rtc_client_auth.py`.
+
+## Acceptance Criteria
+- Saved token lookup is peer-specific.
+- Multi-peer reconnects authenticate with the correct token.
+- Missing or ambiguous peer identity fails safe into pairing rather than sending a random token.
+- Tests cover two or more saved peer credentials.
+
+## Implementation Steps
+1. Add an `RTCClient` helper that resolves a saved token by known stable remote peer ID or active session ID.
+2. Preserve `_default` only as a legacy single-credential fallback when no peer-specific tokens are loaded.
+3. Remove arbitrary single-token fallback from channel-open auth.
+4. Make reverse-pairing skip only when the resolver can safely identify a saved credential for the peer.
+5. Add tests for exact stable-peer selection, ambiguous unknown peer safe-fail, and legacy `_default` fallback.
+6. Run targeted gateway auth tests.
+
+## Verification Strategy
+- `uv run pytest tests/unit/gateway/test_rtc_client_auth.py tests/unit/gateway/test_rtc_auth_enforcement.py -q`

--- a/app/services/gateway/webrtc/rtc_client.py
+++ b/app/services/gateway/webrtc/rtc_client.py
@@ -154,6 +154,53 @@ class RTCClient:
             self._peer_names[session_peer_id] = node_name
         return stable
 
+    def _saved_auth_token_for_peer(self, peer: str) -> str | None:
+        """Return a saved token only when it can be scoped to this peer.
+
+        Per-peer credentials are keyed by stable mesh peer ID. A session-keyed
+        token is accepted for migration from older runtime state. The legacy
+        ``_default`` credential is only accepted when it is the sole saved
+        credential for the room; once peer-scoped credentials exist, using a
+        default token for an unknown peer is ambiguous and must fail safe.
+        """
+        stable_peer_id = self._stable_peer_id_for_session(peer)
+        candidate_keys = [stable_peer_id]
+        if peer != stable_peer_id:
+            candidate_keys.append(peer)
+
+        for key in candidate_keys:
+            token = self._saved_auth_tokens.get(key)
+            if token:
+                log_debug(
+                    f"Saved WebRTC token lookup hit for peer {peer[:8]}… "
+                    f"using credential key {key[:8]}…"
+                )
+                return token
+
+        peer_scoped_keys = [key for key in self._saved_auth_tokens if key != "_default"]
+        default_token = self._saved_auth_tokens.get("_default")
+        if default_token and not peer_scoped_keys:
+            log_info(
+                f"Using legacy default saved WebRTC token for peer {peer[:8]}…; "
+                "no peer-scoped credentials are loaded"
+            )
+            return default_token
+
+        if default_token and peer_scoped_keys:
+            log_warning(
+                f"Saved WebRTC token lookup miss for peer {peer[:8]}… "
+                f"(stable={stable_peer_id[:8]}…); refusing legacy default because "
+                "peer-scoped credentials are loaded"
+            )
+        elif peer_scoped_keys:
+            log_info(
+                f"Saved WebRTC token lookup miss for peer {peer[:8]}… "
+                f"(stable={stable_peer_id[:8]}…); pairing is required"
+            )
+        else:
+            log_debug(f"No saved WebRTC token available for peer {peer[:8]}…")
+        return None
+
     def set_saved_auth_token(self, token: str | None) -> None:
         """Set a single saved auth token (legacy/fallback).
 
@@ -940,8 +987,7 @@ class RTCClient:
         """
         # Skip if we already have tokens from a prior pairing exchange
         # (we initiated pairing earlier, so both sides already trust each other).
-        stable_peer_id = self._stable_peer_id_for_session(peer)
-        if stable_peer_id in self._saved_auth_tokens or "_default" in self._saved_auth_tokens:
+        if self._saved_auth_token_for_peer(peer):
             log_debug(
                 f"Reverse pairing skipped for {peer[:8]}… — "
                 "we already hold a saved token for this peer"
@@ -1026,14 +1072,7 @@ class RTCClient:
                 if self._require_auth:
                     # If we have a saved token from a previous pairing exchange,
                     # send it immediately to authenticate as a returning peer.
-                    stable_peer_id = self._stable_peer_id_for_session(peer)
-                    saved_token = (
-                        self._saved_auth_tokens.get(stable_peer_id)
-                        or self._saved_auth_tokens.get(peer)
-                        or self._saved_auth_tokens.get("_default")
-                    )
-                    if not saved_token and len(self._saved_auth_tokens) == 1:
-                        saved_token = next(iter(self._saved_auth_tokens.values()), None)
+                    saved_token = self._saved_auth_token_for_peer(peer)
                     if saved_token:
                         auth_msg = {
                             "type": "auth",

--- a/tests/unit/gateway/test_rtc_client_auth.py
+++ b/tests/unit/gateway/test_rtc_client_auth.py
@@ -163,6 +163,75 @@ async def test_rtc_client_presence_identity_selects_saved_token_for_new_session(
 
 
 @pytest.mark.asyncio
+async def test_rtc_client_unknown_peer_does_not_receive_unrelated_saved_token(mock_deps):
+    """Unknown sessions fail safe when multiple peer-scoped tokens are loaded."""
+    settings, bus, registry, auth_service = mock_deps
+    client = RTCClient(settings, bus, registry, auth_service, require_auth=True)
+    client._system_token = "system-token"
+    client._saved_auth_tokens = {
+        "stable-remote-peer-a": "token-for-remote-a",
+        "stable-remote-peer-b": "token-for-remote-b",
+    }
+
+    mock_pc = MagicMock()
+    mock_channel = MockDataChannel()
+    mock_pc.createDataChannel.return_value = mock_channel
+
+    with patch("app.services.gateway.webrtc.rtc_client.RTCPeerConnection", return_value=mock_pc):
+        await client._ensure_pc("unknown-session-peer", is_offer_initiator=True)
+        mock_channel.emit("open")
+
+        assert mock_channel.sent_messages == []
+        assert "unknown-session-peer" in client._pairing_tasks
+
+
+@pytest.mark.asyncio
+async def test_rtc_client_legacy_default_token_used_only_when_unambiguous(mock_deps):
+    """A sole legacy `_default` token remains usable for single-peer migration."""
+    settings, bus, registry, auth_service = mock_deps
+    client = RTCClient(settings, bus, registry, auth_service, require_auth=True)
+    client._system_token = "system-token"
+    client._saved_auth_tokens = {"_default": "legacy-room-token"}
+
+    mock_pc = MagicMock()
+    mock_channel = MockDataChannel()
+    mock_pc.createDataChannel.return_value = mock_channel
+
+    with patch("app.services.gateway.webrtc.rtc_client.RTCPeerConnection", return_value=mock_pc):
+        await client._ensure_pc("unknown-session-peer", is_offer_initiator=True)
+        mock_channel.emit("open")
+
+        assert len(mock_channel.sent_messages) == 1
+        msg = json.loads(mock_channel.sent_messages[0])
+        assert msg["type"] == "auth"
+        assert msg["token"] == "legacy-room-token"
+        assert "unknown-session-peer" not in client._pairing_tasks
+
+
+@pytest.mark.asyncio
+async def test_rtc_client_default_token_not_used_when_peer_tokens_exist(mock_deps):
+    """A legacy default plus peer tokens is ambiguous without an exact peer hit."""
+    settings, bus, registry, auth_service = mock_deps
+    client = RTCClient(settings, bus, registry, auth_service, require_auth=True)
+    client._system_token = "system-token"
+    client._saved_auth_tokens = {
+        "_default": "legacy-room-token",
+        "stable-remote-peer-a": "token-for-remote-a",
+    }
+
+    mock_pc = MagicMock()
+    mock_channel = MockDataChannel()
+    mock_pc.createDataChannel.return_value = mock_channel
+
+    with patch("app.services.gateway.webrtc.rtc_client.RTCPeerConnection", return_value=mock_pc):
+        await client._ensure_pc("unknown-session-peer", is_offer_initiator=True)
+        mock_channel.emit("open")
+
+        assert mock_channel.sent_messages == []
+        assert "unknown-session-peer" in client._pairing_tasks
+
+
+@pytest.mark.asyncio
 async def test_rtc_client_manifest_uses_stable_local_identity(mock_deps):
     """Manifest exchange exposes stable local mesh identity."""
     settings, bus, registry, auth_service = mock_deps


### PR DESCRIPTION
## Summary
- Adds peer-scoped saved-token resolution in RTCClient so reconnect auth only uses exact stable/session peer credentials.
- Preserves legacy `_default` token fallback only when it is the sole saved credential for a room.
- Prevents ambiguous multi-peer reconnects from sending an unrelated saved token; they fall back to pairing instead.
- Adds focused gateway auth tests for multi-peer token selection and safe-fail behavior.

## Verification
- `python -m py_compile app/services/gateway/webrtc/rtc_client.py tests/unit/gateway/test_rtc_client_auth.py`
- `git diff --check`

## Not run
- `uv run pytest tests/unit/gateway/test_rtc_client_auth.py tests/unit/gateway/test_rtc_auth_enforcement.py -q`: `uv` is not installed in this runtime.
- pytest/ruff: unavailable in this runtime; only Python 3.14.6 is on PATH, outside Aurora's supported Python 3.10-3.11 range.
