### PR TITLE
[PER-141] Add RAG memory replication policy primitives

### DIFF
--- a/.omx/plans/PER-141-rag-memory-replication.md
+++ b/.omx/plans/PER-141-rag-memory-replication.md
@@ -1,0 +1,35 @@
+# PER-141 Plan: Selective RAG/Memory Replication
+
+## Requirements Summary
+
+- Source issue: PER-141 `[MESH][P4-T02] Design selective RAG/memory replication with provenance and conflict handling`.
+- Scope: RAG/memory replication semantics only. Do not replicate raw SQL, Auth credentials, mesh secrets, scheduler ownership, config, hardware/audio streams, or unrelated UI/P5/P6 work.
+- Policy source: `docs/DATA_SHARING_POLICY.md` permits remote-query-only by default, export/import for curated RAG namespaces, and one-way replication for explicitly published namespaces. Bidirectional sync remains deferred.
+- Missing referenced artifacts in this checkout: `.omx/specs/deep-interview-mesh-distributed-integration.md` and `.omx/multica/mesh-roadmap-tasks/*`.
+
+## Acceptance Criteria
+
+- RAG/memory replication has a documented and tested conflict model.
+- Sync is namespace-scoped and opt-in.
+- Deletes/tombstones are represented.
+- Provenance is queryable through returned item metadata.
+- No raw SQL, Auth credential, token, password hash, or mesh secret data is exported or imported.
+
+## Implementation Steps
+
+1. Extend `app/shared/contracts/models/db.py` with internal-only RAG namespace snapshot/import/change models carrying provenance, tombstones, visibility, policy/correlation IDs, schema version, and conflict mode.
+2. Add pure RAG sync helpers in `app/services/db/rag_service.py` for metadata normalization, tombstone creation, conflict resolution, export snapshot creation, import application, and namespace-scoped change listing.
+3. Add internal DB methods in `app/services/db/service.py` for `DB.RAGExportNamespace`, `DB.RAGImportNamespace`, and `DB.RAGListChanges`.
+4. Document the concrete RAG sync model in `docs/DATA_SHARING_POLICY.md` and update `docs/SERVICE_METHODS_REFERENCE.md`.
+5. Add targeted unit coverage for merge/conflict/tombstone behavior and mocked two-peer import/export flow.
+
+## Verification Strategy
+
+- `uv run pytest tests/unit/db/test_rag_service.py tests/unit/db/test_service.py -q`
+- `git diff --check`
+
+## Risks and Mitigations
+
+- Vector-store delete behavior is best-effort today. Mitigation: tombstones are explicit records, so delete propagation does not rely only on physical deletion.
+- Bidirectional convergence can be overbuilt. Mitigation: contracts include deterministic conflict metadata, but exposed service methods remain internal and support export/import plus one-way change listing first.
+- Sensitive fields could be copied accidentally. Mitigation: shared helpers reject values containing obvious credential/secret keys before export/import.

--- a/.omx/ultragoal/PER-141-checkpoints.md
+++ b/.omx/ultragoal/PER-141-checkpoints.md
@@ -1,0 +1,19 @@
+# PER-141 Ultragoal Checkpoints
+
+## 2026-06-17
+
+- Goal: execute `.omx/plans/PER-141-rag-memory-replication.md`.
+- Scope implemented:
+  - Internal DB contracts for `DB.RAGExportNamespace`, `DB.RAGImportNamespace`, and `DB.RAGListChanges`.
+  - Namespace-scoped RAG snapshot/change models with provenance, policy decision ID, correlation ID, sync operation ID, visibility flags, item version, and tombstone metadata.
+  - RAG export/import helpers with last-writer-wins, remote-wins, and reject-on-conflict modes.
+  - Tombstones are stored as explicit replicated records and filtered from normal live search/list responses.
+  - Sensitive credential-like fields are skipped during export/import.
+  - Docs updated in `docs/DATA_SHARING_POLICY.md` and `docs/SERVICE_METHODS_REFERENCE.md`.
+- Verification:
+  - `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy ~/.local/bin/uv run --extra dev ruff check app/shared/contracts/models/db.py app/services/db/rag_service.py app/services/db/service.py tests/unit/db/test_rag_service.py tests/unit/db/test_service.py` -> passed.
+  - `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy ~/.local/bin/uv run --extra dev --extra service-db --extra test-all pytest tests/unit/db/test_rag_service.py tests/unit/db/test_service.py -q` -> `34 passed, 3 warnings`.
+  - `git diff --check` -> passed.
+- Known limits:
+  - The referenced `.omx/specs/deep-interview-mesh-distributed-integration.md` and `.omx/multica/mesh-roadmap-tasks/*` artifacts are absent from this checkout.
+  - The new replication methods are intentionally internal-only; mesh orchestration/policy invocation remains a follow-up layer.

--- a/app/services/db/rag_service.py
+++ b/app/services/db/rag_service.py
@@ -6,19 +6,149 @@ using SQLiteVec for vector storage and semantic search of memories and tools.
 
 import json
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Optional
 
 from langchain_community.vectorstores import SQLiteVec
 from langgraph.store.base import BaseStore, Item
 
-from app.helpers.aurora_logger import log_debug, log_error, log_info
+from app.helpers.aurora_logger import log_debug, log_error, log_info, log_warning
 from app.shared.config.interface import ConfigAPI
 from app.shared.config.keys import ConfigKeys
 from app.shared.config.models import Db, Embeddings
+from app.shared.contracts.models.db import (
+    DBRAGImportNamespaceResponse,
+    DBRAGReplicatedItem,
+    DBRAGTombstone,
+)
 
 config_api = ConfigAPI()
+
+RAG_SYNC_METADATA_KEY = "_aurora_rag_sync"
+_SENSITIVE_REPLICATION_KEYS = {
+    "api_key",
+    "auth_token",
+    "credential",
+    "credentials",
+    "mesh_secret",
+    "password",
+    "password_hash",
+    "private_key",
+    "room_secret",
+    "secret",
+    "token",
+    "token_hash",
+}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def normalize_rag_namespace(namespace: str | tuple[str, ...]) -> tuple[str, ...]:
+    """Normalize supported RAG namespace spellings to a tuple."""
+    if isinstance(namespace, tuple):
+        return namespace
+    separator = "|" if "|" in namespace else "."
+    return tuple(part for part in namespace.split(separator) if part)
+
+
+def stringify_rag_namespace(namespace: str | tuple[str, ...]) -> str:
+    """Return the contract-facing namespace spelling."""
+    if isinstance(namespace, str):
+        return namespace.replace("|", ".")
+    return ".".join(namespace)
+
+
+def _has_sensitive_replication_value(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if str(key).lower() in _SENSITIVE_REPLICATION_KEYS:
+                return True
+            if _has_sensitive_replication_value(nested):
+                return True
+    elif isinstance(value, list):
+        return any(_has_sensitive_replication_value(item) for item in value)
+    return False
+
+
+def _get_sync_metadata(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict) and isinstance(value.get(RAG_SYNC_METADATA_KEY), dict):
+        return value[RAG_SYNC_METADATA_KEY]
+    return {}
+
+
+def is_rag_tombstone_value(value: Any) -> bool:
+    """Return true when a stored RAG value represents a replicated delete."""
+    metadata = _get_sync_metadata(value)
+    return bool(metadata.get("tombstone"))
+
+
+def _strip_sync_metadata(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    stripped = dict(value)
+    stripped.pop(RAG_SYNC_METADATA_KEY, None)
+    return stripped
+
+
+def _value_with_sync_metadata(item: DBRAGReplicatedItem) -> dict[str, Any]:
+    if item.value is None:
+        value: dict[str, Any] = {}
+    elif isinstance(item.value, dict):
+        value = dict(item.value)
+    else:
+        value = {"value": item.value}
+
+    metadata = item.model_dump(exclude={"value"})
+    value[RAG_SYNC_METADATA_KEY] = metadata
+    return value
+
+
+def _parse_item_updated_at(item: DBRAGReplicatedItem | None) -> datetime:
+    if item is None:
+        return datetime.min.replace(tzinfo=UTC)
+    return _parse_sync_timestamp(item.updated_at)
+
+
+def _parse_sync_timestamp(value: str) -> datetime:
+    raw = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def make_rag_tombstone(
+    *,
+    namespace: str,
+    key: str,
+    source_peer_id: str,
+    owner_peer_id: str,
+    origin_principal_id: str,
+    policy_decision_id: str,
+    correlation_id: str,
+    sync_operation_id: str,
+    deleted_by: str,
+    reason: str = "user_delete",
+) -> DBRAGReplicatedItem:
+    """Build a replicated tombstone for delete/forget propagation."""
+    now = _utc_now_iso()
+    return DBRAGReplicatedItem(
+        namespace=stringify_rag_namespace(namespace),
+        key=key,
+        value=None,
+        source_peer_id=source_peer_id,
+        owner_peer_id=owner_peer_id,
+        origin_principal_id=origin_principal_id,
+        created_at=now,
+        updated_at=now,
+        policy_decision_id=policy_decision_id,
+        correlation_id=correlation_id,
+        sync_operation_id=sync_operation_id,
+        tombstone=DBRAGTombstone(deleted_at=now, deleted_by=deleted_by, reason=reason),
+    )
 
 
 async def _async_wait_for_config_service(max_retries: int = 45, retry_delay: float = 1.0) -> bool:
@@ -831,3 +961,176 @@ class RAGService:
         """Get the combined store."""
         self._ensure_initialized()
         return self._combined_store
+
+    def export_namespace(
+        self,
+        *,
+        namespace: str,
+        source_peer_id: str,
+        owner_peer_id: str,
+        origin_principal_id: str,
+        policy_decision_id: str,
+        correlation_id: str,
+        sync_operation_id: str,
+        limit: int = 100,
+        offset: int = 0,
+        include_tombstones: bool = True,
+        since: str | None = None,
+    ) -> list[DBRAGReplicatedItem]:
+        """Export a namespace-scoped RAG snapshot with provenance."""
+        namespace_tuple = normalize_rag_namespace(namespace)
+        store = self.combined_store
+        items = store.retrieve_items(namespace_tuple, limit=limit, offset=offset)
+        exported: list[DBRAGReplicatedItem] = []
+        since_dt = _parse_sync_timestamp(since) if since else None
+
+        for item in items:
+            metadata = _get_sync_metadata(item.value)
+            if metadata.get("tombstone") and not include_tombstones:
+                continue
+            value = _strip_sync_metadata(item.value)
+            if _has_sensitive_replication_value(value):
+                log_warning(f"Skipping sensitive RAG item during export: {namespace}/{item.key}")
+                continue
+
+            created_at = metadata.get("created_at") or _utc_now_iso()
+            updated_at = metadata.get("updated_at") or _utc_now_iso()
+            if since_dt:
+                parsed_updated = _parse_sync_timestamp(updated_at)
+                if parsed_updated <= since_dt:
+                    continue
+
+            exported.append(
+                DBRAGReplicatedItem(
+                    namespace=stringify_rag_namespace(item.namespace),
+                    key=item.key,
+                    value=value,
+                    source_peer_id=metadata.get("source_peer_id", source_peer_id),
+                    owner_peer_id=metadata.get("owner_peer_id", owner_peer_id),
+                    origin_principal_id=metadata.get("origin_principal_id", origin_principal_id),
+                    created_at=created_at,
+                    updated_at=updated_at,
+                    schema_version=metadata.get("schema_version", 1),
+                    version=metadata.get("version", 1),
+                    policy_decision_id=metadata.get("policy_decision_id", policy_decision_id),
+                    correlation_id=metadata.get("correlation_id", correlation_id),
+                    sync_operation_id=metadata.get("sync_operation_id", sync_operation_id),
+                    visibility=metadata.get("visibility", "private"),
+                    encrypted=metadata.get("encrypted", False),
+                    redacted=metadata.get("redacted", False),
+                    tombstone=metadata.get("tombstone"),
+                )
+            )
+
+        return exported
+
+    def import_namespace(
+        self,
+        *,
+        namespace: str,
+        items: list[DBRAGReplicatedItem],
+        conflict_mode: str = "last_writer_wins",
+    ) -> DBRAGImportNamespaceResponse:
+        """Import replicated RAG items using deterministic conflict handling."""
+        namespace_tuple = normalize_rag_namespace(namespace)
+        namespace_str = stringify_rag_namespace(namespace_tuple)
+        store = self.combined_store
+        response = DBRAGImportNamespaceResponse()
+
+        for incoming in items:
+            if stringify_rag_namespace(incoming.namespace) != namespace_str:
+                response.skipped += 1
+                response.conflicts.append(
+                    {
+                        "key": incoming.key,
+                        "reason": "namespace_mismatch",
+                        "incoming_namespace": incoming.namespace,
+                        "target_namespace": namespace_str,
+                    }
+                )
+                continue
+
+            if incoming.value is not None and _has_sensitive_replication_value(incoming.value):
+                response.skipped += 1
+                response.conflicts.append({"key": incoming.key, "reason": "sensitive_value"})
+                continue
+
+            local_item = store.get(namespace_tuple, incoming.key)
+            local = self._replicated_item_from_local(namespace_tuple, local_item)
+            winner = self.resolve_replication_conflict(
+                local=local, incoming=incoming, conflict_mode=conflict_mode
+            )
+
+            if winner is None:
+                response.skipped += 1
+                response.conflicts.append(
+                    {
+                        "key": incoming.key,
+                        "reason": "local_newer_or_conflict_rejected",
+                        "local_updated_at": local.updated_at if local else None,
+                        "incoming_updated_at": incoming.updated_at,
+                    }
+                )
+                continue
+
+            store.put(namespace_tuple, incoming.key, _value_with_sync_metadata(winner))
+            if incoming.tombstone:
+                response.tombstoned += 1
+            elif local is None:
+                response.imported += 1
+            else:
+                response.updated += 1
+
+        return response
+
+    def _replicated_item_from_local(
+        self, namespace: tuple[str, ...], item: Item | None
+    ) -> DBRAGReplicatedItem | None:
+        if item is None:
+            return None
+
+        metadata = _get_sync_metadata(item.value)
+        now = _utc_now_iso()
+        return DBRAGReplicatedItem(
+            namespace=stringify_rag_namespace(namespace),
+            key=item.key,
+            value=_strip_sync_metadata(item.value),
+            source_peer_id=metadata.get("source_peer_id", "local"),
+            owner_peer_id=metadata.get("owner_peer_id", "local"),
+            origin_principal_id=metadata.get("origin_principal_id", "unknown"),
+            created_at=metadata.get("created_at", now),
+            updated_at=metadata.get("updated_at", now),
+            schema_version=metadata.get("schema_version", 1),
+            version=metadata.get("version", 1),
+            policy_decision_id=metadata.get("policy_decision_id", "local"),
+            correlation_id=metadata.get("correlation_id", "local"),
+            sync_operation_id=metadata.get("sync_operation_id", "local"),
+            visibility=metadata.get("visibility", "private"),
+            encrypted=metadata.get("encrypted", False),
+            redacted=metadata.get("redacted", False),
+            tombstone=metadata.get("tombstone"),
+        )
+
+    @staticmethod
+    def resolve_replication_conflict(
+        *,
+        local: DBRAGReplicatedItem | None,
+        incoming: DBRAGReplicatedItem,
+        conflict_mode: str = "last_writer_wins",
+    ) -> DBRAGReplicatedItem | None:
+        """Resolve a RAG replication conflict.
+
+        Supported modes:
+        - ``last_writer_wins``: newer ``updated_at`` wins.
+        - ``remote_wins``: incoming always wins.
+        - ``reject_on_conflict``: only inserts missing local items.
+        """
+        if local is None or conflict_mode == "remote_wins":
+            return incoming
+        if conflict_mode == "reject_on_conflict":
+            return None
+        if conflict_mode != "last_writer_wins":
+            raise ValueError(f"Unsupported RAG replication conflict mode: {conflict_mode}")
+        if _parse_item_updated_at(incoming) >= _parse_item_updated_at(local):
+            return incoming
+        return None

--- a/app/services/db/service.py
+++ b/app/services/db/service.py
@@ -15,7 +15,11 @@ from app.helpers.aurora_logger import log_debug, log_error, log_info, log_warnin
 from app.messaging import Envelope, QueryResult
 from app.services.db.manager import DatabaseManager
 from app.services.db.models import CronJob, JobStatus, Message, ScheduleType
-from app.services.db.rag_service import RAGService
+from app.services.db.rag_service import (
+    RAGService,
+    is_rag_tombstone_value,
+    normalize_rag_namespace,
+)
 from app.services.db.scheduler_db_service import SchedulerDatabaseService
 from app.shared.contracts.models.common import EmptyOutput
 from app.shared.contracts.models.db import (
@@ -54,11 +58,16 @@ from app.shared.contracts.models.db import (
     DBMethods,
     DBModule,
     DBRAGDeleteRequest,
+    DBRAGExportNamespaceRequest,
     DBRAGGetRequest,
+    DBRAGImportNamespaceRequest,
+    DBRAGImportNamespaceResponse,
     DBRAGItemResponse,
+    DBRAGListChangesRequest,
     DBRAGListRequest,
     DBRAGListResponse,
     DBRAGSearchRequest,
+    DBRAGSnapshotResponse,
     DBRAGStoreRequest,
     DBRevokeTokenRequest,
     DBSaveMeshCredentialRequest,
@@ -392,12 +401,7 @@ class DBService(BaseService):
         try:
             log_debug(f"Storing RAG item: {cmd.namespace}/{cmd.key}")
 
-            # Convert string namespace to tuple (store expects tuple)
-            # Support both "tools" and "main.memories" formats
-            if isinstance(cmd.namespace, str):
-                namespace_tuple = tuple(cmd.namespace.split("."))
-            else:
-                namespace_tuple = cmd.namespace
+            namespace_tuple = normalize_rag_namespace(cmd.namespace)
 
             # Get the appropriate store based on namespace
             store = self.rag_service.combined_store
@@ -423,12 +427,7 @@ class DBService(BaseService):
         try:
             log_debug(f"Deleting RAG item: {cmd.namespace}/{cmd.key}")
 
-            # Convert string namespace to tuple (store expects tuple)
-            # Support both "tools" and "main.memories" formats
-            if isinstance(cmd.namespace, str):
-                namespace_tuple = tuple(cmd.namespace.split("."))
-            else:
-                namespace_tuple = cmd.namespace
+            namespace_tuple = normalize_rag_namespace(cmd.namespace)
 
             # Get the appropriate store based on namespace
             store = self.rag_service.combined_store
@@ -456,12 +455,7 @@ class DBService(BaseService):
                 f"Searching RAG store: namespace={query.namespace}, query='{query.query}', limit={query.limit}"
             )
 
-            # Convert string namespace to tuple (store expects tuple)
-            # Support both "tools" and "main.memories" formats
-            if isinstance(query.namespace, str):
-                namespace_tuple = tuple(query.namespace.split("."))
-            else:
-                namespace_tuple = query.namespace
+            namespace_tuple = normalize_rag_namespace(query.namespace)
 
             # Get the appropriate store based on namespace
             store = self.rag_service.combined_store
@@ -472,6 +466,8 @@ class DBService(BaseService):
             # Convert items to response format
             rag_items = []
             for item in items:
+                if is_rag_tombstone_value(item.value):
+                    continue
                 search_score = None
                 if isinstance(item.value, dict) and "_search_score" in item.value:
                     search_score = item.value.pop("_search_score")
@@ -509,12 +505,7 @@ class DBService(BaseService):
         try:
             log_debug(f"Getting RAG item: {query.namespace}/{query.key}")
 
-            # Convert string namespace to tuple (store expects tuple)
-            # Support both "tools" and "main.memories" formats
-            if isinstance(query.namespace, str):
-                namespace_tuple = tuple(query.namespace.split("."))
-            else:
-                namespace_tuple = query.namespace
+            namespace_tuple = normalize_rag_namespace(query.namespace)
 
             # Get the appropriate store based on namespace
             store = self.rag_service.combined_store
@@ -551,12 +542,7 @@ class DBService(BaseService):
                 f"Listing RAG items: namespace={query.namespace}, limit={query.limit}, offset={query.offset}"
             )
 
-            # Convert string namespace to tuple (store expects tuple)
-            # Support both "tools" and "main.memories" formats
-            if isinstance(query.namespace, str):
-                namespace_tuple = tuple(query.namespace.split("."))
-            else:
-                namespace_tuple = query.namespace
+            namespace_tuple = normalize_rag_namespace(query.namespace)
 
             # Get the appropriate store based on namespace
             store = self.rag_service.combined_store
@@ -565,6 +551,8 @@ class DBService(BaseService):
             # Convert items to response format
             rag_items = []
             for item in items:
+                if is_rag_tombstone_value(item.value):
+                    continue
                 # Convert tuple namespace to string (contract expects string)
                 namespace_str = (
                     ".".join(item.namespace)
@@ -582,6 +570,109 @@ class DBService(BaseService):
         except Exception as e:
             log_error(f"Error listing RAG items: {e}", exc_info=True)
             return DBRAGListResponse(items=[])
+
+    @method_contract(
+        method_id=DBMethods.RAG_EXPORT_NAMESPACE,
+        input_model=DBRAGExportNamespaceRequest,
+        output_model=DBRAGSnapshotResponse,
+        summary="Export opt-in RAG namespace snapshot",
+        exposure="internal",
+        method_type="manage",
+    )
+    async def rag_export_namespace(
+        self, query: DBRAGExportNamespaceRequest
+    ) -> DBRAGSnapshotResponse:
+        """Export a namespace-scoped RAG snapshot with provenance."""
+        try:
+            items = self.rag_service.export_namespace(
+                namespace=query.namespace,
+                source_peer_id=query.source_peer_id,
+                owner_peer_id=query.owner_peer_id,
+                origin_principal_id=query.origin_principal_id,
+                policy_decision_id=query.policy_decision_id,
+                correlation_id=query.correlation_id,
+                sync_operation_id=query.sync_operation_id,
+                limit=query.limit,
+                offset=query.offset,
+                include_tombstones=query.include_tombstones,
+            )
+            return DBRAGSnapshotResponse(
+                namespace=query.namespace,
+                owner_peer_id=query.owner_peer_id,
+                source_peer_id=query.source_peer_id,
+                items=items,
+            )
+        except Exception as e:
+            log_error(f"Error exporting RAG namespace: {e}", exc_info=True)
+            return DBRAGSnapshotResponse(
+                namespace=query.namespace,
+                owner_peer_id=query.owner_peer_id,
+                source_peer_id=query.source_peer_id,
+                items=[],
+            )
+
+    @method_contract(
+        method_id=DBMethods.RAG_IMPORT_NAMESPACE,
+        input_model=DBRAGImportNamespaceRequest,
+        output_model=DBRAGImportNamespaceResponse,
+        summary="Import opt-in RAG namespace snapshot",
+        exposure="internal",
+        method_type="manage",
+    )
+    async def rag_import_namespace(
+        self, cmd: DBRAGImportNamespaceRequest
+    ) -> DBRAGImportNamespaceResponse:
+        """Import namespace-scoped RAG items using the conflict policy."""
+        try:
+            return self.rag_service.import_namespace(
+                namespace=cmd.namespace,
+                items=cmd.items,
+                conflict_mode=cmd.conflict_mode,
+            )
+        except Exception as e:
+            log_error(f"Error importing RAG namespace: {e}", exc_info=True)
+            return DBRAGImportNamespaceResponse(
+                skipped=len(cmd.items), conflicts=[{"reason": str(e)}]
+            )
+
+    @method_contract(
+        method_id=DBMethods.RAG_LIST_CHANGES,
+        input_model=DBRAGListChangesRequest,
+        output_model=DBRAGSnapshotResponse,
+        summary="List opt-in RAG namespace changes",
+        exposure="internal",
+        method_type="use",
+    )
+    async def rag_list_changes(self, query: DBRAGListChangesRequest) -> DBRAGSnapshotResponse:
+        """List namespace-scoped RAG changes after an optional timestamp."""
+        try:
+            items = self.rag_service.export_namespace(
+                namespace=query.namespace,
+                source_peer_id=query.source_peer_id,
+                owner_peer_id=query.owner_peer_id,
+                origin_principal_id=query.origin_principal_id,
+                policy_decision_id=query.policy_decision_id,
+                correlation_id=query.correlation_id,
+                sync_operation_id=query.sync_operation_id,
+                limit=query.limit,
+                offset=query.offset,
+                include_tombstones=query.include_tombstones,
+                since=query.since,
+            )
+            return DBRAGSnapshotResponse(
+                namespace=query.namespace,
+                owner_peer_id=query.owner_peer_id,
+                source_peer_id=query.source_peer_id,
+                items=items,
+            )
+        except Exception as e:
+            log_error(f"Error listing RAG changes: {e}", exc_info=True)
+            return DBRAGSnapshotResponse(
+                namespace=query.namespace,
+                owner_peer_id=query.owner_peer_id,
+                source_peer_id=query.source_peer_id,
+                items=[],
+            )
 
     # ── User CRUD ────────────────────────────────────────────────────────
 

--- a/app/shared/contracts/models/db.py
+++ b/app/shared/contracts/models/db.py
@@ -29,6 +29,9 @@ class DBMethods:
     RAG_DELETE = f"{DBModule.NAME}.RAGDelete"
     RAG_GET = f"{DBModule.NAME}.RAGGet"
     RAG_LIST = f"{DBModule.NAME}.RAGList"
+    RAG_EXPORT_NAMESPACE = f"{DBModule.NAME}.RAGExportNamespace"
+    RAG_IMPORT_NAMESPACE = f"{DBModule.NAME}.RAGImportNamespace"
+    RAG_LIST_CHANGES = f"{DBModule.NAME}.RAGListChanges"
     SAVE_CRON_JOB = f"{DBModule.NAME}.SaveCronJob"
     GET_CRON_JOBS = f"{DBModule.NAME}.GetCronJobs"
     DELETE_CRON_JOB = f"{DBModule.NAME}.DeleteCronJob"
@@ -201,6 +204,99 @@ class DBRAGListResponse(IOModel):
     """Response for RAG list/search."""
 
     items: list[DBRAGItemResponse]
+
+
+class DBRAGTombstone(IOModel):
+    """Deletion marker for replicated RAG data."""
+
+    deleted_at: str
+    deleted_by: str
+    reason: str = "user_delete"
+
+
+class DBRAGReplicatedItem(IOModel):
+    """RAG item with replication provenance and conflict metadata."""
+
+    namespace: str
+    key: str
+    value: Any | None = None
+    source_peer_id: str
+    owner_peer_id: str
+    origin_principal_id: str = "unknown"
+    created_at: str
+    updated_at: str
+    schema_version: int = 1
+    version: int = 1
+    policy_decision_id: str
+    correlation_id: str
+    sync_operation_id: str
+    visibility: str = "private"
+    encrypted: bool = False
+    redacted: bool = False
+    tombstone: DBRAGTombstone | None = None
+
+
+class DBRAGExportNamespaceRequest(IOModel):
+    """Request to export an opt-in RAG namespace snapshot."""
+
+    namespace: str
+    source_peer_id: str
+    owner_peer_id: str
+    origin_principal_id: str = "unknown"
+    policy_decision_id: str
+    correlation_id: str
+    sync_operation_id: str
+    limit: int = 100
+    offset: int = 0
+    include_tombstones: bool = True
+
+
+class DBRAGSnapshotResponse(IOModel):
+    """Namespace-scoped RAG replication snapshot."""
+
+    namespace: str
+    owner_peer_id: str
+    source_peer_id: str
+    schema_version: int = 1
+    items: list[DBRAGReplicatedItem]
+
+
+class DBRAGImportNamespaceRequest(IOModel):
+    """Request to import a bounded RAG namespace snapshot."""
+
+    namespace: str
+    importing_peer_id: str
+    policy_decision_id: str
+    correlation_id: str
+    sync_operation_id: str
+    items: list[DBRAGReplicatedItem]
+    conflict_mode: str = "last_writer_wins"
+
+
+class DBRAGImportNamespaceResponse(IOModel):
+    """Result of importing RAG replication items."""
+
+    imported: int = 0
+    updated: int = 0
+    skipped: int = 0
+    tombstoned: int = 0
+    conflicts: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class DBRAGListChangesRequest(IOModel):
+    """Request to list namespace-scoped RAG replication changes."""
+
+    namespace: str
+    source_peer_id: str
+    owner_peer_id: str
+    origin_principal_id: str = "unknown"
+    policy_decision_id: str
+    correlation_id: str
+    sync_operation_id: str
+    since: str | None = None
+    limit: int = 100
+    offset: int = 0
+    include_tombstones: bool = True
 
 
 # ── Shared response types ────────────────────────────────────────────────

--- a/docs/DATA_SHARING_POLICY.md
+++ b/docs/DATA_SHARING_POLICY.md
@@ -87,14 +87,50 @@ implementation:
 - Auth principal/token/device management and mesh peer management are controlled
   through Auth contracts. The underlying DB rows are not DB/data-sharing domains.
 
+## RAG/Memory Replication Model
+
+Aurora supports a narrow RAG/memory sync model for explicitly approved
+namespaces. The initial contract surface is internal-only:
+
+- `DB.RAGExportNamespace` creates a bounded snapshot for one namespace.
+- `DB.RAGImportNamespace` imports a bounded snapshot into the same namespace.
+- `DB.RAGListChanges` lists namespace changes after an optional timestamp for
+  one-way sync.
+
+These methods are not raw mesh RPC permissions. A gateway, orchestrator, or
+future sync worker must first make a policy decision and pass the resulting
+`policy_decision_id`, `correlation_id`, peer IDs, and sync operation ID into the
+DB contract. The namespace remains the unit of opt-in sharing.
+
+Every replicated RAG item carries:
+
+- namespace and stable key
+- `source_peer_id` and `owner_peer_id`
+- redacted or known `origin_principal_id`
+- `created_at`, `updated_at`, schema version, and item version
+- policy decision ID, correlation ID, and sync operation ID
+- visibility plus encrypted/redacted flags
+- optional tombstone metadata with `deleted_at`, `deleted_by`, and reason
+
+Conflict handling is deterministic and intentionally conservative:
+
+- Default: `last_writer_wins`, comparing item `updated_at` timestamps.
+- `remote_wins` may be used for one-way authoritative published namespaces.
+- `reject_on_conflict` inserts missing local records only and reports conflicts.
+
+Deletes are represented as tombstones rather than raw table deletes. Normal RAG
+search/list responses filter tombstones from live results; change-list/export
+surfaces can include tombstones so peers can evaluate forget propagation. Values
+containing obvious credential or secret fields are skipped during export/import.
+
 ## Follow-up Gates
 
 Before implementing P4 data sync or replication work, create explicit follow-up
 contracts/specs for:
 
-1. RAG namespace export/import with provenance and namespace ownership.
-2. RAG one-way published namespace replication with tombstones.
-3. Chat history export/import with user-scoped redaction and delete handling.
-4. Scheduler migration/import that creates new local jobs unless ownership
+1. Mesh sync orchestration for RAG namespace export/import and one-way
+   published namespace replication.
+2. Chat history export/import with user-scoped redaction and delete handling.
+3. Scheduler migration/import that creates new local jobs unless ownership
    transfer is explicitly approved.
-5. Redacted cross-peer audit query/export for diagnostics.
+4. Redacted cross-peer audit query/export for diagnostics.

--- a/docs/SERVICE_METHODS_REFERENCE.md
+++ b/docs/SERVICE_METHODS_REFERENCE.md
@@ -384,6 +384,9 @@ Database operations for messages and RAG storage.
 | `DB.RAGSearch` | Search RAG store | `DBRAGSearchRequest` | `DBRAGListResponse` | **both** |
 | `DB.RAGGet` | Get RAG item | `DBRAGGetRequest` | `DBRAGItemResponse` | **internal** |
 | `DB.RAGList` | List RAG items | `DBRAGListRequest` | `DBRAGListResponse` | **internal** |
+| `DB.RAGExportNamespace` | Export opt-in RAG namespace snapshot | `DBRAGExportNamespaceRequest` | `DBRAGSnapshotResponse` | **internal** |
+| `DB.RAGImportNamespace` | Import opt-in RAG namespace snapshot | `DBRAGImportNamespaceRequest` | `DBRAGImportNamespaceResponse` | **internal** |
+| `DB.RAGListChanges` | List opt-in RAG namespace changes | `DBRAGListChangesRequest` | `DBRAGSnapshotResponse` | **internal** |
 
 ### Why Some Are Internal
 
@@ -396,6 +399,12 @@ Mesh DB/data sharing is governed by [DATA_SHARING_POLICY.md](./DATA_SHARING_POLI
 Current `both` DB methods are query surfaces, not replication contracts. Raw SQL
 through `DB.ExecuteSQL` is internal-only and must not be exposed through mesh RPC,
 export/import, or sync features.
+
+RAG replication primitives are namespace-scoped and internal-only. They require
+caller-provided provenance (`source_peer_id`, `owner_peer_id`,
+`origin_principal_id`), policy decision ID, correlation ID, sync operation ID,
+and tombstone metadata for delete propagation. The default conflict model is
+last-writer-wins by `updated_at`; stricter imports can use reject-on-conflict.
 
 Scheduler `both` methods are similarly ownership-sensitive: remote scheduling,
 canceling, and listing must use explicit peer/resource selection and policy. DB

--- a/tests/unit/db/test_rag_service.py
+++ b/tests/unit/db/test_rag_service.py
@@ -1,19 +1,24 @@
 """Unit tests for RAGService."""
 
 import tempfile
+import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
 from app.services.db.rag_service import (
+    RAG_SYNC_METADATA_KEY,
     CombinedSQLiteVecStore,
     RAGService,
     SQLiteVecStore,
     async_get_embeddings,
     check_and_update_embedding_model,
     get_embedding_model_signature,
+    make_rag_tombstone,
+    normalize_rag_namespace,
 )
+from app.shared.contracts.models.db import DBRAGReplicatedItem
 
 
 @pytest.fixture
@@ -54,30 +59,40 @@ class TestRAGServiceCore:
         signature = get_embedding_model_signature(model_info)
         assert signature == "openai:text-embedding-3-small:openai"
 
+    def test_normalize_namespace_supports_legacy_pipe_separator(self):
+        """Test RAG namespace normalization for existing callers."""
+        assert normalize_rag_namespace("main|memories") == ("main", "memories")
+        assert normalize_rag_namespace("main.memories") == ("main", "memories")
+
     @patch("app.services.db.rag_service.config_api")
     @pytest.mark.asyncio
     async def test_get_embeddings_local(self, mock_config):
         """Test getting local embeddings."""
-        mock_config.aget = AsyncMock(return_value={"embeddings": {"use_local": True}})
+        mock_config.aget = AsyncMock(
+            return_value=types.SimpleNamespace(embeddings=types.SimpleNamespace(use_local=True))
+        )
+        mock_emb = MagicMock()
+        mock_hf_module = types.SimpleNamespace(HuggingFaceEmbeddings=Mock(return_value=mock_emb))
 
         with (
             patch("app.services.db.rag_service._async_wait_for_config_service", return_value=True),
-            patch("langchain_huggingface.HuggingFaceEmbeddings") as mock_hf,
+            patch.dict("sys.modules", {"langchain_huggingface": mock_hf_module}),
         ):
-            mock_emb = MagicMock()
-            mock_hf.return_value = mock_emb
-
             embeddings, model_info = await async_get_embeddings()
 
             assert model_info["type"] == "huggingface"
             assert model_info["model_name"] == "all-MiniLM-L6-v2"
-            mock_hf.assert_called_once_with(model_name="all-MiniLM-L6-v2")
+            mock_hf_module.HuggingFaceEmbeddings.assert_called_once_with(
+                model_name="all-MiniLM-L6-v2"
+            )
 
     @patch("app.services.db.rag_service.config_api")
     @pytest.mark.asyncio
     async def test_get_embeddings_openai(self, mock_config):
         """Test getting OpenAI embeddings."""
-        mock_config.aget = AsyncMock(return_value={"embeddings": {"use_local": False}})
+        mock_config.aget = AsyncMock(
+            return_value=types.SimpleNamespace(embeddings=types.SimpleNamespace(use_local=False))
+        )
 
         with (
             patch("app.services.db.rag_service._async_wait_for_config_service", return_value=True),
@@ -328,3 +343,190 @@ class TestEmbeddingModelManagement:
             result = check_and_update_embedding_model(mock_store, model_info, embeddings=mock_emb)
 
             assert result is True  # Re-embedding was performed
+
+
+class TestRAGReplication:
+    """Test namespace-scoped RAG replication semantics."""
+
+    def test_last_writer_wins_conflict_resolution(self):
+        """Newer replicated items win; older items are skipped."""
+        local = DBRAGReplicatedItem(
+            namespace="main.memories",
+            key="k1",
+            value={"text": "local"},
+            source_peer_id="peer-a",
+            owner_peer_id="peer-a",
+            created_at="2026-06-17T10:00:00Z",
+            updated_at="2026-06-17T10:10:00Z",
+            policy_decision_id="policy-1",
+            correlation_id="corr-1",
+            sync_operation_id="sync-1",
+        )
+        incoming = DBRAGReplicatedItem(
+            namespace="main.memories",
+            key="k1",
+            value={"text": "remote"},
+            source_peer_id="peer-b",
+            owner_peer_id="peer-a",
+            created_at="2026-06-17T10:00:00Z",
+            updated_at="2026-06-17T10:11:00Z",
+            policy_decision_id="policy-2",
+            correlation_id="corr-2",
+            sync_operation_id="sync-2",
+        )
+
+        winner = RAGService.resolve_replication_conflict(
+            local=local, incoming=incoming, conflict_mode="last_writer_wins"
+        )
+
+        assert winner is incoming
+
+    def test_reject_on_conflict_preserves_local_item(self):
+        """Strict conflict mode inserts only missing records."""
+        local = DBRAGReplicatedItem(
+            namespace="main.memories",
+            key="k1",
+            value={"text": "local"},
+            source_peer_id="peer-a",
+            owner_peer_id="peer-a",
+            created_at="2026-06-17T10:00:00Z",
+            updated_at="2026-06-17T10:10:00Z",
+            policy_decision_id="policy-1",
+            correlation_id="corr-1",
+            sync_operation_id="sync-1",
+        )
+        incoming = local.model_copy(update={"source_peer_id": "peer-b"})
+
+        winner = RAGService.resolve_replication_conflict(
+            local=local, incoming=incoming, conflict_mode="reject_on_conflict"
+        )
+
+        assert winner is None
+
+    def test_make_rag_tombstone_represents_delete_semantics(self):
+        """Tombstones carry delete provenance instead of raw table deletes."""
+        tombstone = make_rag_tombstone(
+            namespace="main.memories",
+            key="forgotten",
+            source_peer_id="peer-a",
+            owner_peer_id="peer-a",
+            origin_principal_id="user-1",
+            policy_decision_id="policy-1",
+            correlation_id="corr-1",
+            sync_operation_id="sync-1",
+            deleted_by="user-1",
+            reason="forget_request",
+        )
+
+        assert tombstone.tombstone is not None
+        assert tombstone.value is None
+        assert tombstone.tombstone.reason == "forget_request"
+
+    def test_import_namespace_stores_tombstone_with_metadata(self):
+        """Importing a tombstone preserves provenance in stored value metadata."""
+        service = RAGService()
+        service._initialized = True
+        mock_store = MagicMock()
+        mock_store.get.return_value = None
+        service._combined_store = mock_store
+        tombstone = make_rag_tombstone(
+            namespace="main.memories",
+            key="forgotten",
+            source_peer_id="peer-a",
+            owner_peer_id="peer-a",
+            origin_principal_id="user-1",
+            policy_decision_id="policy-1",
+            correlation_id="corr-1",
+            sync_operation_id="sync-1",
+            deleted_by="user-1",
+        )
+
+        response = service.import_namespace(namespace="main.memories", items=[tombstone])
+
+        assert response.tombstoned == 1
+        stored_value = mock_store.put.call_args.args[2]
+        assert stored_value[RAG_SYNC_METADATA_KEY]["tombstone"]["deleted_by"] == "user-1"
+
+    def test_export_namespace_skips_sensitive_values(self):
+        """Export refuses obvious credential-bearing memory values."""
+        from datetime import datetime
+
+        from langgraph.store.base import Item
+
+        service = RAGService()
+        service._initialized = True
+        mock_store = MagicMock()
+        mock_store.retrieve_items.return_value = [
+            Item(
+                value={"text": "ok"},
+                key="safe",
+                namespace=("main", "memories"),
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            ),
+            Item(
+                value={"text": "bad", "token": "secret"},
+                key="unsafe",
+                namespace=("main", "memories"),
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            ),
+        ]
+        service._combined_store = mock_store
+
+        snapshot = service.export_namespace(
+            namespace="main.memories",
+            source_peer_id="peer-a",
+            owner_peer_id="peer-a",
+            origin_principal_id="user-1",
+            policy_decision_id="policy-1",
+            correlation_id="corr-1",
+            sync_operation_id="sync-1",
+        )
+
+        assert [item.key for item in snapshot] == ["safe"]
+        assert snapshot[0].source_peer_id == "peer-a"
+
+    def test_mocked_two_peer_export_import_flow(self):
+        """A peer can export a namespace snapshot that another peer imports."""
+        from datetime import datetime
+
+        from langgraph.store.base import Item
+
+        source = RAGService()
+        source._initialized = True
+        source_store = MagicMock()
+        source_store.retrieve_items.return_value = [
+            Item(
+                value={"text": "portable memory"},
+                key="memory-1",
+                namespace=("main", "memories"),
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            )
+        ]
+        source._combined_store = source_store
+
+        snapshot = source.export_namespace(
+            namespace="main.memories",
+            source_peer_id="peer-a",
+            owner_peer_id="peer-a",
+            origin_principal_id="user-1",
+            policy_decision_id="policy-1",
+            correlation_id="corr-1",
+            sync_operation_id="sync-1",
+        )
+
+        target = RAGService()
+        target._initialized = True
+        target_store = MagicMock()
+        target_store.get.return_value = None
+        target._combined_store = target_store
+
+        response = target.import_namespace(namespace="main.memories", items=snapshot)
+
+        assert response.imported == 1
+        target_store.put.assert_called_once()
+        stored_value = target_store.put.call_args.args[2]
+        assert stored_value["text"] == "portable memory"
+        assert stored_value[RAG_SYNC_METADATA_KEY]["source_peer_id"] == "peer-a"

--- a/tests/unit/db/test_service.py
+++ b/tests/unit/db/test_service.py
@@ -296,3 +296,80 @@ class TestDBServiceRAGOperations:
         # Verify response
         assert isinstance(response, DBRAGListResponse)
         assert len(response.items) == 1
+
+    @pytest.mark.asyncio
+    async def test_rag_export_namespace(self, db_service):
+        """Test RAG namespace export contract method."""
+        from app.shared.contracts.models.db import (
+            DBRAGExportNamespaceRequest,
+            DBRAGReplicatedItem,
+            DBRAGSnapshotResponse,
+        )
+
+        replicated_item = DBRAGReplicatedItem(
+            namespace="main.memories",
+            key="memory-1",
+            value={"text": "Test memory"},
+            source_peer_id="peer-a",
+            owner_peer_id="peer-a",
+            created_at="2026-06-17T10:00:00Z",
+            updated_at="2026-06-17T10:00:00Z",
+            policy_decision_id="policy-1",
+            correlation_id="corr-1",
+            sync_operation_id="sync-1",
+        )
+        db_service.rag_service.export_namespace = Mock(return_value=[replicated_item])
+
+        response = await db_service.rag_export_namespace(
+            DBRAGExportNamespaceRequest(
+                namespace="main.memories",
+                source_peer_id="peer-a",
+                owner_peer_id="peer-a",
+                policy_decision_id="policy-1",
+                correlation_id="corr-1",
+                sync_operation_id="sync-1",
+            )
+        )
+
+        assert isinstance(response, DBRAGSnapshotResponse)
+        assert response.items[0].key == "memory-1"
+        db_service.rag_service.export_namespace.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rag_import_namespace(self, db_service):
+        """Test RAG namespace import contract method."""
+        from app.shared.contracts.models.db import (
+            DBRAGImportNamespaceRequest,
+            DBRAGImportNamespaceResponse,
+            DBRAGReplicatedItem,
+        )
+
+        replicated_item = DBRAGReplicatedItem(
+            namespace="main.memories",
+            key="memory-1",
+            value={"text": "Remote memory"},
+            source_peer_id="peer-b",
+            owner_peer_id="peer-b",
+            created_at="2026-06-17T10:00:00Z",
+            updated_at="2026-06-17T10:00:00Z",
+            policy_decision_id="policy-1",
+            correlation_id="corr-1",
+            sync_operation_id="sync-1",
+        )
+        db_service.rag_service.import_namespace = Mock(
+            return_value=DBRAGImportNamespaceResponse(imported=1)
+        )
+
+        response = await db_service.rag_import_namespace(
+            DBRAGImportNamespaceRequest(
+                namespace="main.memories",
+                importing_peer_id="peer-a",
+                policy_decision_id="policy-1",
+                correlation_id="corr-1",
+                sync_operation_id="sync-1",
+                items=[replicated_item],
+            )
+        )
+
+        assert response.imported == 1
+        db_service.rag_service.import_namespace.assert_called_once()


### PR DESCRIPTION
## Summary

Implements PER-141 selective RAG/memory replication primitives on top of the PER-140 data-sharing policy branch.

- Adds internal DB contracts for namespace-scoped RAG export/import/change listing.
- Adds replicated item metadata for provenance, policy decision IDs, correlation IDs, sync operation IDs, visibility flags, versioning, and tombstones.
- Adds RAG helper logic for namespace normalization, sensitive-field rejection, deterministic conflict handling, tombstone storage, and filtering tombstones from normal live search/list results.
- Documents the RAG replication model and updates DB method reference docs.
- Adds unit coverage for conflict/tombstone behavior plus a mocked two-peer export/import flow.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy ~/.local/bin/uv run --extra dev ruff check app/shared/contracts/models/db.py app/services/db/rag_service.py app/services/db/service.py tests/unit/db/test_rag_service.py tests/unit/db/test_service.py`
- `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy ~/.local/bin/uv run --extra dev --extra service-db --extra test-all pytest tests/unit/db/test_rag_service.py tests/unit/db/test_service.py -q` -> `34 passed, 3 warnings`
- `git diff --check`

## Notes

- Base branch is `multica/mesh-p4-data-sharing-policy` to keep this PR focused on PER-141 and avoid re-reviewing PER-140.
- Referenced roadmap artifacts `.omx/specs/deep-interview-mesh-distributed-integration.md` and `.omx/multica/mesh-roadmap-tasks/*` are absent from this checkout, so implementation followed the issue body and `docs/DATA_SHARING_POLICY.md`.
- New replication methods are intentionally internal-only; mesh orchestration/policy invocation remains a follow-up layer.
