### PR TITLE
[PER-137] Add Tooling discovery metadata

### DIFF
--- a/.omx/plans/PER-137-tooling-discovery-metadata.md
+++ b/.omx/plans/PER-137-tooling-discovery-metadata.md
@@ -1,0 +1,19 @@
+# PER-137 Tooling Discovery Metadata Plan
+
+## Scope
+- Issue: PER-137 `[MESH][P3-T01] Extend Tooling discovery with peer/source metadata and stable remote tool IDs`.
+- Source docs available in this checkout: issue description/metadata, `AGENTS.md`, `app/services/AGENTS.md`, `app/shared/AGENTS.md`, `app/shared/contracts/AGENTS.md`, `app/messaging/AGENTS.md`, `tests/AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/GATEWAY.md`, `docs/SERVICE_METHODS_REFERENCE.md`.
+- Source docs named by the issue but missing in this checkout: `.omx/specs/deep-interview-mesh-distributed-integration.md`, `.omx/multica/mesh-roadmap-tasks/P3-T01*`.
+
+## Implementation
+- Add typed Tooling discovery item models with stable identity, provider peer/service identity, namespace/display aliases, execution location, safety/policy hints, schema, and provenance.
+- Preserve backward compatibility by keeping local-only `name` equal to the local tool name and retaining `args_schema`.
+- Namespace provider-selected/remote discovery names so colliding remote tool names do not bind as the same LLM tool.
+- Let Tooling execution resolve local names, stable global IDs, and namespaced discovery names back to the provider-local tool.
+- Update orchestrator call sites to use Tooling contract request models instead of legacy messaging payload aliases.
+- Update docs and focused tests for typed discovery metadata, local regression, and two remote providers with colliding local tool names.
+
+## Verification
+- Run targeted Tooling tests.
+- Run targeted orchestrator tests impacted by request model changes if dependencies permit.
+- Run formatting/lint checks as feasible in this runtime.

--- a/.omx/ultragoal/PER-137-checkpoints.md
+++ b/.omx/ultragoal/PER-137-checkpoints.md
@@ -1,0 +1,6 @@
+# PER-137 Ultragoal Checkpoints
+
+## 2026-06-16
+- Goal: ship typed Tooling discovery metadata for stable mesh-aware tool binding.
+- Constraints: bus-only service interaction, typed contracts, backward-compatible local discovery, privacy-first remote provenance.
+- Stop condition: focused tests pass, PR exists, and issue is handed to QA with evidence.

--- a/.omx/ultragoal/PER-137-checkpoints.md
+++ b/.omx/ultragoal/PER-137-checkpoints.md
@@ -4,3 +4,4 @@
 - Goal: ship typed Tooling discovery metadata for stable mesh-aware tool binding.
 - Constraints: bus-only service interaction, typed contracts, backward-compatible local discovery, privacy-first remote provenance.
 - Stop condition: focused tests pass, PR exists, and issue is handed to QA with evidence.
+- QA follow-up: updated orchestrator chatbot tests to patch `ToolingGetToolsRequest` after the request model migration; targeted Tooling + chatbot tests pass with QA's uv command.

--- a/app/services/orchestrator/agents/chatbot.py
+++ b/app/services/orchestrator/agents/chatbot.py
@@ -26,9 +26,8 @@ from app.shared.config.models import (
     ThirdParty,
 )
 from app.shared.contracts.models.db import DBMethods
-from app.shared.contracts.models.tooling import ToolingMethods
+from app.shared.contracts.models.tooling import ToolingGetToolsRequest, ToolingMethods
 from app.shared.messaging.models.db_models import RAGSearchQuery
-from app.shared.messaging.models.tooling_models import GetToolsQuery
 
 config_api = ConfigAPI()
 
@@ -479,7 +478,7 @@ async def chatbot(state: State, bus: MessageBus):
     # Request tools from ToolingService via bus
     result = await bus.request(
         ToolingMethods.GET_TOOLS,
-        GetToolsQuery(query=state["messages"][-1].content, top_k=10),
+        ToolingGetToolsRequest(query=state["messages"][-1].content, top_k=10),
         timeout=5.0,
         priority=get_interactive_priority(),
     )

--- a/app/services/orchestrator/graph.py
+++ b/app/services/orchestrator/graph.py
@@ -17,9 +17,8 @@ from app.messaging import MessageBus
 from app.messaging.priority_helpers import get_interactive_priority
 from app.services.orchestrator.agents.chatbot import chatbot
 from app.services.orchestrator.state import State
-from app.shared.contracts.models.tooling import ToolingMethods
+from app.shared.contracts.models.tooling import ToolingExecuteToolRequest, ToolingMethods
 from app.shared.contracts.models.tts import TTSMethods
-from app.shared.messaging.models.tooling_models import ExecuteToolCommand
 from app.shared.messaging.models.tts_models import TTSRequest
 
 
@@ -113,7 +112,7 @@ class GraphOrchestrator:
                 # Send tool execution command via bus and wait for response
                 result = await self.bus.request(
                     ToolingMethods.EXECUTE_TOOL,
-                    ExecuteToolCommand(tool_name=tool_name, arguments=tool_args),
+                    ToolingExecuteToolRequest(tool_name=tool_name, arguments=tool_args),
                     timeout=30.0,  # 30 second timeout for tool execution
                     priority=get_interactive_priority(),
                 )

--- a/app/services/tooling/service.py
+++ b/app/services/tooling/service.py
@@ -9,12 +9,11 @@ This service:
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
-from pydantic import BaseModel
-
 from app.helpers.aurora_logger import log_debug, log_error, log_info, log_warning
-from app.messaging import Envelope, MessageBus
+from app.messaging import MessageBus
 from app.messaging.priority_helpers import get_interactive_priority, get_system_priority
 from app.services.tooling.tools_manager import ToolsManager, set_tools_manager
 from app.shared.contracts.models.common import EmptyOutput
@@ -32,6 +31,8 @@ from app.shared.contracts.models.tooling import (
     ToolingMethods,
     ToolingModule,
     ToolingReloadMCPRequest,
+    ToolingToolInfo,
+    ToolingToolProvenance,
 )
 from app.shared.contracts.registry import method_contract
 from app.shared.messaging.models.tooling_models import (
@@ -39,6 +40,10 @@ from app.shared.messaging.models.tooling_models import (
     ToolsReloaded,
 )
 from app.shared.services.base_service import BaseService
+
+ToolingDiscoveryRequest = (
+    ToolingGetToolsRequest | ToolingGetToolByNameRequest | ToolingExecuteToolRequest
+)
 
 
 # Service implementation
@@ -103,6 +108,187 @@ class ToolingService(BaseService):
             log_info("Reloading tools due to config change...")
             await self.tools_manager.reload()
         log_info("ToolingService configuration reloaded")
+
+    @staticmethod
+    def _tool_source(tool: Any) -> str:
+        """Best-effort source classification for a loaded tool."""
+
+        if getattr(tool, "_is_mcp_tool", False):
+            return "mcp"
+        module_name = getattr(tool, "__module__", "") or tool.__class__.__module__
+        if ".plugins." in module_name or module_name.endswith("_toolkit"):
+            return "plugin"
+        if module_name.startswith("app.services.tooling.tools"):
+            return "core"
+        return "unknown"
+
+    @staticmethod
+    def _safe_identifier(value: str) -> str:
+        """Return a LangChain/OpenAI-friendly stable identifier segment."""
+
+        safe = re.sub(r"[^a-zA-Z0-9_-]+", "_", value.strip())
+        safe = re.sub(r"_+", "_", safe).strip("_")
+        return safe or "unnamed"
+
+    @classmethod
+    def _provider_context(
+        cls, request: ToolingDiscoveryRequest
+    ) -> tuple[str, str, str, str]:
+        """Return provider peer, service instance, source type, and namespace."""
+
+        selector = request.mesh_selector
+        if selector and (
+            selector.peer_id or selector.provider_id or selector.service_instance_id
+        ):
+            provider_peer_id = selector.peer_id or selector.provider_id or "remote"
+            provider_service_instance_id = (
+                selector.service_instance_id or f"remote:{provider_peer_id}:Tooling"
+            )
+            source_type = "mesh_peer"
+            namespace = cls._safe_identifier(provider_peer_id)
+        else:
+            provider_peer_id = "local"
+            provider_service_instance_id = "local:Tooling"
+            source_type = "local"
+            namespace = "local"
+
+        return provider_peer_id, provider_service_instance_id, source_type, namespace
+
+    @classmethod
+    def _global_tool_id(
+        cls, provider_peer_id: str, service_instance_id: str, local_name: str
+    ) -> str:
+        """Build a stable global tool identifier for a provider-local tool."""
+
+        return (
+            f"{cls._safe_identifier(provider_peer_id)}:"
+            f"{cls._safe_identifier(service_instance_id)}:"
+            f"tool:{cls._safe_identifier(local_name)}"
+        )
+
+    @classmethod
+    def _namespaced_tool_name(cls, namespace: str, local_name: str) -> str:
+        """Build the bindable namespaced tool name used for remote providers."""
+
+        return f"{cls._safe_identifier(namespace)}_{cls._safe_identifier(local_name)}"
+
+    def _serialize_tool_schema(self, tool: Any) -> dict[str, Any]:
+        """Serialize the tool argument schema for LLM binding."""
+
+        if not hasattr(tool, "args_schema") or not tool.args_schema:
+            return {"type": "object", "properties": {}}
+
+        try:
+            full_schema = tool.args_schema.model_json_schema()
+        except Exception as json_schema_error:
+            log_debug(
+                "Direct schema generation failed for "
+                f"{tool.name}, attempting manual extraction: {json_schema_error}"
+            )
+            return self._extract_schema_manually(tool)
+
+        if "properties" not in full_schema:
+            return {"type": "object", "properties": {}}
+
+        filtered_properties = {
+            prop_name: prop_value
+            for prop_name, prop_value in full_schema["properties"].items()
+            if prop_name not in ["bus", "store"]
+        }
+        args_schema: dict[str, Any] = {
+            "type": "object",
+            "properties": filtered_properties,
+        }
+
+        if "required" in full_schema:
+            filtered_required = [
+                field for field in full_schema["required"] if field not in ["bus", "store"]
+            ]
+            if filtered_required:
+                args_schema["required"] = filtered_required
+
+        return args_schema
+
+    def _serialize_tool(
+        self, tool: Any, request: ToolingGetToolsRequest | ToolingGetToolByNameRequest
+    ) -> ToolingToolInfo:
+        """Serialize a loaded tool with stable mesh-aware discovery metadata."""
+
+        provider_peer_id, service_instance_id, source_type, namespace = self._provider_context(
+            request
+        )
+        local_name = tool.name
+        global_tool_id = self._global_tool_id(provider_peer_id, service_instance_id, local_name)
+        is_remote = source_type == "mesh_peer"
+        bindable_name = (
+            self._namespaced_tool_name(namespace, local_name) if is_remote else local_name
+        )
+        display_name = f"{namespace}.{local_name}" if is_remote else local_name
+        args_schema = self._serialize_tool_schema(tool)
+        required_permissions = getattr(tool, "required_permissions", None) or [
+            ToolingMethods.EXECUTE_TOOL
+        ]
+
+        return ToolingToolInfo(
+            name=bindable_name,
+            local_name=local_name,
+            global_tool_id=global_tool_id,
+            provider_peer_id=provider_peer_id,
+            provider_service_instance_id=service_instance_id,
+            namespace=namespace,
+            display_name=display_name,
+            aliases=[local_name] if bindable_name != local_name else [],
+            description=getattr(tool, "description", "") or "",
+            args_schema=args_schema,
+            schema=args_schema,
+            source_type=source_type,
+            execution_location="remote" if is_remote else "local",
+            safety_class=self._safe_metadata_value(
+                getattr(tool, "safety_class", "standard"),
+                {"standard", "sensitive", "dangerous"},
+                "standard",
+            ),
+            required_permissions=list(required_permissions),
+            confirmation_required=bool(getattr(tool, "confirmation_required", False)),
+            rate_limit_hints=getattr(tool, "rate_limit_hints", None),
+            provenance=ToolingToolProvenance(
+                provider_peer_id=provider_peer_id,
+                provider_service_instance_id=service_instance_id,
+                provider_kind=source_type,
+                source=self._safe_metadata_value(
+                    self._tool_source(tool), {"core", "plugin", "mcp", "unknown"}, "unknown"
+                ),
+                advertised_name=local_name,
+            ),
+        )
+
+    @staticmethod
+    def _safe_metadata_value(value: Any, allowed: set[str], fallback: str) -> str:
+        """Return value if allowed, otherwise a stable fallback."""
+
+        return value if isinstance(value, str) and value in allowed else fallback
+
+    def _resolve_tool_name(self, request: ToolingExecuteToolRequest) -> str:
+        """Resolve discovery IDs or namespaced names back to provider-local names."""
+
+        provider_peer_id, service_instance_id, source_type, namespace = self._provider_context(
+            request
+        )
+        requested_name = request.tool_name
+
+        for local_name in self.tools_manager.get_all_tool_names():
+            if requested_name == local_name:
+                return local_name
+            if requested_name == self._global_tool_id(
+                provider_peer_id, service_instance_id, local_name
+            ):
+                return local_name
+            if source_type == "mesh_peer" and requested_name == self._namespaced_tool_name(
+                namespace, local_name
+            ):
+                return local_name
+
+        return requested_name
 
     def _extract_schema_manually(self, tool: Any) -> dict[str, Any]:
         """Extract schema manually from tool, filtering out non-serializable fields.
@@ -202,7 +388,8 @@ class ToolingService(BaseService):
     async def _on_get_tools(self, request: ToolingGetToolsRequest) -> ToolingGetToolsResponse:
         """Handle get tools query.
 
-        Serializes tools to send through the bus (name, description, and argument descriptions only).
+        Serializes tools to send through the bus with bindable schemas,
+        stable identity, and provenance metadata.
         The bus remains agnostic - it just transports the serialized data.
 
         Args:
@@ -249,75 +436,11 @@ class ToolingService(BaseService):
                 # No query, return all tools
                 tools = self.tools_manager.get_tools(None, request.top_k)
 
-            # Serialize tools to send through bus (only name, description, and argument descriptions)
+            # Serialize tools to send through bus with stable identity and provenance metadata.
             serialized_tools = []
             for tool in tools:
                 try:
-                    # Extract tool schema information - only what's needed for LLM binding
-                    tool_schema = {
-                        "name": tool.name,
-                        "description": tool.description or "",
-                    }
-
-                    # Get the args schema if available
-                    if hasattr(tool, "args_schema") and tool.args_schema:
-                        try:
-                            # Get the full JSON schema
-                            # Some schemas may contain non-serializable types (e.g., BaseStore)
-                            # We'll catch the error and filter out problematic fields
-                            try:
-                                full_schema = tool.args_schema.model_json_schema()
-                            except Exception as json_schema_error:
-                                # If schema generation fails due to non-serializable types,
-                                # use helper method to manually build a schema excluding problematic fields
-                                log_debug(
-                                    f"Direct schema generation failed for {tool.name}, attempting manual extraction: {json_schema_error}"
-                                )
-                                tool_schema["args_schema"] = self._extract_schema_manually(tool)
-
-                                # Skip the rest of the schema processing
-                                serialized_tools.append(tool_schema)
-                                continue
-
-                            # Extract only properties and required fields (filter out injected params)
-                            if "properties" in full_schema:
-                                filtered_properties = {}
-                                for prop_name, prop_value in full_schema["properties"].items():
-                                    # Skip runtime-injected parameters (bus, store, etc.)
-                                    # These are injected at execution time and shouldn't be in the LLM schema
-                                    if prop_name not in ["bus", "store"]:
-                                        filtered_properties[prop_name] = prop_value
-
-                                # Build minimal args_schema with type, properties, and required fields
-                                args_schema = {
-                                    "type": "object",
-                                    "properties": filtered_properties,
-                                }
-
-                                # Include required fields if they exist and filter out injected params
-                                if "required" in full_schema:
-                                    filtered_required = [
-                                        r
-                                        for r in full_schema["required"]
-                                        if r not in ["bus", "store"]
-                                    ]
-                                    if filtered_required:
-                                        args_schema["required"] = filtered_required
-
-                                tool_schema["args_schema"] = args_schema
-                            else:
-                                # No properties - use empty object schema
-                                tool_schema["args_schema"] = {"type": "object", "properties": {}}
-                        except Exception as schema_error:
-                            log_warning(
-                                f"Failed to generate JSON schema for {tool.name}: {schema_error}"
-                            )
-                            tool_schema["args_schema"] = {"type": "object", "properties": {}}
-                    else:
-                        # No arguments schema available - use empty object schema
-                        tool_schema["args_schema"] = {"type": "object", "properties": {}}
-
-                    serialized_tools.append(tool_schema)
+                    serialized_tools.append(self._serialize_tool(tool, request))
 
                 except Exception as tool_error:
                     log_warning(f"Failed to serialize tool {tool.name}: {tool_error}")
@@ -476,15 +599,16 @@ class ToolingService(BaseService):
             log_debug(f"Executing tool: {request.tool_name} with args: {request.arguments}")
 
             # Get the tool
-            tool = self.tools_manager.get_tool_by_name(request.tool_name)
+            local_tool_name = self._resolve_tool_name(request)
+            tool = self.tools_manager.get_tool_by_name(local_tool_name)
             if not tool:
                 # Try to find similar tool names (case-insensitive, partial match)
                 all_tool_names = self.tools_manager.get_all_tool_names()
                 similar_tools = [
                     name
                     for name in all_tool_names
-                    if request.tool_name.lower() in name.lower()
-                    or name.lower() in request.tool_name.lower()
+                    if local_tool_name.lower() in name.lower()
+                    or name.lower() in local_tool_name.lower()
                 ]
 
                 error_msg = f"Tool not found: '{request.tool_name}'"
@@ -516,7 +640,7 @@ class ToolingService(BaseService):
                     if hasattr(tool, "ainvoke")
                     else tool.invoke(tool_args)
                 )
-                log_debug(f"Tool {request.tool_name} executed successfully: {result}")
+                log_debug(f"Tool {local_tool_name} executed successfully: {result}")
 
                 # Return response
                 return ToolingExecuteToolResponse(ok=True, data=result, error=None)

--- a/app/shared/contracts/models/tooling.py
+++ b/app/shared/contracts/models/tooling.py
@@ -1,6 +1,8 @@
 """Tooling service contract models."""
 
-from typing import Any
+from typing import Any, Literal
+
+from pydantic import Field
 
 from app.shared.contracts.models.mesh import MeshAddressSelector
 from app.shared.contracts.registry import IOModel
@@ -36,10 +38,59 @@ class ToolingGetToolsRequest(IOModel):
     mesh_selector: MeshAddressSelector | None = None
 
 
+class ToolingRateLimitHints(IOModel):
+    """Optional rate-limit hints for a discovered tool provider."""
+
+    max_calls: int | None = None
+    window_seconds: int | None = None
+    policy: str | None = None
+
+
+class ToolingToolProvenance(IOModel):
+    """Provenance carried with a discovered tool."""
+
+    provider_peer_id: str
+    provider_service_instance_id: str
+    provider_kind: Literal["local", "mesh_peer"] = "local"
+    source: Literal["core", "plugin", "mcp", "unknown"] = "unknown"
+    advertised_name: str
+
+
+class ToolingToolInfo(IOModel):
+    """Typed metadata for a discovered tool.
+
+    ``name`` remains the bindable tool name expected by existing
+    orchestrator code. For local-only discovery it is the provider-local
+    name; for provider-selected mesh discovery it is namespaced to avoid
+    collisions.
+    """
+
+    name: str
+    local_name: str
+    global_tool_id: str
+    provider_peer_id: str
+    provider_service_instance_id: str
+    namespace: str
+    display_name: str
+    aliases: list[str] = Field(default_factory=list)
+    description: str = ""
+    args_schema: dict[str, Any] = Field(
+        default_factory=lambda: {"type": "object", "properties": {}}
+    )
+    schema: dict[str, Any] = Field(default_factory=lambda: {"type": "object", "properties": {}})
+    source_type: Literal["local", "mesh_peer"] = "local"
+    execution_location: Literal["local", "remote"] = "local"
+    safety_class: Literal["standard", "sensitive", "dangerous"] = "standard"
+    required_permissions: list[str] = Field(default_factory=list)
+    confirmation_required: bool = False
+    rate_limit_hints: ToolingRateLimitHints | None = None
+    provenance: ToolingToolProvenance
+
+
 class ToolingGetToolsResponse(IOModel):
     """Response with available tools."""
 
-    tools: list[dict[str, Any]]
+    tools: list[ToolingToolInfo]
     count: int
 
 

--- a/app/shared/messaging/models/tooling_models.py
+++ b/app/shared/messaging/models/tooling_models.py
@@ -7,6 +7,8 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from app.messaging import Command, Event, Query
+from app.shared.contracts.models.mesh import MeshAddressSelector
+from app.shared.contracts.models.tooling import ToolingToolInfo
 
 
 class ToolsInitialized(Event):
@@ -27,12 +29,13 @@ class GetToolsQuery(Query):
 
     query: str | None = None
     top_k: int = 10
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class GetToolsResponse(BaseModel):
     """Response for GetToolsQuery."""
 
-    tools: list[dict[str, Any]] = Field(default_factory=list)
+    tools: list[ToolingToolInfo] = Field(default_factory=list)
     count: int = 0
 
 
@@ -40,6 +43,7 @@ class GetToolByNameQuery(Query):
     """Query to get a specific tool by name."""
 
     name: str
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class ReloadMCPToolsCommand(Command):
@@ -76,6 +80,7 @@ class ExecuteToolCommand(Command):
 
     tool_name: str
     arguments: dict[str, Any] = Field(default_factory=dict)
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class ExecuteToolResponse(BaseModel):

--- a/docs/SERVICE_METHODS_REFERENCE.md
+++ b/docs/SERVICE_METHODS_REFERENCE.md
@@ -404,6 +404,38 @@ Tool management and execution.
 | `Tooling.ReloadMCP` | Reload MCP tools | `ToolingReloadMCPRequest` | `EmptyOutput` | **internal** |
 | `Tooling.ExecuteTool` | Execute a tool | `ToolingExecuteToolRequest` | `ToolingExecuteToolResponse` | **both** |
 
+### Method Details
+
+#### `Tooling.GetTools` (Both)
+**Purpose**: Return bindable tool schemas with stable local/mesh identity metadata.
+
+```python
+# Output item
+ToolingToolInfo(
+    name="raspi-lab_switch_on",                 # Bindable, collision-safe name
+    local_name="switch_on",                     # Provider-local tool name
+    global_tool_id="raspi-lab:remote_raspi-lab_Tooling:tool:switch_on",
+    provider_peer_id="raspi-lab",
+    provider_service_instance_id="remote:raspi-lab:Tooling",
+    namespace="raspi-lab",
+    display_name="raspi-lab.switch_on",         # Human-facing name
+    aliases=["switch_on"],
+    description="Switch on a target.",
+    args_schema={"type": "object", "properties": {...}},
+    source_type="mesh_peer",                    # "local" | "mesh_peer"
+    execution_location="remote",                # "local" | "remote"
+    safety_class="standard",
+    required_permissions=["Tooling.ExecuteTool"],
+    confirmation_required=False,
+    provenance={...},
+)
+```
+
+Local-only discovery remains backward compatible: `name` is still the local
+tool name. Provider-selected mesh discovery namespaces `name`, for example
+`raspi-lab_switch_on` and `workstation_switch_on`, while `display_name` keeps
+the user-facing `raspi-lab.switch_on` / `workstation.switch_on` form.
+
 ---
 
 ## Config Service

--- a/tests/unit/orchestrator/test_chatbot.py
+++ b/tests/unit/orchestrator/test_chatbot.py
@@ -90,7 +90,7 @@ class TestChatbotMemorySearch:
         with (
             _patch_llm_for_chatbot(),
             patch("app.services.orchestrator.agents.chatbot.ToolingMethods"),
-            patch("app.services.orchestrator.agents.chatbot.GetToolsQuery"),
+            patch("app.services.orchestrator.agents.chatbot.ToolingGetToolsRequest"),
         ):
             # Update the mock response for this specific test
             import app.services.orchestrator.agents.chatbot as chatbot_module
@@ -124,7 +124,7 @@ class TestChatbotMemorySearch:
         with (
             _patch_llm_for_chatbot(),
             patch("app.services.orchestrator.agents.chatbot.ToolingMethods"),
-            patch("app.services.orchestrator.agents.chatbot.GetToolsQuery"),
+            patch("app.services.orchestrator.agents.chatbot.ToolingGetToolsRequest"),
         ):
             result = await chatbot(mock_state, bus=mock_bus)
 
@@ -142,7 +142,7 @@ class TestChatbotMemorySearch:
         with (
             _patch_llm_for_chatbot(),
             patch("app.services.orchestrator.agents.chatbot.ToolingMethods"),
-            patch("app.services.orchestrator.agents.chatbot.GetToolsQuery"),
+            patch("app.services.orchestrator.agents.chatbot.ToolingGetToolsRequest"),
         ):
             result = await chatbot(mock_state, bus=mock_bus)
 
@@ -157,7 +157,6 @@ class TestChatbotToolRetrieval:
     async def test_chatbot_get_tools_success(self, mock_bus, mock_state):
         """Test successful tool retrieval via bus."""
         from app.messaging import QueryResult
-        from app.shared.messaging.models.tooling_models import GetToolsQuery  # noqa: F401
 
         # Mock memory search (first call)
         # Mock tool retrieval (second call)
@@ -180,7 +179,7 @@ class TestChatbotToolRetrieval:
         with (
             _patch_llm_for_chatbot(),
             patch("app.services.orchestrator.agents.chatbot.ToolingMethods") as mock_topics,
-            patch("app.services.orchestrator.agents.chatbot.GetToolsQuery"),
+            patch("app.services.orchestrator.agents.chatbot.ToolingGetToolsRequest"),
         ):
             mock_topics.GET_TOOLS = "Tooling.GetTools"
             result = await chatbot(mock_state, bus=mock_bus)
@@ -205,7 +204,7 @@ class TestChatbotToolRetrieval:
         with (
             _patch_llm_for_chatbot(),
             patch("app.services.orchestrator.agents.chatbot.ToolingMethods"),
-            patch("app.services.orchestrator.agents.chatbot.GetToolsQuery"),
+            patch("app.services.orchestrator.agents.chatbot.ToolingGetToolsRequest"),
         ):
             result = await chatbot(mock_state, bus=mock_bus)
 
@@ -256,7 +255,7 @@ class TestChatbotLLMIntegration:
         with (
             _patch_llm_for_chatbot(),
             patch("app.services.orchestrator.agents.chatbot.ToolingMethods"),
-            patch("app.services.orchestrator.agents.chatbot.GetToolsQuery"),
+            patch("app.services.orchestrator.agents.chatbot.ToolingGetToolsRequest"),
             patch(
                 "app.services.orchestrator.agents.chatbot._deserialize_tools"
             ) as mock_deserialize,
@@ -287,7 +286,7 @@ class TestChatbotLLMIntegration:
         with (
             _patch_llm_for_chatbot(),
             patch("app.services.orchestrator.agents.chatbot.ToolingMethods"),
-            patch("app.services.orchestrator.agents.chatbot.GetToolsQuery"),
+            patch("app.services.orchestrator.agents.chatbot.ToolingGetToolsRequest"),
         ):
             result = await chatbot(mock_state, bus=mock_bus)
 

--- a/tests/unit/tooling/test_service.py
+++ b/tests/unit/tooling/test_service.py
@@ -6,12 +6,9 @@ import pytest
 
 from app.messaging import Envelope, MessageBus
 from app.services.tooling.service import ToolingService
+from app.shared.contracts.models.mesh import MeshAddressSelector
 from app.shared.contracts.models.tooling import ToolingMethods
 from app.shared.messaging.models.tooling_models import (
-    ExecuteToolCommand,
-    GetToolByNameQuery,
-    GetToolsQuery,
-    GetToolStatsQuery,
     ToolsInitialized,
 )
 
@@ -38,6 +35,7 @@ def tooling_service(mock_bus):
         mock_manager.get_stats = Mock(return_value={"total_tools": 5, "mcp_tools_loaded": False})
         mock_manager.get_tools = Mock(return_value=[])
         mock_manager.get_tool_by_name = Mock(return_value=None)
+        mock_manager.get_all_tool_names = Mock(return_value=[])
         mock_tools_mgr.return_value = mock_manager
 
         service = ToolingService()
@@ -126,6 +124,86 @@ class TestToolingServiceQueries:
         # Verify response was returned (contract methods return directly now)
         assert response is not None
         assert hasattr(response, "tools")
+
+    @pytest.mark.asyncio
+    async def test_get_tools_preserves_local_tool_name_with_metadata(self, tooling_service):
+        """Test local discovery remains backward compatible while adding metadata."""
+        from langchain_core.tools import tool
+
+        from app.shared.contracts.models.tooling import ToolingGetToolsRequest, ToolingToolInfo
+
+        @tool
+        def test_tool(input: str):
+            """Test tool."""
+            return input
+
+        tooling_service.tools_manager.get_tools = Mock(return_value=[test_tool])
+
+        response = await tooling_service._on_get_tools(
+            ToolingGetToolsRequest(query=None, top_k=10)
+        )
+
+        assert response.count == 1
+        tool_info = response.tools[0]
+        assert isinstance(tool_info, ToolingToolInfo)
+        assert tool_info.name == "test_tool"
+        assert tool_info.local_name == "test_tool"
+        assert tool_info.provider_peer_id == "local"
+        assert tool_info.source_type == "local"
+        assert tool_info.execution_location == "local"
+        assert tool_info.global_tool_id == "local:local_Tooling:tool:test_tool"
+        assert tool_info.provenance.advertised_name == "test_tool"
+        assert "input" in tool_info.args_schema["properties"]
+
+    @pytest.mark.asyncio
+    async def test_get_tools_namespaces_remote_provider_collisions(self, tooling_service):
+        """Test remote providers with colliding local tool names get distinct IDs."""
+        from langchain_core.tools import tool
+
+        from app.shared.contracts.models.tooling import ToolingGetToolsRequest
+
+        @tool
+        def switch_on(target: str):
+            """Switch on a target."""
+            return target
+
+        tooling_service.tools_manager.get_tools = Mock(return_value=[switch_on])
+
+        lab_response = await tooling_service._on_get_tools(
+            ToolingGetToolsRequest(
+                query=None,
+                top_k=10,
+                mesh_selector=MeshAddressSelector(
+                    peer_id="raspi-lab",
+                    service_instance_id="remote:raspi-lab:Tooling",
+                ),
+            )
+        )
+        workstation_response = await tooling_service._on_get_tools(
+            ToolingGetToolsRequest(
+                query=None,
+                top_k=10,
+                mesh_selector=MeshAddressSelector(
+                    peer_id="workstation",
+                    service_instance_id="remote:workstation:Tooling",
+                ),
+            )
+        )
+
+        lab_tool = lab_response.tools[0]
+        workstation_tool = workstation_response.tools[0]
+
+        assert lab_tool.local_name == workstation_tool.local_name == "switch_on"
+        assert lab_tool.name == "raspi-lab_switch_on"
+        assert workstation_tool.name == "workstation_switch_on"
+        assert lab_tool.name != workstation_tool.name
+        assert lab_tool.display_name == "raspi-lab.switch_on"
+        assert workstation_tool.display_name == "workstation.switch_on"
+        assert lab_tool.global_tool_id != workstation_tool.global_tool_id
+        assert lab_tool.provider_peer_id == "raspi-lab"
+        assert workstation_tool.provider_peer_id == "workstation"
+        assert lab_tool.source_type == "mesh_peer"
+        assert lab_tool.execution_location == "remote"
 
     @pytest.mark.asyncio
     async def test_get_tools_with_query(self, tooling_service, mock_bus):
@@ -232,6 +310,7 @@ class TestToolingServiceToolExecution:
         mock_tool.ainvoke = AsyncMock(return_value="Result: test")
 
         tooling_service.tools_manager.get_tool_by_name = Mock(return_value=mock_tool)
+        tooling_service.tools_manager.get_all_tool_names = Mock(return_value=["test_tool"])
 
         # Contract methods receive the request model directly
         request = ToolingExecuteToolRequest(tool_name="test_tool", arguments={"input": "test"})
@@ -242,6 +321,58 @@ class TestToolingServiceToolExecution:
         assert response is not None
         assert isinstance(response, ToolingExecuteToolResponse)
         assert response.ok is True
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_accepts_remote_namespaced_discovery_name(
+        self, tooling_service, mock_bus
+    ):
+        """Test namespaced discovery names resolve to provider-local tool names."""
+        from app.shared.contracts.models.tooling import ToolingExecuteToolRequest
+
+        mock_tool = Mock()
+        mock_tool.ainvoke = AsyncMock(return_value="ok")
+
+        tooling_service.tools_manager.get_all_tool_names = Mock(return_value=["switch_on"])
+        tooling_service.tools_manager.get_tool_by_name = Mock(return_value=mock_tool)
+
+        request = ToolingExecuteToolRequest(
+            tool_name="raspi-lab_switch_on",
+            arguments={"target": "lamp"},
+            mesh_selector=MeshAddressSelector(
+                peer_id="raspi-lab",
+                service_instance_id="remote:raspi-lab:Tooling",
+            ),
+        )
+
+        response = await tooling_service._on_execute_tool(request)
+
+        assert response.ok is True
+        tooling_service.tools_manager.get_tool_by_name.assert_called_once_with("switch_on")
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_accepts_global_tool_id(self, tooling_service, mock_bus):
+        """Test stable global tool IDs resolve to provider-local tool names."""
+        from app.shared.contracts.models.tooling import ToolingExecuteToolRequest
+
+        mock_tool = Mock()
+        mock_tool.ainvoke = AsyncMock(return_value="ok")
+
+        tooling_service.tools_manager.get_all_tool_names = Mock(return_value=["switch_on"])
+        tooling_service.tools_manager.get_tool_by_name = Mock(return_value=mock_tool)
+
+        request = ToolingExecuteToolRequest(
+            tool_name="raspi-lab:remote_raspi-lab_Tooling:tool:switch_on",
+            arguments={"target": "lamp"},
+            mesh_selector=MeshAddressSelector(
+                peer_id="raspi-lab",
+                service_instance_id="remote:raspi-lab:Tooling",
+            ),
+        )
+
+        response = await tooling_service._on_execute_tool(request)
+
+        assert response.ok is True
+        tooling_service.tools_manager.get_tool_by_name.assert_called_once_with("switch_on")
 
     @pytest.mark.asyncio
     async def test_execute_tool_not_found(self, tooling_service, mock_bus):


### PR DESCRIPTION
## Summary
- add typed Tooling discovery metadata with stable global IDs, provider peer/service identity, namespace/display names, policy hints, schema, and provenance
- namespace provider-selected remote tool names while preserving local-only discovery names for backward compatibility
- let Tooling execution resolve provider-local names, namespaced discovery names, and stable global tool IDs
- switch orchestrator Tooling calls to contract request models and document the new discovery shape

## Verification
- `python -m py_compile app/shared/contracts/models/tooling.py app/services/tooling/service.py app/services/orchestrator/agents/chatbot.py app/services/orchestrator/graph.py app/shared/messaging/models/tooling_models.py tests/unit/tooling/test_service.py`
- `git diff --check`

## Not run
- `uv run ruff ...` and targeted pytest: this runtime has no `uv`, no pytest/ruff installed, and only Python 3.14/3.12 are available, while Aurora requires Python 3.10-3.11.
