### PR TITLE
PER-139 bind authorized remote tools in orchestrator

### DIFF
--- a/.omx/plans/PER-139-orchestrator-authorized-remote-tools.md
+++ b/.omx/plans/PER-139-orchestrator-authorized-remote-tools.md
@@ -1,0 +1,33 @@
+# PER-139 Orchestrator Remote Tool Binding Plan
+
+## Scope
+- Issue: PER-139 `[MESH][P3-T03] Teach Orchestrator to bind local plus authorized remote tools safely`.
+- Source docs read: issue description/metadata/comments, root/runtime `AGENTS.md`, repo `AGENTS.md`, `app/services/AGENTS.md`, `app/shared/AGENTS.md`, `app/shared/contracts/AGENTS.md`, `app/messaging/AGENTS.md`, `tests/AGENTS.md`, `.omx/plans/PER-137-tooling-discovery-metadata.md`, `.omx/plans/PER-138-remote-tooling-execution-routing.md`, `docs/SERVICE_METHODS_REFERENCE.md`.
+- Source docs named by metadata but missing in this checkout: `.omx/specs/deep-interview-mesh-distributed-integration.md`, `.omx/multica/mesh-roadmap-tasks/task-index.json`, `.omx/multica/mesh-roadmap-tasks/P3-T03*`.
+- GitNexus context was requested by repo guidance but no MCP resources were exposed in this runtime.
+
+## Requirements
+- Preserve local-only orchestrator tool behavior.
+- Bind local and safe remote tools into the same LLM planning context.
+- Keep provider provenance out of model arguments but preserve it through execution.
+- Hide remote high-risk/confirmation-required tools from automatic LLM binding for now.
+- Execute remote selections with explicit provider/tool identity rather than display name alone.
+
+## Implementation Steps
+1. Add an orchestrator tool-binding helper that deserializes Tooling discovery metadata, filters unsafe remote tools, creates LangChain `StructuredTool` instances, and returns hidden execution bindings keyed by LLM-visible name.
+2. Extend orchestrator `State` to carry `tool_bindings` alongside messages.
+3. Update `chatbot.py` to use the helper and return bindings with the assistant message.
+4. Update `graph.py` to translate selected tool names through `tool_bindings` into `ToolingExecuteToolRequest` with `global_tool_id` plus `MeshAddressSelector` for remote providers.
+5. Add focused unit tests for local+remote binding, collision-safe remote names, confirmation-required filtering, and remote execution request construction.
+6. Update service-method docs with orchestrator binding semantics.
+
+## Acceptance Criteria
+- Local tools still bind and execute by local name.
+- Standard remote tools bind in the same context as local tools.
+- Colliding remote local names remain deterministic through namespaced bindable names.
+- Remote dangerous/sensitive/confirmation-required tools are hidden from automatic model binding.
+- Remote tool execution uses `global_tool_id` and peer/service selector metadata.
+
+## Verification
+- `uv run pytest tests/unit/orchestrator/test_tool_bindings.py tests/unit/orchestrator/test_graph.py -q`
+- Add `tests/unit/orchestrator/test_chatbot.py` if chatbot changes need direct coverage in this runtime.

--- a/.omx/ultragoal/PER-139-checkpoints.md
+++ b/.omx/ultragoal/PER-139-checkpoints.md
@@ -1,0 +1,17 @@
+# PER-139 Ultragoal Checkpoints
+
+## 2026-06-17
+
+- Plan artifact: `.omx/plans/PER-139-orchestrator-authorized-remote-tools.md`.
+- Implemented orchestrator-local binding helper for safe Tooling discovery metadata.
+- Added graph execution translation from LLM-visible remote names to hidden
+  `global_tool_id` plus `MeshAddressSelector`.
+- Added focused unit coverage for binding filtering/collisions and remote graph
+  execution request construction.
+- Validation completed:
+  - `python -m py_compile app/services/orchestrator/tool_bindings.py app/services/orchestrator/agents/chatbot.py app/services/orchestrator/graph.py app/services/orchestrator/state.py tests/unit/orchestrator/test_tool_bindings.py tests/unit/orchestrator/test_graph.py tests/unit/orchestrator/test_chatbot.py`
+  - `git diff --check`
+- Validation blocked:
+  - `uv run pytest tests/unit/orchestrator/test_tool_bindings.py tests/unit/orchestrator/test_graph.py -q` failed because `uv` is not installed.
+  - `python -m pytest ...` failed because only Python 3.14.6 is available and pytest/project dependencies are not installed.
+  - `python -c "import langchain_core, pydantic"` failed because `langchain_core` is not installed.

--- a/app/services/orchestrator/agents/chatbot.py
+++ b/app/services/orchestrator/agents/chatbot.py
@@ -1,14 +1,12 @@
 import os
 from datetime import datetime
 
-from langchain_core.tools import StructuredTool
-from pydantic import create_model
-
 from app.helpers.aurora_logger import log_debug, log_error, log_info, log_warning
 from app.helpers.getUseHardwareAcceleration import get_use_hardware_acceleration
 from app.messaging import MessageBus
 from app.messaging.priority_helpers import get_interactive_priority
 from app.services.orchestrator.state import State
+from app.services.orchestrator.tool_bindings import build_tool_bindings
 from app.shared.config.interface import ConfigAPI
 from app.shared.config.keys import ConfigKeys
 from app.shared.config.models import (
@@ -303,118 +301,11 @@ async def _initialize_llm() -> None:
         log_error(f"❌ Failed to initialize LLM with provider: {provider}")
 
 
-def _deserialize_tools(tool_schemas: list[dict]) -> list[StructuredTool]:
-    """Deserialize tool schemas received from ToolingService via bus into LangChain StructuredTool objects.
+def _deserialize_tools(tool_schemas: list[dict]):
+    """Backward-compatible tool deserialization wrapper."""
 
-    This function reconstructs LangChain tools from serialized data (name, description, argument descriptions)
-    that was sent through the bus. The bus remains agnostic - it just transported the data.
-
-    Args:
-        tool_schemas: List of serialized tool schemas from ToolingService (name, description, args_schema)
-
-    Returns:
-        List of LangChain StructuredTool objects that can be bound to LLM
-    """
-    from pydantic import Field
-
-    tools = []
-
-    for schema in tool_schemas:
-        try:
-            tool_name = schema.get("name", "unknown_tool")
-            tool_description = schema.get("description", "")
-            args_schema_dict = schema.get("args_schema", {})
-
-            # Create a Pydantic model from the JSON schema
-            # If the schema has properties, create a model with those fields
-            if (
-                args_schema_dict
-                and isinstance(args_schema_dict, dict)
-                and "properties" in args_schema_dict
-            ):
-                properties = args_schema_dict["properties"]
-                required_fields = args_schema_dict.get("required", [])
-
-                # Build field definitions for create_model
-                field_defs = {}
-                if properties:  # Only iterate if properties is not empty
-                    for field_name, field_info in properties.items():
-                        field_type = _json_schema_type_to_python(field_info.get("type", "string"))
-                        field_description = field_info.get("description", "")
-
-                        # Check if field is required
-                        if field_name in required_fields:
-                            # Required field - use Ellipsis (...) with Field description if available
-                            if field_description:
-                                field_defs[field_name] = (
-                                    field_type,
-                                    Field(..., description=field_description),
-                                )
-                            else:
-                                field_defs[field_name] = (field_type, ...)
-                        else:
-                            # Optional field - use Field with default None and description if available
-                            if field_description:
-                                field_defs[field_name] = (
-                                    field_type,
-                                    Field(default=None, description=field_description),
-                                )
-                            else:
-                                field_defs[field_name] = (field_type, None)
-
-                # Create the Pydantic model dynamically (empty field_defs creates empty model)
-                args_model = create_model(f"{tool_name}Args", **field_defs)
-            else:
-                # No arguments
-                args_model = create_model(f"{tool_name}Args")
-
-            # Create a dummy function for the tool (execution happens via bus)
-            # Use a factory function to properly capture tool_name and avoid B023
-            def _create_dummy_func(name: str):
-                def func(**kwargs):
-                    raise NotImplementedError(
-                        f"Tool {name} should be executed via message bus, not directly"
-                    )
-
-                return func
-
-            dummy_func = _create_dummy_func(tool_name)
-
-            # Create the StructuredTool
-            tool = StructuredTool(
-                name=tool_name,
-                description=tool_description,
-                func=dummy_func,
-                args_schema=args_model,
-            )
-
-            tools.append(tool)
-
-        except Exception as e:
-            log_warning(f"Failed to deserialize tool schema: {e}")
-            continue
-
+    tools, _ = build_tool_bindings(tool_schemas)
     return tools
-
-
-def _json_schema_type_to_python(json_type: str) -> type:
-    """Convert JSON schema type to Python type.
-
-    Args:
-        json_type: JSON schema type string
-
-    Returns:
-        Corresponding Python type
-    """
-    type_mapping = {
-        "string": str,
-        "number": float,
-        "integer": int,
-        "boolean": bool,
-        "array": list,
-        "object": dict,
-    }
-    return type_mapping.get(json_type, str)
 
 
 # Def the chatbot node
@@ -483,6 +374,7 @@ async def chatbot(state: State, bus: MessageBus):
         priority=get_interactive_priority(),
     )
 
+    tool_bindings = {}
     if not result.ok:
         log_error(f"Failed to get tools from ToolingService: {result.error}")
         tools = []
@@ -497,7 +389,7 @@ async def chatbot(state: State, bus: MessageBus):
             tool_schemas = result.data.get("tools", [])
             if not tool_schemas:
                 log_warning("No tools returned from ToolingService")
-            tools = _deserialize_tools(tool_schemas)
+            tools, tool_bindings = build_tool_bindings(tool_schemas)
             log_debug(f"Loaded {len(tools)} tools for LLM binding")
         else:
             log_error(f"Unexpected result.data type: {type(result.data)}")
@@ -528,5 +420,6 @@ async def chatbot(state: State, bus: MessageBus):
                     *state["messages"][-4:],
                 ]
             )
-        ]
+        ],
+        "tool_bindings": tool_bindings,
     }

--- a/app/services/orchestrator/graph.py
+++ b/app/services/orchestrator/graph.py
@@ -17,6 +17,7 @@ from app.messaging import MessageBus
 from app.messaging.priority_helpers import get_interactive_priority
 from app.services.orchestrator.agents.chatbot import chatbot
 from app.services.orchestrator.state import State
+from app.shared.contracts.models.mesh import MeshAddressSelector
 from app.shared.contracts.models.tooling import ToolingExecuteToolRequest, ToolingMethods
 from app.shared.contracts.models.tts import TTSMethods
 from app.shared.messaging.models.tts_models import TTSRequest
@@ -99,12 +100,15 @@ class GraphOrchestrator:
             return {"messages": []}
 
         tool_messages = []
+        tool_bindings = state.get("tool_bindings", {})
 
         # Execute each tool call via bus
         for tool_call in last_message.tool_calls:
             tool_name = tool_call["name"]
             tool_args = tool_call.get("args", {})
             tool_id = tool_call.get("id", "")
+            binding = tool_bindings.get(tool_name, {}) if isinstance(tool_bindings, dict) else {}
+            request = self._tool_execution_request(tool_name, tool_args, binding)
 
             log_debug(f"Executing tool via bus: {tool_name} with args: {tool_args}")
 
@@ -112,7 +116,7 @@ class GraphOrchestrator:
                 # Send tool execution command via bus and wait for response
                 result = await self.bus.request(
                     ToolingMethods.EXECUTE_TOOL,
-                    ToolingExecuteToolRequest(tool_name=tool_name, arguments=tool_args),
+                    request,
                     timeout=30.0,  # 30 second timeout for tool execution
                     priority=get_interactive_priority(),
                 )
@@ -149,6 +153,26 @@ class GraphOrchestrator:
                 )
 
         return {"messages": tool_messages}
+
+    @staticmethod
+    def _tool_execution_request(
+        tool_name: str, tool_args: dict[str, Any], binding: dict[str, Any]
+    ) -> ToolingExecuteToolRequest:
+        """Build a Tooling execution request from hidden binding metadata."""
+
+        request_tool_name = binding.get("tool_name") or tool_name
+        mesh_selector_data = binding.get("mesh_selector")
+        mesh_selector = None
+        if isinstance(mesh_selector_data, dict):
+            mesh_selector = MeshAddressSelector(
+                **{key: value for key, value in mesh_selector_data.items() if value is not None}
+            )
+
+        return ToolingExecuteToolRequest(
+            tool_name=request_tool_name,
+            arguments=tool_args,
+            mesh_selector=mesh_selector,
+        )
 
     def _tools_end_condition(
         self,

--- a/app/services/orchestrator/state.py
+++ b/app/services/orchestrator/state.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 from langgraph.graph.message import add_messages
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 
 # New messages from both the user and the assistant are persisted in the state
@@ -10,3 +10,4 @@ class State(TypedDict):
     # in the annotation defines how this state key should be updated
     # (in this case, it appends messages to the list, rather than overwriting them)
     messages: Annotated[list, add_messages]
+    tool_bindings: NotRequired[dict]

--- a/app/services/orchestrator/tool_bindings.py
+++ b/app/services/orchestrator/tool_bindings.py
@@ -1,0 +1,181 @@
+"""Tool binding helpers for orchestrator-safe Tooling discovery metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.tools import StructuredTool
+from pydantic import Field, create_model
+
+
+ToolBinding = dict[str, Any]
+
+
+def build_tool_bindings(
+    tool_schemas: list[dict[str, Any]],
+) -> tuple[list[StructuredTool], dict[str, ToolBinding]]:
+    """Build LLM-bindable tools and hidden execution bindings.
+
+    Tooling discovery already decides what a provider advertises. The
+    orchestrator adds one more safety layer: remote tools that require
+    confirmation or are marked sensitive/dangerous are not bound for automatic
+    model selection. Safe remote tools keep a model-visible namespaced name,
+    while execution uses the hidden global provider/tool identity.
+    """
+
+    tools: list[StructuredTool] = []
+    bindings: dict[str, ToolBinding] = {}
+
+    for schema in tool_schemas:
+        if not _is_safe_to_bind(schema):
+            continue
+
+        try:
+            bindable_name = _unique_tool_name(
+                str(schema.get("name") or "unknown_tool"), bindings
+            )
+            tool = _structured_tool_from_schema(schema, bindable_name)
+            tools.append(tool)
+            bindings[bindable_name] = _execution_binding(schema, bindable_name)
+        except Exception:
+            continue
+
+    return tools, bindings
+
+
+def _is_safe_to_bind(schema: dict[str, Any]) -> bool:
+    """Return whether a discovered tool may be advertised to the LLM."""
+
+    is_remote = _is_remote_tool(schema)
+    if not is_remote:
+        return True
+
+    safety_class = schema.get("safety_class") or "standard"
+    confirmation_required = bool(schema.get("confirmation_required"))
+    return safety_class == "standard" and not confirmation_required
+
+
+def _is_remote_tool(schema: dict[str, Any]) -> bool:
+    return (
+        schema.get("execution_location") == "remote"
+        or schema.get("source_type") == "mesh_peer"
+    )
+
+
+def _unique_tool_name(candidate: str, existing: dict[str, ToolBinding]) -> str:
+    """Return a deterministic collision-safe LLM-visible tool name."""
+
+    if candidate not in existing:
+        return candidate
+
+    suffix = 2
+    while f"{candidate}_{suffix}" in existing:
+        suffix += 1
+    return f"{candidate}_{suffix}"
+
+
+def _structured_tool_from_schema(
+    schema: dict[str, Any], bindable_name: str
+) -> StructuredTool:
+    args_schema = _args_model_from_json_schema(
+        bindable_name, schema.get("args_schema") or schema.get("schema") or {}
+    )
+    description = str(schema.get("description") or "")
+    if _is_remote_tool(schema):
+        display_name = schema.get("display_name") or bindable_name
+        provider_peer_id = schema.get("provider_peer_id") or "remote"
+        description = (
+            f"Remote tool from {provider_peer_id} as {display_name}. {description}"
+        ).strip()
+
+    def _bus_only_tool(**kwargs: Any) -> None:
+        raise NotImplementedError(
+            f"Tool {bindable_name} should be executed via message bus, not directly"
+        )
+
+    return StructuredTool(
+        name=bindable_name,
+        description=description,
+        func=_bus_only_tool,
+        args_schema=args_schema,
+    )
+
+
+def _args_model_from_json_schema(bindable_name: str, args_schema: dict[str, Any]) -> type:
+    if not isinstance(args_schema, dict) or "properties" not in args_schema:
+        return create_model(f"{_model_name_segment(bindable_name)}Args")
+
+    properties = args_schema.get("properties") or {}
+    required_fields = set(args_schema.get("required") or [])
+    field_defs: dict[str, tuple[type, Any]] = {}
+
+    for field_name, field_info in properties.items():
+        if not isinstance(field_info, dict):
+            field_info = {}
+        field_type = _json_schema_type_to_python(field_info.get("type", "string"))
+        field_description = field_info.get("description", "")
+
+        if field_name in required_fields:
+            field_default = (
+                Field(..., description=field_description)
+                if field_description
+                else ...
+            )
+        else:
+            field_default = (
+                Field(default=None, description=field_description)
+                if field_description
+                else None
+            )
+        field_defs[field_name] = (field_type, field_default)
+
+    return create_model(f"{_model_name_segment(bindable_name)}Args", **field_defs)
+
+
+def _json_schema_type_to_python(json_type: str) -> type:
+    type_mapping = {
+        "string": str,
+        "number": float,
+        "integer": int,
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+    return type_mapping.get(json_type, str)
+
+
+def _model_name_segment(tool_name: str) -> str:
+    segment = "".join(char if char.isalnum() else "_" for char in tool_name)
+    segment = "".join(part.capitalize() for part in segment.split("_") if part)
+    return segment or "Tool"
+
+
+def _execution_binding(schema: dict[str, Any], bindable_name: str) -> ToolBinding:
+    is_remote = _is_remote_tool(schema)
+    local_name = str(schema.get("local_name") or schema.get("name") or bindable_name)
+    global_tool_id = schema.get("global_tool_id")
+    provider_peer_id = schema.get("provider_peer_id")
+    provider_service_instance_id = schema.get("provider_service_instance_id")
+
+    binding: ToolBinding = {
+        "bindable_name": bindable_name,
+        "tool_name": global_tool_id if is_remote and global_tool_id else local_name,
+        "local_name": local_name,
+        "global_tool_id": global_tool_id,
+        "provider_peer_id": provider_peer_id,
+        "provider_service_instance_id": provider_service_instance_id,
+        "execution_location": schema.get("execution_location") or "local",
+        "source_type": schema.get("source_type") or "local",
+        "safety_class": schema.get("safety_class") or "standard",
+        "confirmation_required": bool(schema.get("confirmation_required")),
+    }
+
+    if is_remote:
+        binding["mesh_selector"] = {
+            "peer_id": provider_peer_id,
+            "provider_id": provider_peer_id,
+            "service_instance_id": provider_service_instance_id,
+            "tool_id": global_tool_id,
+        }
+
+    return binding

--- a/docs/SERVICE_METHODS_REFERENCE.md
+++ b/docs/SERVICE_METHODS_REFERENCE.md
@@ -436,6 +436,16 @@ tool name. Provider-selected mesh discovery namespaces `name`, for example
 `raspi-lab_switch_on` and `workstation_switch_on`, while `display_name` keeps
 the user-facing `raspi-lab.switch_on` / `workstation.switch_on` form.
 
+The Orchestrator binds local tools and remote tools marked
+`execution_location="remote"`, `safety_class="standard"`, and
+`confirmation_required=False` into the same LLM planning context. Remote
+sensitive, dangerous, or confirmation-required tools are hidden from automatic
+model selection until an explicit confirmation flow is available. For bound
+remote tools, the LLM-visible name remains the collision-safe `name`, but the
+graph stores hidden binding metadata and executes with the tool's
+`global_tool_id` plus a `MeshAddressSelector` containing provider peer,
+service instance, and tool ID.
+
 #### `Tooling.ExecuteTool` (Both)
 **Purpose**: Execute a provider-local or explicitly selected remote tool with
 policy checks and audit provenance.

--- a/tests/unit/orchestrator/test_graph.py
+++ b/tests/unit/orchestrator/test_graph.py
@@ -120,11 +120,61 @@ class TestGraphOrchestratorToolExecution:
 
         # Verify tool was executed via bus
         mock_bus.request.assert_called_once()
+        request = mock_bus.request.await_args.args[1]
+        assert request.tool_name == "test_tool"
+        assert request.mesh_selector is None
 
         # Verify result contains tool messages
         assert "messages" in result
         assert len(result["messages"]) == 1
         assert isinstance(result["messages"][0], ToolMessage)
+
+    @pytest.mark.asyncio
+    async def test_execute_remote_tool_uses_hidden_provider_binding(
+        self, graph_orchestrator, mock_bus
+    ):
+        """Remote tool selections execute with global ID and mesh selector."""
+        from langchain_core.messages import AIMessage
+
+        from app.messaging import QueryResult
+
+        mock_bus.request.return_value = QueryResult(ok=True, data="remote result")
+
+        ai_message = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "raspi-lab_switch_on",
+                    "args": {"target": "lamp"},
+                    "id": "tool_remote",
+                }
+            ],
+        )
+        state = State(
+            messages=[ai_message],
+            tool_bindings={
+                "raspi-lab_switch_on": {
+                    "tool_name": "raspi-lab:remote_raspi-lab_Tooling:tool:switch_on",
+                    "global_tool_id": "raspi-lab:remote_raspi-lab_Tooling:tool:switch_on",
+                    "mesh_selector": {
+                        "peer_id": "raspi-lab",
+                        "provider_id": "raspi-lab",
+                        "service_instance_id": "remote:raspi-lab:Tooling",
+                        "tool_id": "raspi-lab:remote_raspi-lab_Tooling:tool:switch_on",
+                    },
+                }
+            },
+        )
+
+        result = await graph_orchestrator._execute_tools_via_bus(state)
+
+        mock_bus.request.assert_called_once()
+        request = mock_bus.request.await_args.args[1]
+        assert request.tool_name == "raspi-lab:remote_raspi-lab_Tooling:tool:switch_on"
+        assert request.mesh_selector.peer_id == "raspi-lab"
+        assert request.mesh_selector.service_instance_id == "remote:raspi-lab:Tooling"
+        assert request.mesh_selector.tool_id == request.tool_name
+        assert result["messages"][0].content == "remote result"
 
     @pytest.mark.asyncio
     async def test_execute_tools_no_tool_calls(self, graph_orchestrator):

--- a/tests/unit/orchestrator/test_tool_bindings.py
+++ b/tests/unit/orchestrator/test_tool_bindings.py
@@ -1,0 +1,112 @@
+"""Unit tests for orchestrator Tooling binding metadata."""
+
+from app.services.orchestrator.tool_bindings import build_tool_bindings
+
+
+def test_build_tool_bindings_keeps_local_and_safe_remote_tools():
+    """Local and standard remote tools bind into one planning context."""
+
+    tools, bindings = build_tool_bindings(
+        [
+            {
+                "name": "weather",
+                "local_name": "weather",
+                "description": "Get weather.",
+                "args_schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+                "execution_location": "local",
+                "source_type": "local",
+            },
+            {
+                "name": "raspi-lab_switch_on",
+                "local_name": "switch_on",
+                "global_tool_id": "raspi-lab:remote_raspi-lab_Tooling:tool:switch_on",
+                "provider_peer_id": "raspi-lab",
+                "provider_service_instance_id": "remote:raspi-lab:Tooling",
+                "display_name": "raspi-lab.switch_on",
+                "description": "Switch on a target.",
+                "args_schema": {
+                    "type": "object",
+                    "properties": {"target": {"type": "string"}},
+                    "required": ["target"],
+                },
+                "execution_location": "remote",
+                "source_type": "mesh_peer",
+                "safety_class": "standard",
+                "confirmation_required": False,
+            },
+        ]
+    )
+
+    assert [tool.name for tool in tools] == ["weather", "raspi-lab_switch_on"]
+    assert bindings["weather"]["tool_name"] == "weather"
+    remote_binding = bindings["raspi-lab_switch_on"]
+    assert remote_binding["tool_name"] == "raspi-lab:remote_raspi-lab_Tooling:tool:switch_on"
+    assert remote_binding["mesh_selector"]["peer_id"] == "raspi-lab"
+    assert remote_binding["mesh_selector"]["service_instance_id"] == "remote:raspi-lab:Tooling"
+    assert remote_binding["mesh_selector"]["tool_id"] == remote_binding["global_tool_id"]
+
+
+def test_build_tool_bindings_hides_remote_confirmation_required_tools():
+    """High-risk remote tools are not advertised for automatic model selection."""
+
+    tools, bindings = build_tool_bindings(
+        [
+            {
+                "name": "raspi-lab_unlock_door",
+                "local_name": "unlock_door",
+                "global_tool_id": "raspi-lab:remote_raspi-lab_Tooling:tool:unlock_door",
+                "provider_peer_id": "raspi-lab",
+                "provider_service_instance_id": "remote:raspi-lab:Tooling",
+                "description": "Unlock a door.",
+                "args_schema": {"type": "object", "properties": {}},
+                "execution_location": "remote",
+                "source_type": "mesh_peer",
+                "safety_class": "dangerous",
+                "confirmation_required": True,
+            }
+        ]
+    )
+
+    assert tools == []
+    assert bindings == {}
+
+
+def test_build_tool_bindings_resolves_duplicate_names_deterministically():
+    """Unexpected duplicate bind names are suffixed while preserving provider IDs."""
+
+    tools, bindings = build_tool_bindings(
+        [
+            {
+                "name": "remote_status",
+                "local_name": "status",
+                "global_tool_id": "peer-a:service:tool:status",
+                "provider_peer_id": "peer-a",
+                "provider_service_instance_id": "service-a",
+                "description": "Status A.",
+                "args_schema": {"type": "object", "properties": {}},
+                "execution_location": "remote",
+                "source_type": "mesh_peer",
+                "safety_class": "standard",
+            },
+            {
+                "name": "remote_status",
+                "local_name": "status",
+                "global_tool_id": "peer-b:service:tool:status",
+                "provider_peer_id": "peer-b",
+                "provider_service_instance_id": "service-b",
+                "description": "Status B.",
+                "args_schema": {"type": "object", "properties": {}},
+                "execution_location": "remote",
+                "source_type": "mesh_peer",
+                "safety_class": "standard",
+            },
+        ]
+    )
+
+    assert [tool.name for tool in tools] == ["remote_status", "remote_status_2"]
+    assert bindings["remote_status"]["tool_name"] == "peer-a:service:tool:status"
+    assert bindings["remote_status_2"]["tool_name"] == "peer-b:service:tool:status"


### PR DESCRIPTION
## Summary
- Add orchestrator tool-binding helper that binds local tools plus standard/confirmation-free remote Tooling discoveries into one LLM planning context.
- Carry hidden execution bindings through graph state so remote tool selections execute with `global_tool_id` and `MeshAddressSelector` instead of ambiguous display names.
- Hide remote sensitive/dangerous/confirmation-required tools from automatic LLM binding pending an explicit confirmation flow.
- Add focused unit coverage for local+remote binding, duplicate-name handling, policy filtering, and remote graph execution request construction.
- Document Orchestrator binding semantics in `docs/SERVICE_METHODS_REFERENCE.md`.

## Verification
- PASS: `python -m py_compile app/services/orchestrator/tool_bindings.py app/services/orchestrator/agents/chatbot.py app/services/orchestrator/graph.py app/services/orchestrator/state.py tests/unit/orchestrator/test_tool_bindings.py tests/unit/orchestrator/test_graph.py tests/unit/orchestrator/test_chatbot.py`
- PASS: `git diff --check`
- BLOCKED: `uv run pytest tests/unit/orchestrator/test_tool_bindings.py tests/unit/orchestrator/test_graph.py -q` because `uv` is not installed in this runtime.
- BLOCKED: `python -m pytest ...` because only Python 3.14.6 is available and pytest/project dependencies are not installed.
- BLOCKED: dependency import check for `langchain_core` failed because project dependencies are not installed.

## Notes
- The Multica checkout path failed with `repo is configured but not synced`; the canonical `/home/developer/projects/aurora` path was not writable under sandbox, so implementation was done in the writable Multica checkout.
