### PR TITLE
Define Auth and Config mesh boundaries

### DIFF
--- a/.omx/plans/PER-144-auth-config-mesh-boundaries.md
+++ b/.omx/plans/PER-144-auth-config-mesh-boundaries.md
@@ -1,0 +1,51 @@
+# PER-144 Plan: Auth and Config Mesh Exposure Boundaries
+
+## Requirements Summary
+
+- Source issue: PER-144 `[MESH][P5-T03] Define Auth and Config mesh exposure boundaries`.
+- Scope: make Auth/Config mesh exposure policy explicit, keep pairing/login infrastructure working, and avoid config defaults that imply unsupported broad Auth/Config sharing.
+- Privacy constraint: Auth credentials, token state, peer trust, and local configuration remain local-authoritative by default.
+- Message-bus constraint: preserve RPC-to-bus behavior; do not call service implementations directly.
+- Referenced `.omx/specs/deep-interview-mesh-distributed-integration.md` and `.omx/multica/mesh-roadmap-tasks/*` are absent from this checkout after fetching the latest migration branch. Adjacent PER-132 and PER-140 plans document the same missing-doc fallback.
+
+## Exposure Categories
+
+- Infra-required: `Auth.PairingStart`, `Auth.PairingConnect`, `Auth.PairingExchange`, and `Auth.Login` stay available to unauthenticated WebRTC peers through the existing RPC infrastructure bypass.
+- Local peer administration: Auth mesh peer list/get/approve/deny/update/remove contracts are local admin surfaces. They may be exposed through local Gateway routes with normal permissions, but are not automatically shared as a mesh provider.
+- Broad Auth admin: principal, token, permission, device, audit, and password management are never transparently routed by default.
+- Config diagnostics/mutation: Config get/validate/plugin reads and Config set/plugin writes are not transparently routed by default; config mutation stays local unless a future explicit remote-admin policy is designed.
+- Never-share: raw credential material, token hashes, inbound mesh tokens, API keys, and config secrets.
+
+## Implementation Steps
+
+1. Remove `services.auth.mesh_sharing` and `services.config.mesh_sharing` from the config schema so generated defaults and keys stop advertising unsupported broad mesh sharing knobs.
+2. Regenerate config artifacts from schema.
+3. Keep Gateway mesh config service wiring limited to currently supported shared service modules.
+4. Add focused RPC tests that broad Auth/Config calls are denied when not explicitly shared, while pairing/login infrastructure still bypasses ordinary service sharing gates.
+5. Add an explicit test that manually shared Auth still requires normal method permissions, proving sharing is not enough to bypass RBAC.
+6. Update pairing/config docs to name the Auth/Config exposure categories and explain infrastructure bypass behavior.
+
+## Acceptance Criteria
+
+- Auth/Config sharing policy is explicit in docs.
+- Config schema, generated defaults, generated keys, and generated models no longer imply Auth/Config are supported mesh-shareable services.
+- Pairing/login infrastructure remains functional through WebRTC RPC.
+- Broad Auth/Config calls are denied by the mesh sharing gate unless an explicit in-memory service sharing policy is present.
+- Explicit sharing does not bypass Auth/Config method permissions.
+
+## Verification Strategy
+
+- `make generate-config`
+- `make check-config-generated`
+- `uv run pytest tests/unit/gateway/test_rpc.py tests/unit/app/config/test_mesh_sharing_schema.py -q`
+- `git diff --check`
+
+## Risks and Mitigations
+
+- Risk: removing Auth/Config mesh keys could surprise operators who saw generated defaults. Mitigation: docs state these were not wired into Gateway mesh service sharing and broad remote admin remains unsupported.
+- Risk: confusing pairing/login bypass with broad Auth sharing. Mitigation: docs and tests separate infra-required methods from Auth admin methods.
+- Risk: future remote admin work needs config surfaces. Mitigation: leave room for a future explicit policy instead of silently exposing current broad contracts.
+
+## Stop Condition
+
+PER-144 is ready for QA when generated config artifacts are in sync, RPC and config tests pass, docs describe the policy, a commit is pushed, and a PR is opened.

--- a/.omx/ultragoal/PER-144-checkpoints.md
+++ b/.omx/ultragoal/PER-144-checkpoints.md
@@ -1,0 +1,18 @@
+# PER-144 Ultragoal Checkpoints
+
+## Context
+
+- Issue: PER-144 `[MESH][P5-T03] Define Auth and Config mesh exposure boundaries`.
+- Branch: `multica/PER-144-auth-config-mesh-boundaries`.
+- Plan: `.omx/plans/PER-144-auth-config-mesh-boundaries.md`.
+- Referenced deep mesh spec and per-task bundle are absent in this checkout after fetching; implementation proceeds from the Multica issue, subsystem AGENTS files, and adjacent PER-132/PER-140 plans.
+
+## Checkpoints
+
+- Planning complete: policy categories, schema/default implication fix, RPC tests, docs, and verification strategy captured.
+- Implementation complete: removed Auth/Config mesh sharing from schema/defaults/generated keys/models, added RPC/config tests, and documented exposure categories.
+- Verification passed:
+  - `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy /home/developer/.local/bin/uv run --extra dev --extra service-db --extra test-all pytest tests/unit/gateway/test_rpc.py tests/unit/app/config/test_mesh_sharing_schema.py -q` -> 23 passed, 4 warnings.
+  - `PATH=/home/developer/.local/bin:$PATH UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy make check-config-generated` -> passed.
+  - `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy /home/developer/.local/bin/uv run --extra dev ruff check app/shared/config/keys.py app/shared/config/models.py tests/unit/app/config/test_mesh_sharing_schema.py tests/unit/gateway/test_rpc.py` -> passed.
+  - `git diff --check` -> passed.

--- a/app/services/config/config_defaults.json
+++ b/app/services/config/config_defaults.json
@@ -55,15 +55,6 @@
     },
     "auth": {
       "enabled": false,
-      "mesh_sharing": {
-        "share": false,
-        "max_concurrent": 10,
-        "allowed_peers": null,
-        "prefer": "local",
-        "fallback": "local",
-        "min_version": null,
-        "required_capabilities": []
-      },
       "api_keys": [],
       "token_expiry_days": 365,
       "session_token_expiry_hours": 24,
@@ -312,16 +303,7 @@
       }
     },
     "config": {
-      "enabled": true,
-      "mesh_sharing": {
-        "share": false,
-        "max_concurrent": 10,
-        "allowed_peers": null,
-        "prefer": "local",
-        "fallback": "local",
-        "min_version": null,
-        "required_capabilities": []
-      }
+      "enabled": true
     }
   }
 }

--- a/app/services/config/config_schema.json
+++ b/app/services/config/config_schema.json
@@ -243,7 +243,6 @@
               "description": "Enable authentication service",
               "default": false
             },
-            "mesh_sharing": { "$ref": "#/$defs/mesh_sharing" },
             "api_keys": {
               "type": "array",
               "description": "List of valid API keys (sensitive; prefer AURORA_GATEWAY_API_KEYS in .env)",
@@ -1187,8 +1186,7 @@
               "type": "boolean",
               "description": "Enable config service",
               "default": true
-            },
-            "mesh_sharing": { "$ref": "#/$defs/mesh_sharing" }
+            }
           }
         }
       }

--- a/app/shared/config/keys.py
+++ b/app/shared/config/keys.py
@@ -433,50 +433,6 @@ class _ServicesToolingPluginsSlackConfigPath(ConfigPath):
         return self
 
 
-class _ServicesAuthMeshSharingConfigPath(ConfigPath):
-    allowed_peers: ConfigPath
-    fallback: ConfigPath
-    max_concurrent: ConfigPath
-    min_version: ConfigPath
-    prefer: ConfigPath
-    required_capabilities: ConfigPath
-    share: ConfigPath
-
-    def __new__(cls) -> _ServicesAuthMeshSharingConfigPath:
-        self = super().__new__(cls, "services.auth.mesh_sharing")
-        self.allowed_peers = ConfigPath("services.auth.mesh_sharing.allowed_peers")
-        self.fallback = ConfigPath("services.auth.mesh_sharing.fallback")
-        self.max_concurrent = ConfigPath("services.auth.mesh_sharing.max_concurrent")
-        self.min_version = ConfigPath("services.auth.mesh_sharing.min_version")
-        self.prefer = ConfigPath("services.auth.mesh_sharing.prefer")
-        self.required_capabilities = ConfigPath("services.auth.mesh_sharing.required_capabilities")
-        self.share = ConfigPath("services.auth.mesh_sharing.share")
-        return self
-
-
-class _ServicesConfigMeshSharingConfigPath(ConfigPath):
-    allowed_peers: ConfigPath
-    fallback: ConfigPath
-    max_concurrent: ConfigPath
-    min_version: ConfigPath
-    prefer: ConfigPath
-    required_capabilities: ConfigPath
-    share: ConfigPath
-
-    def __new__(cls) -> _ServicesConfigMeshSharingConfigPath:
-        self = super().__new__(cls, "services.config.mesh_sharing")
-        self.allowed_peers = ConfigPath("services.config.mesh_sharing.allowed_peers")
-        self.fallback = ConfigPath("services.config.mesh_sharing.fallback")
-        self.max_concurrent = ConfigPath("services.config.mesh_sharing.max_concurrent")
-        self.min_version = ConfigPath("services.config.mesh_sharing.min_version")
-        self.prefer = ConfigPath("services.config.mesh_sharing.prefer")
-        self.required_capabilities = ConfigPath(
-            "services.config.mesh_sharing.required_capabilities"
-        )
-        self.share = ConfigPath("services.config.mesh_sharing.share")
-        return self
-
-
 class _ServicesDbEmbeddingsConfigPath(ConfigPath):
     use_local: ConfigPath
 
@@ -802,7 +758,6 @@ class _ServicesAuthConfigPath(ConfigPath):
     audit_retention_days: ConfigPath
     default_pairing_permissions: ConfigPath
     enabled: ConfigPath
-    mesh_sharing: _ServicesAuthMeshSharingConfigPath
     pairing_code_expiry_minutes: ConfigPath
     pairing_max_attempts_per_ip: ConfigPath
     session_token_expiry_hours: ConfigPath
@@ -817,7 +772,6 @@ class _ServicesAuthConfigPath(ConfigPath):
         self.audit_retention_days = ConfigPath("services.auth.audit_retention_days")
         self.default_pairing_permissions = ConfigPath("services.auth.default_pairing_permissions")
         self.enabled = ConfigPath("services.auth.enabled")
-        self.mesh_sharing = _ServicesAuthMeshSharingConfigPath()
         self.pairing_code_expiry_minutes = ConfigPath("services.auth.pairing_code_expiry_minutes")
         self.pairing_max_attempts_per_ip = ConfigPath("services.auth.pairing_max_attempts_per_ip")
         self.session_token_expiry_hours = ConfigPath("services.auth.session_token_expiry_hours")
@@ -831,12 +785,10 @@ class _ServicesAuthConfigPath(ConfigPath):
 
 class _ServicesConfigConfigPath(ConfigPath):
     enabled: ConfigPath
-    mesh_sharing: _ServicesConfigMeshSharingConfigPath
 
     def __new__(cls) -> _ServicesConfigConfigPath:
         self = super().__new__(cls, "services.config")
         self.enabled = ConfigPath("services.config.enabled")
-        self.mesh_sharing = _ServicesConfigMeshSharingConfigPath()
         return self
 
 

--- a/app/shared/config/models.py
+++ b/app/shared/config/models.py
@@ -177,6 +177,53 @@ class Gateway(BaseConfigModel):
     """
 
 
+class Auth(BaseConfigModel):
+    enabled: bool | None = False
+    """
+    Enable authentication service
+    """
+    api_keys: list[SecretStr] | None = []
+    """
+    List of valid API keys (sensitive; prefer AURORA_GATEWAY_API_KEYS in .env)
+    """
+    token_expiry_days: int | None = Field(365, ge=1)
+    """
+    Default token expiry in days
+    """
+    session_token_expiry_hours: int | None = Field(24, ge=1)
+    """
+    Session token expiry in hours (for login)
+    """
+    pairing_code_expiry_minutes: int | None = Field(5, ge=1)
+    """
+    Pairing code expiry in minutes
+    """
+    pairing_max_attempts_per_ip: int | None = Field(5, ge=1)
+    """
+    Max pairing attempts per IP before rate limiting
+    """
+    default_pairing_permissions: list[str] | None = []
+    """
+    Default permissions assigned to new devices during pairing
+    """
+    webrtc_auth_timeout_seconds: float | None = Field(10.0, ge=1.0)
+    """
+    Timeout in seconds for WebRTC peer authentication
+    """
+    webrtc_pairing_timeout_seconds: float | None = Field(300.0, ge=10.0)
+    """
+    Timeout in seconds for peers in the pairing flow (awaiting human approval)
+    """
+    audit_enabled: bool | None = True
+    """
+    Enable audit logging of security events
+    """
+    audit_retention_days: int | None = Field(90, ge=1)
+    """
+    Audit log retention period in days
+    """
+
+
 class AmbientTranscription(BaseConfigModel):
     enable: bool | None = False
     """
@@ -595,6 +642,13 @@ class Plugins(BaseConfigModel):
     gcalendar: Gcalendar | None = None
 
 
+class Config(BaseConfigModel):
+    enabled: bool | None = True
+    """
+    Enable config service
+    """
+
+
 class MeshSharing(BaseConfigModel):
     share: bool | None = False
     """
@@ -623,54 +677,6 @@ class MeshSharing(BaseConfigModel):
     required_capabilities: list[str] | None = []
     """
     Remote service capabilities required before this service may be selected as a mesh provider.
-    """
-
-
-class Auth(BaseConfigModel):
-    enabled: bool | None = False
-    """
-    Enable authentication service
-    """
-    mesh_sharing: MeshSharing | None = None
-    api_keys: list[SecretStr] | None = []
-    """
-    List of valid API keys (sensitive; prefer AURORA_GATEWAY_API_KEYS in .env)
-    """
-    token_expiry_days: int | None = Field(365, ge=1)
-    """
-    Default token expiry in days
-    """
-    session_token_expiry_hours: int | None = Field(24, ge=1)
-    """
-    Session token expiry in hours (for login)
-    """
-    pairing_code_expiry_minutes: int | None = Field(5, ge=1)
-    """
-    Pairing code expiry in minutes
-    """
-    pairing_max_attempts_per_ip: int | None = Field(5, ge=1)
-    """
-    Max pairing attempts per IP before rate limiting
-    """
-    default_pairing_permissions: list[str] | None = []
-    """
-    Default permissions assigned to new devices during pairing
-    """
-    webrtc_auth_timeout_seconds: float | None = Field(10.0, ge=1.0)
-    """
-    Timeout in seconds for WebRTC peer authentication
-    """
-    webrtc_pairing_timeout_seconds: float | None = Field(300.0, ge=10.0)
-    """
-    Timeout in seconds for peers in the pairing flow (awaiting human approval)
-    """
-    audit_enabled: bool | None = True
-    """
-    Enable audit logging of security events
-    """
-    audit_retention_days: int | None = Field(90, ge=1)
-    """
-    Audit log retention period in days
     """
 
 
@@ -861,14 +867,6 @@ class Scheduler(BaseConfigModel):
     enabled: bool | None = True
     """
     Enable scheduler service
-    """
-    mesh_sharing: MeshSharing | None = None
-
-
-class Config(BaseConfigModel):
-    enabled: bool | None = True
-    """
-    Enable config service
     """
     mesh_sharing: MeshSharing | None = None
 

--- a/docs/CONFIG_SERVICE_PATTERN.md
+++ b/docs/CONFIG_SERVICE_PATTERN.md
@@ -116,6 +116,11 @@ Per-service `mesh_sharing` combines sharing and routing policy. Defaults are pri
 capabilities are required. `allowed_peers=null` means any authenticated peer may use the
 service only after that service is explicitly shared.
 
+Auth and Config do not expose operator-facing `mesh_sharing` blocks. Pairing/login
+infrastructure is handled by the WebRTC RPC auth gate, and local Auth peer management
+or Config mutation remains local-admin behavior. Do not model broad remote Auth admin
+or Config writes as ordinary transparent mesh service sharing.
+
 Home LAN / VPN: share a low-risk local service with authenticated peers, but keep local
 execution preferred and fall back locally if the peer is unavailable.
 

--- a/docs/PEER_PAIRING_FLOW.md
+++ b/docs/PEER_PAIRING_FLOW.md
@@ -174,6 +174,29 @@ can use stable peer IDs while DataChannel sends still target the live session.
 
 ---
 
+## Auth and Config Mesh Exposure Boundaries
+
+Auth and Config are not ordinary transparent mesh providers. Gateway does not wire
+`services.auth` or `services.config` into `gateway.mesh.services`, and the config
+schema intentionally does not expose `services.auth.mesh_sharing` or
+`services.config.mesh_sharing`.
+
+Exposure categories:
+
+| Category | Methods / data | Mesh behavior |
+|----------|----------------|---------------|
+| Pairing/login infrastructure | `Auth.PairingStart`, `Auth.PairingConnect`, `Auth.PairingExchange`, `Auth.Login` | Allowed through the WebRTC RPC infrastructure bypass so unauthenticated peers can pair or authenticate. |
+| Local peer administration | Auth mesh peer list/get/approve/deny/update/remove contracts | Local admin surface with normal permissions; not advertised as a shareable mesh provider by default. |
+| Broad Auth administration | Principals, tokens, permissions, devices, audit log, password changes | Not transparently routed by default. |
+| Config diagnostics and mutation | Config get/validate/plugin reads, Config set/plugin writes | Not transparently routed by default. |
+| Secrets and credentials | API keys, token hashes, inbound mesh tokens, raw credential material | Never shared as mesh data or ordinary RPC payloads. |
+
+If a future remote-admin policy intentionally exposes any Auth or Config surface,
+it must be explicit, peer-scoped, permission-checked, and audited. A generic
+service-sharing toggle is not enough to make Auth or Config safe to route.
+
+---
+
 ## Pairing Flow (Step-by-Step)
 
 The pairing process is a **4-phase handshake** between the new device, the Gateway, and an admin user.

--- a/tests/unit/app/config/test_mesh_sharing_schema.py
+++ b/tests/unit/app/config/test_mesh_sharing_schema.py
@@ -56,3 +56,17 @@ def test_generated_config_keys_include_mesh_policy_leaf_paths() -> None:
         mesh_keys.required_capabilities
         == "services.tts.mesh_sharing.required_capabilities"
     )
+
+
+@pytest.mark.unit
+def test_auth_and_config_do_not_advertise_mesh_sharing() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text())
+    services = schema["properties"]["services"]["properties"]
+    defaults = json.loads(DEFAULTS_PATH.read_text())["services"]
+
+    assert "mesh_sharing" not in services["auth"]["properties"]
+    assert "mesh_sharing" not in services["config"]["properties"]
+    assert "mesh_sharing" not in defaults["auth"]
+    assert "mesh_sharing" not in defaults["config"]
+    assert not hasattr(ConfigKeys.services.auth, "mesh_sharing")
+    assert not hasattr(ConfigKeys.services.config, "mesh_sharing")

--- a/tests/unit/gateway/test_rpc.py
+++ b/tests/unit/gateway/test_rpc.py
@@ -423,6 +423,131 @@ async def test_mesh_gate_capacity_exceeded(
 
 
 @pytest.mark.asyncio
+async def test_mesh_gate_blocks_broad_auth_admin_when_not_shared(
+    mock_bus,
+    mock_registry,
+    mock_send_fn,
+):
+    """Auth admin methods are not routed unless Auth is explicitly shared."""
+    admin_identity = Identity(
+        principal_id="admin",
+        principal_name="admin",
+        is_admin=True,
+        effective_perms=frozenset(["*"]),
+        source="webrtc_peer",
+    )
+    acl_provider = MagicMock(return_value=admin_identity)
+    mesh_config = _make_mesh_config(enabled=True, sharing={})
+    handler = RPCHandler(
+        mock_bus,
+        mock_registry,
+        mock_send_fn,
+        acl_provider,
+        mesh_config=mesh_config,
+    )
+
+    await handler.on_message(
+        json.dumps(
+            {
+                "type": "call",
+                "id": "auth-admin",
+                "method": "Auth.ListPrincipals",
+                "params": {},
+            }
+        )
+    )
+
+    resp = json.loads(mock_send_fn.call_args[0][0])
+    assert resp["type"] == "error"
+    assert resp["error"]["code"] == 403
+    assert "not shared" in resp["error"]["message"]
+    mock_bus.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mesh_gate_blocks_config_mutation_when_not_shared(
+    mock_bus,
+    mock_registry,
+    mock_send_fn,
+):
+    """Config mutation is not transparently routed by default."""
+    admin_identity = Identity(
+        principal_id="admin",
+        principal_name="admin",
+        is_admin=True,
+        effective_perms=frozenset(["*"]),
+        source="webrtc_peer",
+    )
+    acl_provider = MagicMock(return_value=admin_identity)
+    mesh_config = _make_mesh_config(enabled=True, sharing={})
+    handler = RPCHandler(
+        mock_bus,
+        mock_registry,
+        mock_send_fn,
+        acl_provider,
+        mesh_config=mesh_config,
+    )
+
+    await handler.on_message(
+        json.dumps(
+            {
+                "type": "call",
+                "id": "config-set",
+                "method": "Config.Set",
+                "params": {"key_path": "services.gateway.enabled", "value": True},
+            }
+        )
+    )
+
+    resp = json.loads(mock_send_fn.call_args[0][0])
+    assert resp["type"] == "error"
+    assert resp["error"]["code"] == 403
+    assert "not shared" in resp["error"]["message"]
+    mock_bus.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_explicit_auth_share_still_requires_method_permissions(
+    mock_bus,
+    mock_registry,
+    mock_send_fn,
+    mock_acl_provider,
+):
+    """An explicit Auth share does not bypass normal Auth method permissions."""
+    mesh_config = _make_mesh_config(
+        enabled=True,
+        sharing={"Auth": _make_sharing_entry(share=True)},
+    )
+    handler = RPCHandler(
+        mock_bus,
+        mock_registry,
+        mock_send_fn,
+        mock_acl_provider,
+        mesh_config=mesh_config,
+    )
+    method_info = MethodInfo(
+        name="ListPrincipals",
+        required_perms=["Auth.manage"],
+        method_type="manage",
+    )
+    mock_registry.get_service.return_value = ServiceAnnouncement(
+        module="Auth",
+        version="1.0",
+        methods=[method_info],
+    )
+
+    await handler.on_message(
+        json.dumps({"type": "call", "id": "auth-shared", "method": "Auth.ListPrincipals"})
+    )
+
+    resp = json.loads(mock_send_fn.call_args[0][0])
+    assert resp["type"] == "error"
+    assert resp["error"]["code"] == 403
+    assert resp["error"]["message"] == "Forbidden"
+    mock_bus.request.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_handle_call_datetime_in_response(rpc_handler, mock_registry, mock_bus):
     """RPC result containing a datetime must be serialized via ISO-8601."""
     from datetime import datetime, timedelta


### PR DESCRIPTION
## Summary

- Removes `services.auth.mesh_sharing` and `services.config.mesh_sharing` from the schema-generated config surface so defaults/models/keys no longer imply broad Auth or Config mesh sharing is supported.
- Documents Auth/Config mesh exposure categories: pairing/login infrastructure, local peer administration, broad Auth admin, Config diagnostics/mutation, and never-share secrets.
- Adds focused RPC/config tests proving broad Auth/Config calls are blocked by default and explicit Auth sharing still requires normal permissions.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy /home/developer/.local/bin/uv run --extra dev --extra service-db --extra test-all pytest tests/unit/gateway/test_rpc.py tests/unit/app/config/test_mesh_sharing_schema.py -q` -> 23 passed, 4 warnings.
- `PATH=/home/developer/.local/bin:$PATH UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy make check-config-generated` -> passed.
- `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy /home/developer/.local/bin/uv run --extra dev ruff check app/shared/config/keys.py app/shared/config/models.py tests/unit/app/config/test_mesh_sharing_schema.py tests/unit/gateway/test_rpc.py` -> passed.
- `git diff --check` -> passed.

## Notes

The referenced `.omx/specs/deep-interview-mesh-distributed-integration.md` and `.omx/multica/mesh-roadmap-tasks/*` files were absent in this checkout after fetching; adjacent PER-132/PER-140 plans already document the same missing-doc fallback.
