### PR TITLE
PER-135: Add hybrid mesh addressing selectors

### DIFF
--- a/.omx/plans/PER-135-hybrid-addressing-primitives.md
+++ b/.omx/plans/PER-135-hybrid-addressing-primitives.md
@@ -1,0 +1,39 @@
+# PER-135 Hybrid Addressing Primitives Plan
+
+## Source Context
+
+- Multica issue: PER-135, `[MESH][P2-T02] Add hybrid addressing primitives for peer, provider, resource, and namespace selectors`.
+- Issue acceptance: typed and validated explicit selector paths; transparent routing remains compatible; selector failures are actionable; policy can require explicit selectors for safety-sensitive categories.
+- Present source docs read: `AGENTS.md`, `app/messaging/AGENTS.md`, `app/shared/AGENTS.md`, `app/shared/contracts/AGENTS.md`, `app/services/gateway/AGENTS.md`, `tests/AGENTS.md`.
+- Referenced `.omx/multica/mesh-roadmap-tasks/` and `.omx/specs/deep-interview-mesh-distributed-integration.md` are not present on this checked-out branch, so the issue body is the task source of truth.
+
+## Requirements
+
+- Add a common typed selector model with optional `peer_id`, `provider_id`, `service_instance_id`, `resource_namespace`, `tool_id`, `hardware_target`, and `data_scope`.
+- Keep transparent routing behavior for existing callers that do not provide selectors.
+- Make explicit selector routing take precedence over module-level `prefer` policy.
+- Return clear route errors for missing peer/provider/service, stale peers, disallowed peers, incompatible versions/capabilities, or policy-required selectors.
+- Add per-service policy configuration that can require explicit selectors without changing defaults.
+- Document transparent vs explicit categories and focused test coverage.
+
+## Implementation Steps
+
+1. Add selector and failure primitives in `app/shared/contracts/models/mesh.py` and route-decision metadata in `app/services/gateway/mesh/models.py`.
+2. Add optional selector fields to safety-sensitive contract payloads in `app/shared/contracts/models/tooling.py` and DB/RAG models in `app/shared/contracts/models/db.py`.
+3. Extend `MeshServiceConfig` in `app/services/gateway/config.py` with a backwards-compatible `require_explicit_selector` flag.
+4. Teach `RoutingTable.resolve()` and fallback logic to accept a selector, enforce explicit selector policy, and validate peer/provider/service compatibility before transparent routing.
+5. Teach `MeshBus` to extract `mesh_selector` from typed payloads and pass it into routing/fallback resolution.
+6. Add unit/integration tests for explicit peer/provider precedence, failure messages, policy-required selectors, and backward-compatible transparent routing.
+7. Update mesh docs with the hybrid addressing contract and verification guidance.
+
+## Verification
+
+- `uv run pytest tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_mesh_bus.py tests/integration/test_mesh_routing.py -q`
+- `uv run ruff check` on changed Python files.
+- `git diff --check`
+
+## Risks
+
+- Risk: selector shape becomes too broad before all services consume it. Mitigation: add typed optional primitives only, and route only on selectors the current registry can validate.
+- Risk: explicit selector fallback weakens intent. Mitigation: explicit selector failures return `error`; fallback is used only for transparent routing.
+- Risk: safety-sensitive policy breaks defaults. Mitigation: `require_explicit_selector` defaults to `False`.

--- a/.omx/ultragoal/PER-135-checkpoints.md
+++ b/.omx/ultragoal/PER-135-checkpoints.md
@@ -1,0 +1,37 @@
+# PER-135 Ultragoal Checkpoints
+
+## G001 - Plan
+
+Status: complete
+
+Evidence:
+- Read Multica issue PER-135, metadata, and comments.
+- Read repo and subsystem AGENTS guidance for messaging, shared/contracts, gateway mesh, and tests.
+- Confirmed referenced `.omx` mesh task/spec files are absent on this branch.
+- Created `.omx/plans/PER-135-hybrid-addressing-primitives.md`.
+
+## G002 - Implementation
+
+Status: complete
+
+Evidence:
+- Added `MeshAddressSelector` and route error metadata.
+- Added optional `mesh_selector` fields to Tooling and DB/RAG payloads.
+- Added `require_explicit_selector` mesh service policy.
+- Updated `RoutingTable` and `MeshBus` so explicit peer/provider/service selectors override transparent routing and do not silently fall back.
+- Documented hybrid transparent vs explicit categories in `docs/PEER_PAIRING_FLOW.md`.
+
+## G003 - Verification
+
+Status: complete
+
+Evidence:
+- `~/.local/bin/uv run --extra test-integration pytest tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_mesh_bus.py tests/integration/test_mesh_routing.py -q` -> 49 passed, 5 warnings.
+- `~/.local/bin/uv run --extra dev ruff check app/shared/contracts/models/mesh.py app/shared/contracts/models/tooling.py app/shared/contracts/models/db.py app/services/gateway/config.py app/services/gateway/mesh/models.py app/services/gateway/mesh/routing_table.py app/messaging/mesh_bus.py tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_mesh_bus.py` -> passed.
+- `git diff --check` -> passed.
+- First broader suite attempt without gateway extra failed during collection because `aiortc` was missing.
+- `~/.local/bin/uv run --extra test-integration --extra gateway pytest tests/unit/gateway/test_negotiation.py tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_peer_bridge.py tests/unit/gateway/test_rpc.py tests/unit/gateway/test_rtc_auth_enforcement.py tests/integration/test_mesh_routing.py tests/integration/test_mesh_permissions.py tests/integration/test_mesh_failover.py -q` -> 93 passed, 13 warnings.
+
+## Stop Condition
+
+Implementation can hand off when code, tests, docs, branch/PR, and QA comment are complete, with explicit note about missing referenced `.omx` specs.

--- a/app/messaging/mesh_bus.py
+++ b/app/messaging/mesh_bus.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel
 
 from app.helpers.aurora_logger import log_debug, log_error, log_warning
 from app.messaging.bus import Handler, QueryResult
+from app.shared.contracts.models.mesh import MeshAddressSelector
 
 if TYPE_CHECKING:
     from app.messaging.bus import MessageBus
@@ -155,7 +156,8 @@ class MeshBus:
             return
 
         # For commands, check routing
-        route = self._routing_table.resolve(topic)
+        selector = _extract_mesh_selector(message)
+        route = self._routing_table.resolve(topic, selector=selector)
         log_debug(
             f"MeshBus: Routing command {topic} → target={route.target}, "
             f"peer={route.peer_id or 'n/a'}, module={route.module}"
@@ -203,7 +205,15 @@ class MeshBus:
             fallback = self._routing_table.resolve_fallback(
                 topic,
                 failed_peer_id=route.peer_id,
+                selector=selector,
             )
+            if fallback.target == "error":
+                raise RuntimeError(
+                    fallback.error_message or f"No fallback route available for {topic}"
+                )
+            if fallback.target == "none":
+                log_warning(f"MeshBus: No fallback route for {topic} (target=none)")
+                return
             if fallback.target == "local":
                 await self._inner.publish(
                     topic,
@@ -257,7 +267,7 @@ class MeshBus:
                 return
 
         if route.target == "error":
-            raise RuntimeError(f"No remote peer available for {topic} and fallback=error")
+            raise RuntimeError(route.error_message or f"No remote peer available for {topic}")
 
         if route.target == "none":
             log_warning(f"MeshBus: No route for {topic} (target=none), dropping command")
@@ -308,7 +318,8 @@ class MeshBus:
         Returns:
             QueryResult containing the response data or error
         """
-        route = self._routing_table.resolve(topic)
+        selector = _extract_mesh_selector(message)
+        route = self._routing_table.resolve(topic, selector=selector)
         log_debug(
             f"MeshBus: Routing request {topic} → target={route.target}, "
             f"peer={route.peer_id or 'n/a'}, module={route.module}"
@@ -348,7 +359,15 @@ class MeshBus:
             fallback = self._routing_table.resolve_fallback(
                 topic,
                 failed_peer_id=route.peer_id,
+                selector=selector,
             )
+            if fallback.target == "error":
+                return QueryResult(
+                    ok=False,
+                    error=fallback.error_message or f"No fallback route available for {topic}",
+                )
+            if fallback.target == "none":
+                return QueryResult(ok=False, error=f"No fallback route available for {topic}")
             if fallback.target == "local":
                 log_debug(f"MeshBus: Falling back to local for {topic}")
                 return await self._inner.request(
@@ -384,7 +403,10 @@ class MeshBus:
                     )
 
         if route.target == "error":
-            return QueryResult(ok=False, error=f"No remote peer available for {topic}")
+            return QueryResult(
+                ok=False,
+                error=route.error_message or f"No remote peer available for {topic}",
+            )
 
         if route.target == "none":
             return QueryResult(ok=False, error=f"No route available for {topic}")
@@ -414,3 +436,14 @@ class MeshBus:
             handler: Async function to handle messages
         """
         self._inner.subscribe(topic, handler)
+
+
+def _extract_mesh_selector(message: BaseModel) -> MeshAddressSelector | None:
+    """Return a typed mesh selector from a bus payload when present."""
+
+    selector = getattr(message, "mesh_selector", None)
+    if isinstance(selector, MeshAddressSelector):
+        return selector
+    if isinstance(selector, dict):
+        return MeshAddressSelector.model_validate(selector)
+    return None

--- a/app/services/gateway/config.py
+++ b/app/services/gateway/config.py
@@ -25,6 +25,8 @@ class MeshServiceConfig(BaseModel):
         fallback: Fallback strategy ("local" | "network" | "error" | "none")
         min_version: Minimum required version (semver) for remote service
         required_capabilities: Capabilities the remote service must have
+        require_explicit_selector: Require callers to provide a peer/provider
+            selector before routing this module remotely
     """
 
     share: bool = False
@@ -34,6 +36,7 @@ class MeshServiceConfig(BaseModel):
     fallback: str = "local"
     min_version: str | None = None
     required_capabilities: list[str] = Field(default_factory=list)
+    require_explicit_selector: bool = False
 
 
 # Backward-compatible aliases

--- a/app/services/gateway/mesh/models.py
+++ b/app/services/gateway/mesh/models.py
@@ -14,6 +14,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.shared.contracts.models.gateway import MethodInfo
+from app.shared.contracts.models.mesh import MeshAddressSelector
 
 
 class PeerServiceInfo(BaseModel):
@@ -113,18 +114,24 @@ class RouteDecision(BaseModel):
     Tells the MeshBus whether to deliver a message locally or remotely.
 
     Attributes:
-        target: "local" or "remote"
+        target: "local", "remote", "none", or "error"
         peer_id: Target peer ID (only if target == "remote")
         module: Service module name
         version: Remote service version (only if remote)
         latency_ms: Expected latency (only if remote)
+        selector: Explicit selector that influenced this decision
+        error_code: Machine-readable failure reason for target="error"
+        error_message: Human-readable failure detail
     """
 
-    target: str  # "local" | "remote"
+    target: str  # "local" | "remote" | "none" | "error"
     peer_id: str | None = None
     module: str = ""
     version: str = ""
     latency_ms: float = 0.0
+    selector: MeshAddressSelector | None = None
+    error_code: str | None = None
+    error_message: str | None = None
 
 
 class CapacityUpdate(BaseModel):

--- a/app/services/gateway/mesh/routing_table.py
+++ b/app/services/gateway/mesh/routing_table.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from app.helpers.aurora_logger import log_debug
+from app.shared.contracts.models.mesh import MeshAddressSelector
 
 from .models import RouteDecision
 
@@ -37,6 +38,7 @@ class RoutingTable:
         topic: str,
         routing_config: MeshServiceConfig | None = None,
         exclude: list[str] | None = None,
+        selector: MeshAddressSelector | None = None,
     ) -> RouteDecision:
         """Determine where to route a message.
 
@@ -51,6 +53,7 @@ class RoutingTable:
             topic: Bus topic (e.g., "TTS.Request")
             routing_config: Override routing config (if None, uses mesh config)
             exclude: Peer IDs to exclude from selection
+            selector: Optional explicit peer/provider/resource selector
 
         Returns:
             RouteDecision indicating where to deliver the message
@@ -61,9 +64,24 @@ class RoutingTable:
         if routing_config is None:
             routing_config = self._config.services.get(module)
 
+        if selector and selector.has_routing_target():
+            return self._resolve_explicit_selector(
+                module=module,
+                routing_config=routing_config,
+                selector=selector,
+            )
+
         # No routing config or mesh disabled → always local
         if not routing_config:
             return RouteDecision(target="local", module=module)
+
+        if routing_config.require_explicit_selector:
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_required",
+                message=f"{module} requires an explicit mesh selector",
+            )
 
         prefer = routing_config.prefer
 
@@ -127,11 +145,128 @@ class RoutingTable:
         """
         return self._registry.get_negotiated_peers()
 
+    def _resolve_explicit_selector(
+        self,
+        module: str,
+        routing_config: MeshServiceConfig | None,
+        selector: MeshAddressSelector,
+    ) -> RouteDecision:
+        peer_id, conflict_error = _selector_peer_id(selector, module)
+        if conflict_error:
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_conflict",
+                message=conflict_error,
+            )
+        if not peer_id:
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_missing_provider",
+                message=f"{module} selector does not name a peer/provider/service instance",
+            )
+
+        peer = self._registry.get_peer(peer_id)
+        if not peer:
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_peer_not_found",
+                message=f"{module} selector peer/provider '{peer_id}' is not connected",
+            )
+        if peer.status != "negotiated":
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_peer_stale" if peer.status == "stale" else "selector_peer_not_ready",
+                message=(
+                    f"{module} selector peer/provider '{peer_id}' is {peer.status}, "
+                    "not negotiated"
+                ),
+            )
+
+        if (
+            routing_config
+            and routing_config.allowed_peers is not None
+            and peer_id not in routing_config.allowed_peers
+        ):
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_peer_unauthorized",
+                message=f"{module} selector peer/provider '{peer_id}' is not allowed by policy",
+            )
+
+        svc = self._registry.get_peer_service(peer_id, module)
+        if not svc:
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_service_missing",
+                message=f"{module} is not shared by selector peer/provider '{peer_id}'",
+            )
+
+        if routing_config and routing_config.min_version:
+            from .version_compat import is_compatible
+
+            if not is_compatible(
+                routing_config.min_version,
+                svc.version,
+                self._config.version_policy,
+                routing_config.min_version,
+            ):
+                return _route_error(
+                    module=module,
+                    selector=selector,
+                    code="selector_incompatible_version",
+                    message=(
+                        f"{module} selector peer/provider '{peer_id}' version {svc.version} "
+                        f"does not satisfy {routing_config.min_version}"
+                    ),
+                )
+
+        if (
+            routing_config
+            and routing_config.required_capabilities
+            and not all(cap in svc.capabilities for cap in routing_config.required_capabilities)
+        ):
+            missing = [
+                cap for cap in routing_config.required_capabilities if cap not in svc.capabilities
+            ]
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_incompatible_capabilities",
+                message=(
+                    f"{module} selector peer/provider '{peer_id}' lacks required "
+                    f"capabilities: {', '.join(missing)}"
+                ),
+            )
+
+        if svc.max_concurrent > 0 and peer.active_calls >= svc.max_concurrent:
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_provider_at_capacity",
+                message=f"{module} selector peer/provider '{peer_id}' is at capacity",
+            )
+
+        return RouteDecision(
+            target="remote",
+            peer_id=peer_id,
+            module=module,
+            version=svc.version,
+            latency_ms=peer.latency_ms,
+            selector=selector,
+        )
+
     def resolve_fallback(
         self,
         topic: str,
         routing_config: MeshServiceConfig | None = None,
         failed_peer_id: str | None = None,
+        selector: MeshAddressSelector | None = None,
     ) -> RouteDecision:
         """Resolve a fallback route after a primary route failure.
 
@@ -139,11 +274,21 @@ class RoutingTable:
             topic: Bus topic
             routing_config: Routing configuration
             failed_peer_id: The peer that failed (to exclude)
+            selector: Optional explicit selector. Explicit routes do not
+                transparently fall back to another target.
 
         Returns:
             RouteDecision for the fallback target
         """
         module = _extract_module(topic)
+
+        if selector and selector.has_routing_target():
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_target_failed",
+                message=f"{module} explicit selector target failed; transparent fallback skipped",
+            )
 
         if routing_config is None:
             routing_config = self._config.services.get(module)
@@ -198,3 +343,44 @@ def _extract_module(topic: str) -> str:
     if "." in topic:
         return topic.split(".")[0]
     return topic
+
+
+def _selector_peer_id(selector: MeshAddressSelector, module: str) -> tuple[str | None, str | None]:
+    """Resolve selector peer aliases into a single peer id."""
+
+    peer_ids: list[str] = []
+    for value in (selector.peer_id, selector.provider_id):
+        if value and value not in peer_ids:
+            peer_ids.append(value)
+
+    if selector.service_instance_id:
+        service_peer = selector.service_instance_id
+        if ":" in service_peer:
+            service_peer, service_module = service_peer.split(":", 1)
+            if service_module and service_module != module:
+                return None, (
+                    f"service_instance_id '{selector.service_instance_id}' targets "
+                    f"{service_module}, not {module}"
+                )
+        if service_peer and service_peer not in peer_ids:
+            peer_ids.append(service_peer)
+
+    if len(peer_ids) > 1:
+        return None, f"selector names multiple peer/provider targets: {', '.join(peer_ids)}"
+    return (peer_ids[0], None) if peer_ids else (None, None)
+
+
+def _route_error(
+    *,
+    module: str,
+    selector: MeshAddressSelector | None,
+    code: str,
+    message: str,
+) -> RouteDecision:
+    return RouteDecision(
+        target="error",
+        module=module,
+        selector=selector,
+        error_code=code,
+        error_message=message,
+    )

--- a/app/shared/contracts/models/db.py
+++ b/app/shared/contracts/models/db.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pydantic import Field
 
+from app.shared.contracts.models.mesh import MeshAddressSelector
 from app.shared.contracts.registry import IOModel
 
 
@@ -88,6 +89,7 @@ class DBGetMessagesRequest(IOModel):
     offset: int = 0
     role: str | None = None
     message_type: str | None = None
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class DBGetMessagesResponse(IOModel):
@@ -148,6 +150,7 @@ class DBRAGStoreRequest(IOModel):
     key: str
     value: Any
     index: bool = True
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class DBRAGDeleteRequest(IOModel):
@@ -155,6 +158,7 @@ class DBRAGDeleteRequest(IOModel):
 
     namespace: str
     key: str
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class DBRAGSearchRequest(IOModel):
@@ -164,6 +168,7 @@ class DBRAGSearchRequest(IOModel):
     query: str
     limit: int = 10
     offset: int = 0
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class DBRAGGetRequest(IOModel):
@@ -171,6 +176,7 @@ class DBRAGGetRequest(IOModel):
 
     namespace: str
     key: str
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class DBRAGListRequest(IOModel):
@@ -179,6 +185,7 @@ class DBRAGListRequest(IOModel):
     namespace: str
     limit: int = 100
     offset: int = 0
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class DBRAGItemResponse(IOModel):
@@ -450,6 +457,7 @@ class DBExecuteSQLRequest(IOModel):
 
     sql: str
     params: list[Any] | None = None
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class DBExecuteSQLResponse(IOModel):

--- a/app/shared/contracts/models/mesh.py
+++ b/app/shared/contracts/models/mesh.py
@@ -7,7 +7,7 @@ violating the "no cross-service imports" rule.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.shared.auth.permissions import Permission
 
@@ -21,6 +21,47 @@ class MeshEvents:
 
     PEER_APPROVED = "Mesh.PeerApproved"
     PEER_PERMISSIONS_UPDATED = "Mesh.PeerPermissionsUpdated"
+
+
+# ── Hybrid addressing selectors ─────────────────────────────────────────
+
+
+class MeshAddressSelector(BaseModel):
+    """Explicit mesh target selector for safety-sensitive remote calls.
+
+    The selector is optional on bus payloads so transparent module routing
+    remains backward compatible. When present, routing treats peer/provider
+    fields as binding hints and validates them before falling back to module
+    selection.
+    """
+
+    peer_id: str | None = None
+    provider_id: str | None = None
+    service_instance_id: str | None = None
+    resource_namespace: str | None = None
+    tool_id: str | None = None
+    hardware_target: str | None = None
+    data_scope: str | None = None
+
+    @field_validator(
+        "peer_id",
+        "provider_id",
+        "service_instance_id",
+        "resource_namespace",
+        "tool_id",
+        "hardware_target",
+        "data_scope",
+    )
+    @classmethod
+    def _non_blank(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("selector values must not be blank")
+        return value
+
+    def has_routing_target(self) -> bool:
+        """Return True when this selector names a routeable provider."""
+
+        return bool(self.peer_id or self.provider_id or self.service_instance_id)
 
 
 # ── Peer Info (returned by queries) ──────────────────────────────────────

--- a/app/shared/contracts/models/tooling.py
+++ b/app/shared/contracts/models/tooling.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from app.shared.contracts.models.mesh import MeshAddressSelector
 from app.shared.contracts.registry import IOModel
 
 
@@ -32,6 +33,7 @@ class ToolingGetToolsRequest(IOModel):
 
     query: str | None = None
     top_k: int = 100
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class ToolingGetToolsResponse(IOModel):
@@ -45,6 +47,7 @@ class ToolingGetToolByNameRequest(IOModel):
     """Request to get a specific tool by name."""
 
     name: str
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class ToolingGetToolByNameResponse(IOModel):
@@ -95,6 +98,7 @@ class ToolingExecuteToolRequest(IOModel):
 
     tool_name: str
     arguments: dict[str, Any]
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class ToolingExecuteToolResponse(IOModel):

--- a/docs/PEER_PAIRING_FLOW.md
+++ b/docs/PEER_PAIRING_FLOW.md
@@ -1360,6 +1360,19 @@ Peer selection among multiple providers uses the configured `peer_selection` str
 - `round_robin`: Rotate among available peers.
 - `random`: Random selection.
 
+### Hybrid Addressing
+
+Mesh routing supports two addressing modes:
+
+- **Transparent module routing** remains the default for low-risk, local-like service dependencies. Existing callers that publish or request `TTS.Request`, `Orchestrator.UserInput`, or similar module topics without a selector continue to use the module's `prefer`, `fallback`, version, capability, latency, and capacity policy.
+- **Explicit selector routing** is used when a caller must choose the remote authority or resource. Typed payloads can include `mesh_selector` with `peer_id`, `provider_id`, `service_instance_id`, `resource_namespace`, `tool_id`, `hardware_target`, or `data_scope`. `peer_id`, `provider_id`, and `service_instance_id` are binding route targets; `resource_namespace`, `tool_id`, `hardware_target`, and `data_scope` preserve the caller's resource intent for policy and audit surfaces.
+
+When an explicit selector names a peer/provider, `RoutingTable.resolve()` validates that the peer exists, is negotiated, is allowed by per-service policy, shares the requested module, satisfies version/capability requirements, and has capacity. Selector failures return actionable error codes such as `selector_peer_not_found`, `selector_peer_unauthorized`, `selector_peer_stale`, `selector_service_missing`, or `selector_incompatible_capabilities`.
+
+Per-service mesh config can set `require_explicit_selector: true` for safety-sensitive categories. This is intended for tools, DB/data namespaces, hardware controls, scheduler ownership, remote playback, and privacy-sensitive data. Transparent routing is still appropriate for low-risk module dependencies where any compatible provider can satisfy the request.
+
+Explicit selector routes do not silently fall back to a different peer or local service after selector validation or target transport failure. A caller that chooses a specific tool/resource/provider receives an error if that target cannot satisfy the call.
+
 ### Event Forwarding
 
 #### The Problem

--- a/tests/unit/gateway/test_mesh_bus.py
+++ b/tests/unit/gateway/test_mesh_bus.py
@@ -10,10 +10,12 @@ from app.messaging.bus import QueryResult
 from app.messaging.mesh_bus import MeshBus
 from app.services.gateway.config import MeshConfig, MeshServiceConfig
 from app.services.gateway.mesh.models import RouteDecision
+from app.shared.contracts.models.mesh import MeshAddressSelector
 
 
 class FakePayload(BaseModel):
     text: str = "hello"
+    mesh_selector: MeshAddressSelector | None = None
 
 
 @pytest.fixture
@@ -172,6 +174,12 @@ class TestMeshBusPublish:
         inner_bus.publish.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_command_passes_selector_to_routing(self, mesh_bus, routing_table):
+        selector = MeshAddressSelector(peer_id="peer-1")
+        await mesh_bus.publish("TTS.Request", FakePayload(mesh_selector=selector), event=False)
+        routing_table.resolve.assert_called_once_with("TTS.Request", selector=selector)
+
+    @pytest.mark.asyncio
     async def test_command_remote_route(self, mesh_bus, inner_bus, routing_table, peer_bridge):
         routing_table.resolve.return_value = RouteDecision(
             target="remote", peer_id="peer-1", module="TTS"
@@ -236,6 +244,29 @@ class TestMeshBusRequest:
         result = await mesh_bus.request("TTS.Request", FakePayload())
         assert result.ok is True
         inner_bus.request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_explicit_remote_request_failure_does_not_fallback_local(
+        self, mesh_bus, inner_bus, routing_table, peer_bridge
+    ):
+        selector = MeshAddressSelector(peer_id="peer-1")
+        routing_table.resolve.return_value = RouteDecision(
+            target="remote", peer_id="peer-1", module="TTS", selector=selector
+        )
+        peer_bridge.call.side_effect = Exception("timeout")
+        routing_table.resolve_fallback.return_value = RouteDecision(
+            target="error",
+            module="TTS",
+            selector=selector,
+            error_code="selector_target_failed",
+            error_message="TTS explicit selector target failed; transparent fallback skipped",
+        )
+
+        result = await mesh_bus.request("TTS.Request", FakePayload(mesh_selector=selector))
+
+        assert result.ok is False
+        assert "transparent fallback skipped" in result.error
+        inner_bus.request.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_remote_error_result_triggers_fallback(

--- a/tests/unit/gateway/test_routing_table.py
+++ b/tests/unit/gateway/test_routing_table.py
@@ -6,6 +6,7 @@ from app.services.gateway.config import MeshConfig, MeshServiceConfig
 from app.services.gateway.mesh.models import PeerManifest, PeerServiceInfo, PeerState, RouteDecision
 from app.services.gateway.mesh.peer_registry import PeerRegistry
 from app.services.gateway.mesh.routing_table import RoutingTable, _extract_module
+from app.shared.contracts.models.mesh import MeshAddressSelector
 
 
 class TestExtractModule:
@@ -31,6 +32,7 @@ def mesh_config():
             "DB": MeshServiceConfig(prefer="local"),
             "STT": MeshServiceConfig(prefer="network_only", fallback="error"),
             "Scheduler": MeshServiceConfig(prefer="local_only"),
+            "Tooling": MeshServiceConfig(prefer="local", require_explicit_selector=True),
         },
     )
 
@@ -111,6 +113,64 @@ class TestRoutingTableResolve:
         route = routing_table.resolve("TTS.Request", exclude=["peer-1"])
         # Peer excluded, no other peers → fallback
         assert route.target == "local"
+
+    @pytest.mark.asyncio
+    async def test_explicit_peer_overrides_local_preference(self, routing_table, peer_registry):
+        peer = _make_negotiated_peer("peer-1", ["DB"], latency_ms=15.0)
+        await peer_registry.register_peer("peer-1")
+        await peer_registry.update_manifest("peer-1", peer.manifest)
+        await peer_registry.update_latency("peer-1", 15.0)
+
+        route = routing_table.resolve(
+            "DB.GetMessages",
+            selector=MeshAddressSelector(peer_id="peer-1", resource_namespace="journal"),
+        )
+
+        assert route.target == "remote"
+        assert route.peer_id == "peer-1"
+        assert route.selector.resource_namespace == "journal"
+
+    @pytest.mark.asyncio
+    async def test_explicit_missing_peer_returns_actionable_error(self, routing_table):
+        route = routing_table.resolve(
+            "DB.GetMessages",
+            selector=MeshAddressSelector(peer_id="missing-peer"),
+        )
+
+        assert route.target == "error"
+        assert route.error_code == "selector_peer_not_found"
+        assert "missing-peer" in route.error_message
+
+    @pytest.mark.asyncio
+    async def test_explicit_peer_not_allowed_returns_unauthorized(self, mesh_config, peer_registry):
+        mesh_config.services["DB"] = MeshServiceConfig(prefer="local", allowed_peers=["peer-2"])
+        routing_table = RoutingTable(mesh_config, peer_registry)
+        peer = _make_negotiated_peer("peer-1", ["DB"])
+        await peer_registry.register_peer("peer-1")
+        await peer_registry.update_manifest("peer-1", peer.manifest)
+
+        route = routing_table.resolve(
+            "DB.GetMessages",
+            selector=MeshAddressSelector(provider_id="peer-1"),
+        )
+
+        assert route.target == "error"
+        assert route.error_code == "selector_peer_unauthorized"
+
+    def test_policy_can_require_explicit_selector(self, routing_table):
+        route = routing_table.resolve("Tooling.ExecuteTool")
+
+        assert route.target == "error"
+        assert route.error_code == "selector_required"
+
+    def test_conflicting_explicit_selectors_return_error(self, routing_table):
+        route = routing_table.resolve(
+            "Tooling.ExecuteTool",
+            selector=MeshAddressSelector(peer_id="peer-1", provider_id="peer-2"),
+        )
+
+        assert route.target == "error"
+        assert route.error_code == "selector_conflict"
 
 
 class TestRoutingTableResolveFallback:


### PR DESCRIPTION
## Summary

- Adds `MeshAddressSelector` for typed explicit peer/provider/resource selection.
- Adds optional `mesh_selector` fields to Tooling and DB/RAG request payloads.
- Adds `require_explicit_selector` per-service mesh policy.
- Updates `RoutingTable` and `MeshBus` so explicit peer/provider/service selectors take precedence over transparent module routing and return actionable errors for missing, stale, unauthorized, incompatible, or failed selected targets.
- Documents transparent vs explicit hybrid addressing categories in `docs/PEER_PAIRING_FLOW.md`.

## Verification

- `~/.local/bin/uv run --extra test-integration pytest tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_mesh_bus.py tests/integration/test_mesh_routing.py -q` -> 49 passed, 5 warnings.
- `~/.local/bin/uv run --extra dev ruff check app/shared/contracts/models/mesh.py app/shared/contracts/models/tooling.py app/shared/contracts/models/db.py app/services/gateway/config.py app/services/gateway/mesh/models.py app/services/gateway/mesh/routing_table.py app/messaging/mesh_bus.py tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_mesh_bus.py` -> passed.
- `git diff --check` -> passed.
- First broader suite attempt without gateway extra failed during collection because `aiortc` was missing.
- `~/.local/bin/uv run --extra test-integration --extra gateway pytest tests/unit/gateway/test_negotiation.py tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_peer_bridge.py tests/unit/gateway/test_rpc.py tests/unit/gateway/test_rtc_auth_enforcement.py tests/integration/test_mesh_routing.py tests/integration/test_mesh_permissions.py tests/integration/test_mesh_failover.py -q` -> 93 passed, 13 warnings.

## Notes

- The branch did not contain the issue-referenced `.omx/multica/mesh-roadmap-tasks/` bundle or `.omx/specs/deep-interview-mesh-distributed-integration.md`; implementation used the Multica issue, repo AGENTS guidance, and present mesh docs/code as source context.
