### PR TITLE
[PER-133] Clarify DataChannel app-layer E2EE behavior

### DIFF
--- a/.omx/plans/PER-133-datachannel-app-layer-e2ee.md
+++ b/.omx/plans/PER-133-datachannel-app-layer-e2ee.md
@@ -1,0 +1,35 @@
+# PER-133 DataChannel App-Layer E2EE Plan
+
+## Requirements Summary
+
+- Source issue: PER-133, `[MESH][P1-T05] Clarify and test DataChannel app-layer E2EE behavior`.
+- Scope is limited to WebRTC DataChannel payload encoding/decoding, mismatch behavior, directly affected tests, and gateway/pairing docs.
+- Local branch is missing the referenced `.omx/specs/deep-interview-mesh-distributed-integration.md` and `.omx/multica/mesh-roadmap-tasks/` artifacts, so the issue body and present docs/code are the source of truth.
+
+## Decision
+
+Support both configured modes explicitly:
+
+- `services.gateway.webrtc.enable_app_layer_e2ee=false`: send JSON text over WebRTC DataChannels and rely on WebRTC DTLS plus authenticated peer gates.
+- `services.gateway.webrtc.enable_app_layer_e2ee=true`: seal all RTCClient-managed DataChannel JSON messages with AEAD using the room data key and send them as binary frames.
+
+No automatic plaintext fallback is allowed when app-layer E2EE is enabled; plaintext inbound messages are treated as a peer configuration mismatch and dropped.
+
+## Implementation Steps
+
+1. Centralize DataChannel send encoding in `app/services/gateway/webrtc/rtc_client.py` so RPC calls, auth messages, manifests, ping/pong, capacity updates, and forwarded events use the same mode.
+2. Centralize inbound DataChannel decoding in `rtc_client.py`; when E2EE is enabled require binary AEAD frames, and when disabled parse plaintext JSON while logging binary decode failures.
+3. Add unit tests in `tests/unit/gateway/` covering plaintext send, encrypted send/decrypt, encrypted inbound handling, and plaintext mismatch drop.
+4. Update `docs/GATEWAY.md` and `docs/PEER_PAIRING_FLOW.md` to distinguish signaling encryption, WebRTC DTLS, and optional app-layer DataChannel E2EE.
+
+## Acceptance Criteria
+
+- Config option behavior is unambiguous in code and docs.
+- Outbound/inbound paths are symmetric for both modes.
+- Mismatched peers fail safely by dropping undecodable or plaintext-when-encrypted messages.
+- Tests cover encrypted and non-encrypted DataChannel paths.
+
+## Verification
+
+- `uv run pytest tests/unit/gateway/test_rtc_client_e2ee.py tests/unit/gateway/test_rtc_client_auth.py tests/unit/gateway/test_rtc_auth_enforcement.py -q`
+- If time allows, run the targeted mesh/gateway subset from the issue handoff.

--- a/app/services/config/config_schema.json
+++ b/app/services/config/config_schema.json
@@ -193,7 +193,7 @@
                 },
                 "enable_app_layer_e2ee": {
                   "type": "boolean",
-                  "description": "Enable application-layer end-to-end encryption",
+                  "description": "When true, all WebRTC DataChannel JSON messages are sealed as binary AEAD payloads with the room data key. Peers with mismatched settings do not fall back to plaintext.",
                   "default": false
                 },
                 "stun_servers": {

--- a/app/services/gateway/webrtc/rtc_client.py
+++ b/app/services/gateway/webrtc/rtc_client.py
@@ -391,12 +391,68 @@ class RTCClient:
 
     # ── Mesh P2P helpers ─────────────────────────────────────────────────
 
+    def _encode_datachannel_message(self, text: str) -> str | bytes:
+        """Encode an outbound DataChannel JSON message for the configured mode."""
+        if not self._settings.webrtc.enable_app_layer_e2ee:
+            return text
+
+        try:
+            obj = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError("DataChannel E2EE messages must be JSON objects") from exc
+        if not isinstance(obj, dict):
+            raise ValueError("DataChannel E2EE messages must be JSON objects")
+        return aead_seal(self._keys.k_data, obj)
+
+    def _decode_datachannel_message(
+        self,
+        peer: str,
+        message: str | bytes | bytearray | memoryview,
+    ) -> str | None:
+        """Decode an inbound DataChannel message according to the configured mode."""
+        e2ee_enabled = self._settings.webrtc.enable_app_layer_e2ee
+
+        if isinstance(message, str):
+            if e2ee_enabled:
+                log_warning(
+                    "RTCClient: Dropping plaintext DataChannel message from "
+                    f"{peer}; app-layer E2EE is enabled"
+                )
+                return None
+            return message
+
+        if isinstance(message, (bytes, bytearray, memoryview)):
+            payload = bytes(message)
+            try:
+                if e2ee_enabled:
+                    obj = aead_open(self._keys.k_data, payload)
+                    return json.dumps(obj)
+                return payload.decode()
+            except Exception as e:
+                mode = "decrypt" if e2ee_enabled else "decode"
+                log_error(f"Failed to {mode} DataChannel message from {peer}: {e}")
+                return None
+
+        log_warning(
+            "RTCClient: Dropping unsupported DataChannel message from "
+            f"{peer}: {type(message).__name__}"
+        )
+        return None
+
+    def _send_channel_text(self, channel: Any, text: str) -> bool:
+        """Send JSON text on a DataChannel after applying configured encoding."""
+        if channel.readyState != "open":
+            return False
+        channel.send(self._encode_datachannel_message(text))
+        return True
+
     def send_to_peer(self, peer_id: str, text: str) -> bool:
         """Send a text message to a specific peer via their DataChannel.
 
         Args:
             peer_id: Target peer identifier
-            text: JSON string to send
+            text: JSON string to send. When app-layer E2EE is enabled this
+                is sealed and sent as binary AEAD payload.
 
         Returns:
             True if the message was sent, False if peer not connected or send failed
@@ -893,7 +949,7 @@ class RTCClient:
                 "signaling_peer_id": self._peer_id,
                 "token": token,
             }
-            chan.send(json.dumps(auth_msg))
+            self._send_channel_text(chan, json.dumps(auth_msg))
 
             # Register in mesh and exchange manifests (non-blocking)
             if self._mesh_enabled and self._peer_registry:
@@ -983,8 +1039,7 @@ class RTCClient:
 
         def send_fn(text: str) -> None:
             try:
-                if channel.readyState == "open":
-                    channel.send(text)
+                self._send_channel_text(channel, text)
             except Exception:
                 log_debug(f"RTCClient: Failed to send to peer {peer} (channel closed)")
 
@@ -1042,7 +1097,7 @@ class RTCClient:
                             "signaling_peer_id": self._peer_id,
                             "token": saved_token,
                         }
-                        chan.send(json.dumps(auth_msg))
+                        self._send_channel_text(chan, json.dumps(auth_msg))
                         log_info(
                             f"Sent saved pairing token to peer {peer} "
                             "(returning peer — previously paired)"
@@ -1127,28 +1182,9 @@ class RTCClient:
 
             @chan.on("message")
             def on_message(message: str | bytes | bytearray | memoryview) -> None:
-                if isinstance(message, bytes):
-                    try:
-                        if self._settings.webrtc.enable_app_layer_e2ee:
-                            obj = aead_open(self._keys.k_data, message)
-                            text = json.dumps(obj)
-                        else:
-                            text = message.decode()
-                    except Exception as e:
-                        log_error(f"Failed to decrypt/decode message from {peer}: {e}")
-                        return
-                elif isinstance(message, (bytearray, memoryview)):
-                    try:
-                        if self._settings.webrtc.enable_app_layer_e2ee:
-                            obj = aead_open(self._keys.k_data, bytes(message))
-                            text = json.dumps(obj)
-                        else:
-                            text = bytes(message).decode()
-                    except Exception as e:
-                        log_error(f"Failed to decrypt/decode message from {peer}: {e}")
-                        return
-                else:
-                    text = message
+                text = self._decode_datachannel_message(peer, message)
+                if text is None:
+                    return
 
                 try:
                     obj = json.loads(text)

--- a/app/shared/config/models.py
+++ b/app/shared/config/models.py
@@ -128,7 +128,7 @@ class Webrtc(BaseConfigModel):
     """
     enable_app_layer_e2ee: bool | None = False
     """
-    Enable application-layer end-to-end encryption
+    When true, all WebRTC DataChannel JSON messages are sealed as binary AEAD payloads with the room data key. Peers with mismatched settings do not fall back to plaintext.
     """
     stun_servers: list[str] | None = ["stun:stun.l.google.com:19302"]
     """

--- a/docs/GATEWAY.md
+++ b/docs/GATEWAY.md
@@ -103,6 +103,7 @@ The gateway is configured in `config.json`:
 - **webrtc.room**: Room name (auto-generated if `"default"` or empty)
 - **webrtc.password**: Room password (auto-generated if empty; required when auth is enabled)
 - **webrtc.encrypt_signaling**: Encrypt MQTT presence with AEAD (default: `false`)
+- **webrtc.enable_app_layer_e2ee**: Encrypt WebRTC DataChannel JSON messages with AEAD in addition to WebRTC DTLS (default: `false`). When enabled, both peers must enable it and share the same room password-derived data key; plaintext DataChannel messages are dropped instead of downgraded.
 
 ### Dynamic Configuration
 
@@ -478,6 +479,15 @@ When `api.auth_enabled` is `true`, the RTCClient enforces a strict auth gate:
 When `api.auth_enabled` is `false`:
 - Peers receive the `OPEN_PEER` identity immediately (full permissions).
 - No auth message is sent, no timeout, no auth gate.
+
+### DataChannel Encryption Modes
+
+WebRTC DataChannels are protected in transit by WebRTC DTLS. Aurora can also add an optional application-layer encryption step for every JSON message sent through the `aurora-rpc` DataChannel:
+
+- `webrtc.enable_app_layer_e2ee=false` (default): auth messages, JSON-RPC calls/responses, manifests, ping/pong, capacity updates, and mesh events are sent as JSON text over the DTLS-protected DataChannel.
+- `webrtc.enable_app_layer_e2ee=true`: those same JSON messages are sealed with AES-GCM using the room password-derived DataChannel key and sent as binary frames.
+
+The mode is strict. A peer with app-layer E2EE enabled drops plaintext DataChannel messages, and a peer with it disabled cannot decode encrypted binary frames. This avoids silent downgrade behavior; paired peers must use matching `enable_app_layer_e2ee`, `webrtc.app_id`, `webrtc.room`, and `webrtc.password` values.
 
 ### Bilateral Mesh Pairing
 

--- a/docs/PEER_PAIRING_FLOW.md
+++ b/docs/PEER_PAIRING_FLOW.md
@@ -1242,7 +1242,7 @@ Paired Device            MQTT Broker              RTCClient (Gateway)
 | `webrtc.room` | WebRTC room name. If set to `"default"` or empty, a random room name is auto-generated on startup and persisted to config. |
 | `webrtc.password` | Shared secret used to derive AEAD keys for signaling encryption. If empty and auth is enabled, startup is blocked with an error. If empty and auth is disabled, a warning is logged. Auto-generated if empty on startup. |
 | `webrtc.encrypt_signaling` | When `true`, MQTT presence announcements are AEAD-encrypted using room key derivatives. Receivers fall back to plaintext if decryption fails. |
-| `webrtc.enable_app_layer_e2ee` | When `true`, DataChannel messages are additionally encrypted with AEAD. |
+| `webrtc.enable_app_layer_e2ee` | When `true`, all Aurora DataChannel JSON messages are additionally sealed with AEAD and sent as binary frames. Both peers must enable it and derive the same room data key; plaintext messages are dropped rather than downgraded. When `false`, DataChannel messages are JSON text protected by WebRTC DTLS. |
 
 ---
 

--- a/tests/unit/gateway/test_rtc_client_e2ee.py
+++ b/tests/unit/gateway/test_rtc_client_e2ee.py
@@ -1,0 +1,137 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.gateway.acl.identity import ANONYMOUS
+from app.services.gateway.utils.crypto import aead_open, aead_seal
+from app.services.gateway.webrtc.rtc_client import RTCClient
+
+
+class MockDataChannel:
+    def __init__(self, label="aurora-rpc"):
+        self.label = label
+        self.readyState = "open"
+        self.events = {}
+        self.sent_messages = []
+
+    def on(self, event_name):
+        def decorator(callback):
+            self.events[event_name] = callback
+            return callback
+
+        return decorator
+
+    def send(self, message):
+        self.sent_messages.append(message)
+
+    def close(self):
+        self.readyState = "closed"
+
+    def emit(self, event_name, *args, **kwargs):
+        if event_name in self.events:
+            if asyncio.iscoroutinefunction(self.events[event_name]):
+                return asyncio.create_task(self.events[event_name](*args, **kwargs))
+            return self.events[event_name](*args, **kwargs)
+        return None
+
+
+@pytest.fixture
+def mock_deps():
+    settings = MagicMock()
+    settings.webrtc.password = "test-password"
+    settings.webrtc.app_id = "test-app"
+    settings.webrtc.room = "test-room"
+    settings.webrtc.stun_servers = ["stun:stun.l.google.com:19302"]
+    settings.webrtc.turn_servers = []
+    settings.webrtc.enable_app_layer_e2ee = False
+    settings.webrtc.encrypt_signaling = False
+
+    bus = MagicMock()
+    registry = MagicMock()
+    auth_service = AsyncMock()
+    auth_service.get_system_token.return_value = "system-token"
+
+    return settings, bus, registry, auth_service
+
+
+@pytest.mark.asyncio
+async def test_send_to_peer_plaintext_when_e2ee_disabled(mock_deps):
+    settings, bus, registry, auth_service = mock_deps
+    client = RTCClient(settings, bus, registry, auth_service, require_auth=False)
+
+    mock_pc = MagicMock()
+    mock_channel = MockDataChannel()
+    mock_pc.createDataChannel.return_value = mock_channel
+
+    with patch("app.services.gateway.webrtc.rtc_client.RTCPeerConnection", return_value=mock_pc):
+        await client._ensure_pc("peer1")
+
+    assert client.send_to_peer("peer1", json.dumps({"type": "ping"})) is True
+    assert mock_channel.sent_messages == ['{"type": "ping"}']
+
+
+@pytest.mark.asyncio
+async def test_send_to_peer_seals_binary_when_e2ee_enabled(mock_deps):
+    settings, bus, registry, auth_service = mock_deps
+    settings.webrtc.enable_app_layer_e2ee = True
+    client = RTCClient(settings, bus, registry, auth_service, require_auth=False)
+
+    mock_pc = MagicMock()
+    mock_channel = MockDataChannel()
+    mock_pc.createDataChannel.return_value = mock_channel
+
+    with patch("app.services.gateway.webrtc.rtc_client.RTCPeerConnection", return_value=mock_pc):
+        await client._ensure_pc("peer1")
+
+    assert client.send_to_peer("peer1", json.dumps({"type": "ping", "id": "abc"})) is True
+    sent = mock_channel.sent_messages[0]
+    assert isinstance(sent, bytes)
+    assert aead_open(client._keys.k_data, sent) == {"type": "ping", "id": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_inbound_encrypted_message_processed_when_e2ee_enabled(mock_deps):
+    settings, bus, registry, auth_service = mock_deps
+    settings.webrtc.enable_app_layer_e2ee = True
+    client = RTCClient(settings, bus, registry, auth_service, require_auth=True)
+
+    mock_pc = MagicMock()
+    mock_channel = MockDataChannel()
+    mock_pc.createDataChannel.return_value = mock_channel
+
+    auth_service.authenticate_token.return_value = None
+
+    with patch("app.services.gateway.webrtc.rtc_client.RTCPeerConnection", return_value=mock_pc):
+        await client._ensure_pc("peer1")
+
+    encrypted = aead_seal(client._keys.k_data, {"type": "auth", "token": "valid-token"})
+    task = mock_channel.emit("message", encrypted)
+    if task is not None:
+        await task
+    await asyncio.sleep(0.05)
+
+    assert auth_service.authenticate_token.called
+
+
+@pytest.mark.asyncio
+async def test_inbound_plaintext_dropped_when_e2ee_enabled(mock_deps):
+    settings, bus, registry, auth_service = mock_deps
+    settings.webrtc.enable_app_layer_e2ee = True
+    client = RTCClient(settings, bus, registry, auth_service, require_auth=True)
+
+    mock_pc = MagicMock()
+    mock_channel = MockDataChannel()
+    mock_pc.createDataChannel.return_value = mock_channel
+
+    with patch("app.services.gateway.webrtc.rtc_client.RTCPeerConnection", return_value=mock_pc):
+        await client._ensure_pc("peer1")
+
+    task = mock_channel.emit("message", json.dumps({"type": "auth", "token": "valid-token"}))
+    if task is not None:
+        await task
+    await asyncio.sleep(0.05)
+
+    assert not auth_service.authenticate_token.called
+    assert client._peer_acl.get("peer1", ANONYMOUS) == ANONYMOUS


### PR DESCRIPTION
## Summary

Fixes PER-133 by making `services.gateway.webrtc.enable_app_layer_e2ee` a strict, symmetric DataChannel mode instead of an ambiguous inbound-only path.

- Centralizes RTCClient DataChannel send encoding so auth messages, JSON-RPC calls/responses, manifests, ping/pong, capacity updates, and mesh events all use the configured mode.
- Adds strict inbound decoding: plaintext is accepted only when app-layer E2EE is disabled; when enabled, DataChannel messages must be binary AEAD payloads.
- Documents the difference between MQTT signaling encryption, WebRTC DTLS, and optional app-layer DataChannel E2EE.
- Adds focused regression tests for plaintext mode, encrypted send/decrypt, encrypted inbound auth handling, and plaintext mismatch drop.

## Validation

- `env UV_CACHE_DIR=/tmp/uv-cache /home/developer/.local/bin/uv run python scripts/generate_config_artifacts.py`
- `env UV_CACHE_DIR=/tmp/uv-cache /home/developer/.local/bin/uv run ruff check app/services/gateway/webrtc/rtc_client.py tests/unit/gateway/test_rtc_client_e2ee.py app/shared/config/models.py`
- `env UV_CACHE_DIR=/tmp/uv-cache /home/developer/.local/bin/uv run pytest tests/unit/gateway/test_rtc_client_e2ee.py tests/unit/gateway/test_rtc_client_auth.py tests/unit/gateway/test_rtc_auth_enforcement.py -q`
- `env UV_CACHE_DIR=/tmp/uv-cache /home/developer/.local/bin/uv run pytest tests/unit/gateway/test_negotiation.py tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_peer_bridge.py tests/unit/gateway/test_rpc.py tests/unit/gateway/test_rtc_auth_enforcement.py tests/integration/test_mesh_routing.py tests/integration/test_mesh_permissions.py tests/integration/test_mesh_failover.py -q`

## Notes

The referenced `.omx/specs/deep-interview-mesh-distributed-integration.md` and `.omx/multica/mesh-roadmap-tasks/` files were not present in this branch; the issue body and available gateway/pairing docs were used as the scoped source of truth.
