### PR TITLE
[PER-131] Make reverse pairing peer-specific

### DIFF
--- a/.omx/plans/PER-131-peer-specific-reverse-pairing.md
+++ b/.omx/plans/PER-131-peer-specific-reverse-pairing.md
@@ -1,0 +1,26 @@
+# PER-131 Peer-Specific Reverse Pairing Plan
+
+## Sources
+- Multica issue PER-131, metadata, and empty comment history.
+- Repo guidance: root `AGENTS.md`, `app/services/AGENTS.md`, `app/services/gateway/AGENTS.md`, `app/services/auth/AGENTS.md`, and `tests/AGENTS.md`.
+- Code paths: `app/services/gateway/webrtc/rtc_client.py`, gateway RTC auth tests.
+- Docs: `docs/PEER_PAIRING_FLOW.md`, `docs/MESH_PAIRING_FIX_PLAN.md`.
+
+## Scope
+- Ensure `_reverse_pairing()` skips only when this node already holds a saved credential keyed to the current remote stable peer.
+- Preserve reconnect auth fallback behavior that can still use legacy `_default` tokens before the remote stable peer is known.
+- Add focused multi-peer coverage and update bilateral pairing docs.
+
+## Implementation Steps
+1. Keep stable-peer lookup through `_stable_peer_id_for_session(peer)`.
+2. Change reverse-pairing skip logic to check only the current peer's stable token key, not `_default` or unrelated tokens.
+3. Expand log messages to include the stable peer key used for the start/skip decision.
+4. Add unit tests covering peer A already saved and peer B newly authenticated, including legacy `_default` presence.
+5. Update docs so Phase 2 says the skip is peer-specific.
+6. Run targeted RTC auth tests.
+
+## Verification
+- `uv run pytest tests/unit/gateway/test_rtc_client_auth.py tests/unit/gateway/test_rtc_auth_enforcement.py -q`
+
+## Notes
+- The branch checkout lacks the committed `.omx/specs/deep-interview-mesh-distributed-integration.md` and per-task mesh task bundle named by the issue, so the Multica issue body and available docs are the task source of truth for this run.

--- a/.omx/ultragoal/PER-131-checkpoints.md
+++ b/.omx/ultragoal/PER-131-checkpoints.md
@@ -1,0 +1,15 @@
+# PER-131 Ultragoal Checkpoints
+
+- [x] Read issue, metadata, and full comment history.
+- [x] Read relevant repo AGENTS and bilateral pairing docs.
+- [x] Build plan artifact for peer-specific reverse pairing.
+- [x] Implement scoped code/test/doc changes.
+- [x] Run targeted verification.
+  - `python -m py_compile app/services/gateway/webrtc/rtc_client.py tests/unit/gateway/test_rtc_client_auth.py` passed.
+  - `git diff --check` passed.
+  - `uv run pytest tests/unit/gateway/test_rtc_client_auth.py tests/unit/gateway/test_rtc_auth_enforcement.py -q` could not run because `uv` is not installed in this runtime; no `.venv` or `pytest` is available, and system Python is 3.14.6.
+- [x] Commit and publish PR.
+  - Commit: `76be14c7d230365dc8c29fb74402df94317341d2`.
+  - Draft PR: https://github.com/joaojhgs/aurora/pull/29.
+  - GitHub reports PR #29 open, draft, mergeable, with no checks reported yet.
+- [ ] Hand off to QA.

--- a/app/services/gateway/webrtc/rtc_client.py
+++ b/app/services/gateway/webrtc/rtc_client.py
@@ -938,13 +938,14 @@ class RTCClient:
         This makes the mesh truly bilateral — each side has a token
         (and therefore a principal) on the other side.
         """
-        # Skip if we already have tokens from a prior pairing exchange
-        # (we initiated pairing earlier, so both sides already trust each other).
+        # Skip only if we already have a saved credential for this remote
+        # stable peer. A legacy/default token or another peer's token must not
+        # suppress reverse pairing for a newly authenticated peer.
         stable_peer_id = self._stable_peer_id_for_session(peer)
-        if stable_peer_id in self._saved_auth_tokens or "_default" in self._saved_auth_tokens:
+        if stable_peer_id in self._saved_auth_tokens:
             log_debug(
                 f"Reverse pairing skipped for {peer[:8]}… — "
-                "we already hold a saved token for this peer"
+                f"saved token exists for stable peer {stable_peer_id}"
             )
             return
 
@@ -960,7 +961,8 @@ class RTCClient:
 
         log_info(
             f"Phase 2: Initiating reverse pairing with peer {peer[:8]}… "
-            f"(they authenticated to us, now we authenticate to them)"
+            f"(stable_peer_id={stable_peer_id}; "
+            "they authenticated to us, now we authenticate to them)"
         )
 
         # Reuse the standard pairing flow — it will call PairingStart on the

--- a/docs/MESH_PAIRING_FIX_PLAN.md
+++ b/docs/MESH_PAIRING_FIX_PLAN.md
@@ -433,8 +433,10 @@ async def _initiate_bilateral_pairing(self, peer: str, chan: Any) -> None:
 async def _on_peer_authenticated(self, peer: str, chan: Any, identity: Identity) -> None:
     """Called when a peer successfully authenticates to us.
     
-    If we have no saved credential for them (no inbound token),
-    start reverse pairing to get OUR token from THEIR auth service.
+    If we have no saved credential keyed to this remote stable peer_id
+    (no inbound token for this peer), start reverse pairing to get OUR token
+    from THEIR auth service. Credentials for other peers or legacy/default
+    fallback tokens must not suppress this step.
     """
     peer_record = await self._load_peer_record(peer)
     if not peer_record or not peer_record.get("inbound_token"):

--- a/docs/PEER_PAIRING_FLOW.md
+++ b/docs/PEER_PAIRING_FLOW.md
@@ -430,7 +430,7 @@ Phase 2 (`_reverse_pairing`) is automatically triggered inside `validate_peer()`
 2. `validate_peer()` validates the token, builds an `Identity`, and stores it in `_peer_acl`.
 3. If mesh is enabled, the peer is registered in `PeerRegistry` and manifests are exchanged.
 4. `_reverse_pairing(peer)` is called as an `asyncio.create_task()`.
-5. `_reverse_pairing()` checks if we already have an auth token (meaning we initiated the forward pairing). If so, it skips — the reverse direction is not needed because we already hold a token.
+5. `_reverse_pairing()` checks if we already have an auth token for that remote peer's stable `peer_id` (meaning we initiated the forward pairing with this same peer). If so, it skips — the reverse direction is not needed because we already hold a peer-specific token. Legacy/default tokens or tokens for other peers do not suppress reverse pairing for this peer.
 6. If we don't have a token, it calls `_initiate_pairing(peer, chan)` which runs the standard 4-phase flow (PairingStart → PairingConnect → PairingExchange) on the **remote peer's** auth service via DataChannel RPC.
 
 ### Partial Completion

--- a/tests/unit/gateway/test_rtc_client_auth.py
+++ b/tests/unit/gateway/test_rtc_client_auth.py
@@ -163,6 +163,43 @@ async def test_rtc_client_presence_identity_selects_saved_token_for_new_session(
 
 
 @pytest.mark.asyncio
+async def test_reverse_pairing_skips_only_current_stable_peer_token(mock_deps):
+    """Reverse pairing skip is scoped to the authenticated remote stable peer."""
+    settings, bus, registry, auth_service = mock_deps
+    client = RTCClient(settings, bus, registry, auth_service, require_auth=True)
+    channel = MockDataChannel()
+    client._peer_data_channels["session-peer-a"] = channel
+    client._remember_stable_peer_id("session-peer-a", "stable-peer-a")
+    client._saved_auth_tokens["stable-peer-a"] = "token-for-peer-a"
+    client._initiate_pairing = AsyncMock()
+
+    await client._reverse_pairing("session-peer-a")
+
+    client._initiate_pairing.assert_not_awaited()
+    assert "session-peer-a" not in client._pairing_tasks
+
+
+@pytest.mark.asyncio
+async def test_reverse_pairing_starts_for_new_peer_despite_other_saved_tokens(mock_deps):
+    """A saved/default token for peer A must not suppress reverse pairing for peer B."""
+    settings, bus, registry, auth_service = mock_deps
+    client = RTCClient(settings, bus, registry, auth_service, require_auth=True)
+    channel = MockDataChannel()
+    client._peer_data_channels["session-peer-b"] = channel
+    client._remember_stable_peer_id("session-peer-a", "stable-peer-a")
+    client._remember_stable_peer_id("session-peer-b", "stable-peer-b")
+    client._saved_auth_tokens["stable-peer-a"] = "token-for-peer-a"
+    client._saved_auth_tokens["_default"] = "legacy-default-token"
+    client._initiate_pairing = AsyncMock()
+
+    await client._reverse_pairing("session-peer-b")
+
+    task = client._pairing_tasks["session-peer-b"]
+    await task
+    client._initiate_pairing.assert_awaited_once_with("session-peer-b", channel)
+
+
+@pytest.mark.asyncio
 async def test_rtc_client_manifest_uses_stable_local_identity(mock_deps):
     """Manifest exchange exposes stable local mesh identity."""
     settings, bus, registry, auth_service = mock_deps


### PR DESCRIPTION
## Summary
- Make WebRTC reverse pairing skip only when a saved token exists for the current remote stable peer ID.
- Keep legacy/default reconnect auth fallback behavior, but prevent it from suppressing reverse pairing for another peer.
- Add focused RTCClient unit coverage for peer-specific skip/start behavior and update bilateral pairing docs.

## Root Cause
`RTCClient._reverse_pairing()` treated the legacy `_default` saved token as sufficient evidence that the current authenticated peer already had an inbound credential. In multi-peer setups, a credential for peer A could therefore suppress reverse pairing for peer B.

## Validation
- `python -m py_compile app/services/gateway/webrtc/rtc_client.py tests/unit/gateway/test_rtc_client_auth.py` passed.
- `git diff --check` passed.
- `uv run pytest tests/unit/gateway/test_rtc_client_auth.py tests/unit/gateway/test_rtc_auth_enforcement.py -q` could not run in this runtime because `uv`, `.venv`, and `pytest` are unavailable; system Python is 3.14.6, outside Aurora's supported 3.10-3.11 range.
