### PR TITLE
PER-142 add audio mesh capability boundaries

### DIFF
--- a/.omx/plans/PER-142-audio-capability-boundaries.md
+++ b/.omx/plans/PER-142-audio-capability-boundaries.md
@@ -1,0 +1,49 @@
+# PER-142 Audio Capability Boundaries Plan
+
+## Sources Read
+
+- Multica issue `PER-142` title, description, labels, metadata, and full comment history.
+- Runtime and repo guidance: root `AGENTS.md`, `app/services/AGENTS.md`, `app/messaging/AGENTS.md`, `app/services/gateway/AGENTS.md`, `app/services/auth/AGENTS.md`, `app/shared/AGENTS.md`, `app/shared/contracts/AGENTS.md`, `tests/AGENTS.md`.
+- Existing mesh policy context: `docs/PEER_PAIRING_FLOW.md` hybrid addressing section.
+- Existing code anchors: `app/services/gateway/config.py`, `app/services/gateway/mesh/routing_table.py`, `app/services/gateway/mesh/capability_graph.py`, `app/shared/contracts/models/{gateway,mesh,tts,stt}.py`, `app/messaging/audio_messages.py`, `app/services/tts/service.py`, `app/services/stt_transcription/service.py`, `app/services/stt_wakeword/service.py`.
+- Required runtime mesh spec/task files were absent in this checkout: `.omx/specs/deep-interview-mesh-distributed-integration.md` and `.omx/multica/mesh-roadmap-tasks/*PER-142*`.
+
+## Requirements Summary
+
+- Document audio sharing boundaries for TTS, transcription, wakeword, and raw audio streams.
+- Preserve transparent mesh routing for lower-risk remote synthesize and batch transcription.
+- Prevent implicit transparent routing for remote playback and raw microphone/audio streaming.
+- Represent audio policy in capability graph metadata so callers can distinguish batch, playback, streaming, and wakeword behaviors.
+- Cover allowed/denied routing and capability metadata in tests.
+
+## Implementation Steps
+
+1. Extend `CapabilityPolicyInfo` with compact audio policy metadata fields that are diagnostic only, preserving existing defaults for non-audio capabilities.
+2. Update `capability_graph.py` audio classification:
+   - `TTS.Synthesize` => low-risk batch output, no explicit selector by default.
+   - `TTS.Request`, `TTS.Stop`, `TTS.Pause`, `TTS.Resume` => remote playback/control, explicit selector and remote confirmation required.
+   - `Transcription.Transcribe` => lower-risk batch transcription, no explicit selector by default.
+   - `Transcription.ProcessAudio`, `WakeWord.ProcessAudio`, `WakeWord.Detect`, coordinator audio/listen/control, and `Audio*` modules/topics => streaming/privacy-sensitive, explicit selector and remote confirmation required.
+3. Update audio request models to carry optional `mesh_selector` where explicit peer/device intent is needed and keep lower-risk batch APIs selector-capable without forcing transparent-route denial.
+4. Add routing-table tests proving playback/streaming configs with `require_explicit_selector=True` deny implicit routing and allow explicit selected peer routing.
+5. Add capability-graph tests proving method-level policy differs between `TTS.Synthesize` and `TTS.Request`, and between `Transcription.Transcribe` and streaming/wakeword audio methods.
+6. Add a short docs section in `docs/PEER_PAIRING_FLOW.md` describing audio sharing boundaries and operator expectations.
+
+## Acceptance Criteria
+
+- `TTS.Synthesize` and `Transcription.Transcribe` remain shareable/routable without an explicit selector when operator mesh config permits transparent routing.
+- `TTS.Request`/playback controls and streaming audio/wakeword methods are marked `explicit_selector_required=True` and `confirmation_required=True` for remote providers in the capability graph.
+- Routing tests demonstrate `require_explicit_selector=True` rejects implicit remote playback/streaming and explicit selectors route only to the selected negotiated peer.
+- Documentation names safe batch operations, explicit target operations, and non-default raw microphone/audio streaming constraints.
+
+## Verification Strategy
+
+- Run targeted tests:
+  - `uv run pytest tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_capability_graph.py -q`
+- Run focused mesh baseline if time permits:
+  - `uv run pytest tests/unit/gateway/test_negotiation.py tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_peer_bridge.py tests/unit/gateway/test_rpc.py tests/unit/gateway/test_rtc_auth_enforcement.py tests/integration/test_mesh_routing.py tests/integration/test_mesh_permissions.py tests/integration/test_mesh_failover.py -q`
+
+## Risks
+
+- Existing `require_explicit_selector` is module-level, while this issue needs method-level policy. Mitigation: enforce hard routing denial via operator module config and expose finer method semantics through capability graph metadata and docs.
+- Some existing integration tests use literal topics. This task will not broaden that legacy surface; new tests should use typed constants where available.

--- a/.omx/ultragoal/PER-142-checkpoints.md
+++ b/.omx/ultragoal/PER-142-checkpoints.md
@@ -1,0 +1,20 @@
+# PER-142 Ultragoal Checkpoints
+
+## 2026-06-17 Plan
+
+- Scope: explicit remote TTS/STT/audio capability boundaries from Multica PER-142.
+- Plan artifact: `.omx/plans/PER-142-audio-capability-boundaries.md`.
+- Context gap: referenced `.omx/specs/deep-interview-mesh-distributed-integration.md` and generated PER-142 task file were absent in this checkout; implementation used the issue body, AGENTS guidance, `docs/PEER_PAIRING_FLOW.md`, and current mesh routing/capability graph code.
+
+## 2026-06-17 Implementation
+
+- Added audio policy metadata to capability graph policies.
+- Added optional `mesh_selector` fields to TTS/STT audio request models.
+- Denied implicit network-preferred routing for remote playback and live/streaming audio topics while preserving transparent routing for batch synthesize and batch transcription.
+- Documented audio sharing boundaries in `docs/PEER_PAIRING_FLOW.md`.
+
+## 2026-06-17 Verification
+
+- PASS: `env UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy ~/.local/bin/uv run --extra dev ruff check app/shared/contracts/models/gateway.py app/shared/contracts/models/tts.py app/shared/contracts/models/stt.py app/services/gateway/mesh/routing_table.py app/services/gateway/mesh/capability_graph.py tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_capability_graph.py`
+- PASS: `env UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy ~/.local/bin/uv run --extra dev --extra service-db --extra test-all pytest tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_capability_graph.py -q` (`29 passed, 3 warnings`)
+- Note: pytest emitted coverage warnings from a stale `.coverage` database, but tests passed.

--- a/app/services/gateway/mesh/capability_graph.py
+++ b/app/services/gateway/mesh/capability_graph.py
@@ -47,6 +47,24 @@ _HARDWARE_OR_AUDIO_MODULES = {
     "TTS",
 }
 
+_LOW_RISK_AUDIO_METHODS = {
+    ("TTS", "Synthesize"): ("batch_synthesize", "generated_audio"),
+    ("Transcription", "Transcribe"): ("batch_transcription", "submitted_audio"),
+}
+
+_EXPLICIT_AUDIO_METHODS = {
+    ("TTS", "Request"): ("remote_playback", "output_device"),
+    ("TTS", "Stop"): ("remote_playback_control", "output_device"),
+    ("TTS", "Pause"): ("remote_playback_control", "output_device"),
+    ("TTS", "Resume"): ("remote_playback_control", "output_device"),
+    ("STTCoordinator", "Listen"): ("microphone_capture", "microphone"),
+    ("STTCoordinator", "StopListening"): ("microphone_capture_control", "microphone"),
+    ("STTCoordinator", "Audio"): ("audio_streaming", "microphone"),
+    ("WakeWord", "ProcessAudio"): ("wakeword_streaming", "microphone"),
+    ("WakeWord", "Detect"): ("wakeword_detection", "submitted_audio"),
+    ("Transcription", "ProcessAudio"): ("transcription_streaming", "microphone"),
+}
+
 
 def build_capability_graph(
     *,
@@ -301,7 +319,28 @@ def _policy_for_method(
 ) -> CapabilityPolicyInfo:
     policy = _policy_for_module(module, sharing_config, provider_kind=provider_kind)
     policy.required_perms = list(method.required_perms)
-    policy.safety_class = _safety_class(module, method.method_type)
+    policy.safety_class = _safety_class(module, method.method_type, method.name)
+
+    low_risk_audio = _LOW_RISK_AUDIO_METHODS.get((module, method.name))
+    if low_risk_audio:
+        policy.operation_class, policy.resource_scope = low_risk_audio
+        policy.explicit_selector_required = False
+        policy.confirmation_required = False
+        policy.consent_required = False
+        policy.privacy_indicator_required = False
+        policy.bandwidth_check_required = False
+        return policy
+
+    explicit_audio = _EXPLICIT_AUDIO_METHODS.get((module, method.name))
+    if explicit_audio:
+        policy.operation_class, policy.resource_scope = explicit_audio
+        policy.explicit_selector_required = True
+        policy.consent_required = True
+        policy.privacy_indicator_required = True
+        policy.confirmation_required = provider_kind == "remote"
+        policy.bandwidth_check_required = "streaming" in policy.operation_class
+        return policy
+
     if method.method_type == "manage":
         policy.explicit_selector_required = True
         policy.confirmation_required = provider_kind == "remote"
@@ -328,6 +367,11 @@ def _policy_for_module(
         explicit_selector_required=explicit_required,
         confirmation_required=provider_kind == "remote"
         and safety_class in {"hardware", "data", "admin"},
+        consent_required=module in _HARDWARE_OR_AUDIO_MODULES,
+        privacy_indicator_required=module in _HARDWARE_OR_AUDIO_MODULES,
+        bandwidth_check_required=module in {"AudioInput", "STTCoordinator", "WakeWord", "Transcription"},
+        operation_class="audio_service" if module in _HARDWARE_OR_AUDIO_MODULES else None,
+        resource_scope="audio" if module in _HARDWARE_OR_AUDIO_MODULES else None,
         mesh_visible=bool(sharing_config.share) if sharing_config else provider_kind == "remote",
         local_only=provider_kind == "local" and not (sharing_config and sharing_config.share),
     )
@@ -381,13 +425,15 @@ def _remote_route_blockers(
     return blockers
 
 
-def _safety_class(module: str, method_type: str = "use") -> str:
+def _safety_class(module: str, method_type: str = "use", method_name: str | None = None) -> str:
     if method_type == "manage" or module in {"Auth", "Config"}:
         return "admin"
     if module == "DB":
         return "data"
     if module in {"Scheduler", "Tooling"}:
         return "delegated_action"
+    if (module, method_name or "") in _LOW_RISK_AUDIO_METHODS:
+        return "standard"
     if module in _HARDWARE_OR_AUDIO_MODULES:
         return "hardware"
     return "standard"

--- a/app/services/gateway/mesh/routing_table.py
+++ b/app/services/gateway/mesh/routing_table.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from app.helpers.aurora_logger import log_debug
+from app.messaging.audio_messages import AudioTopics
 from app.shared.contracts.models.mesh import MeshAddressSelector
+from app.shared.contracts.models.stt import STTMethods, TranscriptionMethods, WakeWordMethods
+from app.shared.contracts.models.tts import TTSMethods
 
 from .models import RouteDecision
 
@@ -74,6 +77,17 @@ class RoutingTable:
         # No routing config or mesh disabled → always local
         if not routing_config:
             return RouteDecision(target="local", module=module)
+
+        if (
+            _requires_explicit_audio_selector(topic)
+            and routing_config.prefer in {"network", "network_only"}
+        ):
+            return _route_error(
+                module=module,
+                selector=selector,
+                code="selector_required",
+                message=f"{topic} requires an explicit mesh selector",
+            )
 
         if routing_config.require_explicit_selector:
             return _route_error(
@@ -343,6 +357,33 @@ def _extract_module(topic: str) -> str:
     if "." in topic:
         return topic.split(".")[0]
     return topic
+
+
+_EXPLICIT_AUDIO_TOPICS = {
+    TTSMethods.REQUEST,
+    TTSMethods.STOP,
+    TTSMethods.PAUSE,
+    TTSMethods.RESUME,
+    STTMethods.LISTEN,
+    STTMethods.STOP_LISTENING,
+    STTMethods.AUDIO,
+    STTMethods.CONTROL,
+    WakeWordMethods.PROCESS_AUDIO,
+    WakeWordMethods.DETECT,
+    WakeWordMethods.CONTROL,
+    TranscriptionMethods.PROCESS_AUDIO,
+    TranscriptionMethods.CONTROL,
+    AudioTopics.STREAM_MICROPHONE,
+    AudioTopics.STREAM_WEBSOCKET,
+    AudioTopics.STREAM_GENERIC,
+    AudioTopics.CONTROL,
+}
+
+
+def _requires_explicit_audio_selector(topic: str) -> bool:
+    """Return True for audio operations that must name a target peer/device."""
+
+    return topic in _EXPLICIT_AUDIO_TOPICS
 
 
 def _selector_peer_id(selector: MeshAddressSelector, module: str) -> tuple[str | None, str | None]:

--- a/app/shared/contracts/models/gateway.py
+++ b/app/shared/contracts/models/gateway.py
@@ -286,6 +286,11 @@ class CapabilityPolicyInfo(IOModel):
     allowed_peers: list[str] | None = None
     explicit_selector_required: bool = False
     confirmation_required: bool = False
+    consent_required: bool = False
+    privacy_indicator_required: bool = False
+    bandwidth_check_required: bool = False
+    operation_class: str | None = None
+    resource_scope: str | None = None
     rate_limit_key: str | None = None
     mesh_visible: bool = False
     local_only: bool = False

--- a/app/shared/contracts/models/stt.py
+++ b/app/shared/contracts/models/stt.py
@@ -2,6 +2,7 @@
 
 from pydantic import Field
 
+from app.shared.contracts.models.mesh import MeshAddressSelector
 from app.shared.contracts.registry import IOModel
 
 
@@ -127,6 +128,7 @@ class STTAudioChunk(IOModel):
     channels: int
     format: str = "pcm_s16le"
     sample_width: int | None = None  # Bytes per sample (derived from format if not provided)
+    mesh_selector: MeshAddressSelector | None = None
 
 
 # ============================================================================
@@ -146,6 +148,7 @@ class TranscribeAudioRequest(IOModel):
     channels: int = 1
     language: str | None = None  # ISO language code or None for auto-detect
     model: str = "realtime"  # "realtime" | "accurate"
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class TranscribeAudioResponse(IOModel):
@@ -168,6 +171,7 @@ class WakeWordDetectRequest(IOModel):
     sample_rate: int = 16000
     channels: int = 1
     format: str = "raw"  # "raw" (PCM 16-bit) | "wav"
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class WakeWordDetectResponse(IOModel):

--- a/app/shared/contracts/models/tts.py
+++ b/app/shared/contracts/models/tts.py
@@ -1,5 +1,6 @@
 """TTS (Text-to-Speech) service contract models."""
 
+from app.shared.contracts.models.mesh import MeshAddressSelector
 from app.shared.contracts.registry import IOModel
 
 
@@ -34,6 +35,7 @@ class TTSRequest(IOModel):
     voice: str | None = None
     speed: float = 1.0
     interrupt: bool = True  # Interrupt current playback
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class TTSSynthesizeRequest(IOModel):
@@ -44,6 +46,7 @@ class TTSSynthesizeRequest(IOModel):
     speed: float = 1.0
     format: str = "wav"  # "wav" | "raw"
     sample_rate: int | None = None  # None = use model default
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class TTSSynthesizeResponse(IOModel):
@@ -61,6 +64,7 @@ class TTSControl(IOModel):
     """Control TTS playback (stop, pause, resume)."""
 
     action: str  # "stop" | "pause" | "resume"
+    mesh_selector: MeshAddressSelector | None = None
 
 
 class TTSStatus(IOModel):

--- a/docs/PEER_PAIRING_FLOW.md
+++ b/docs/PEER_PAIRING_FLOW.md
@@ -1373,6 +1373,18 @@ Per-service mesh config can set `require_explicit_selector: true` for safety-sen
 
 Explicit selector routes do not silently fall back to a different peer or local service after selector validation or target transport failure. A caller that chooses a specific tool/resource/provider receives an error if that target cannot satisfy the call.
 
+#### Audio Sharing Boundaries
+
+Audio capabilities use narrower defaults than generic module routing:
+
+- `TTS.Synthesize` can be shared as a lower-risk batch operation because it returns generated audio data to the caller and does not play sound on the provider device.
+- `Transcription.Transcribe` can be shared as a lower-risk batch operation because the caller submits a bounded audio payload and receives text.
+- `TTS.Request` and playback controls target a provider's physical output device, so network-preferred routing requires an explicit selector such as `peer_id` plus `hardware_target`.
+- Live microphone, wakeword, and streaming transcription paths require an explicit selector, local consent, visible privacy indicators, and bandwidth/capacity checks before they are enabled for remote use.
+- Raw microphone or wakeword streaming should remain local-only unless an operator explicitly configures mesh sharing and a UI flow obtains target-device consent.
+
+Capability graph policy metadata exposes these boundaries with `operation_class`, `resource_scope`, `explicit_selector_required`, `consent_required`, `privacy_indicator_required`, and `bandwidth_check_required` fields. These fields are diagnostic and client-facing; routing enforcement still depends on explicit selectors and per-service mesh policy.
+
 ### Event Forwarding
 
 #### The Problem

--- a/tests/unit/gateway/test_capability_graph.py
+++ b/tests/unit/gateway/test_capability_graph.py
@@ -16,6 +16,8 @@ from app.shared.contracts.models.gateway import (
     MethodInfo,
     ServiceAnnouncement,
 )
+from app.shared.contracts.models.stt import TranscriptionMethods, WakeWordMethods
+from app.shared.contracts.models.tts import TTSMethods
 
 
 def _method(module: str, name: str = "Execute", method_type: str = "use") -> MethodInfo:
@@ -29,6 +31,11 @@ def _method(module: str, name: str = "Execute", method_type: str = "use") -> Met
         input_model=f"{name}Request",
         output_model=f"{name}Response",
     )
+
+
+def _method_from_topic(topic: str) -> MethodInfo:
+    module, name = topic.split(".", 1)
+    return _method(module, name)
 
 
 def _remote_service(module: str, version: str, max_concurrent: int = 4) -> PeerServiceInfo:
@@ -191,6 +198,83 @@ def test_capability_graph_models_support_explicit_resource_selectors():
     data = resource.model_dump()
     assert data["namespace"] == "memories/home"
     assert data["address"]["resource_id"] == "db:memories:home"
+
+
+def test_capability_graph_classifies_audio_boundaries():
+    mesh_config = MeshConfig(
+        enabled=True,
+        node_name="local-node",
+        services={
+            "TTS": MeshServiceConfig(share=True, prefer="network"),
+            "Transcription": MeshServiceConfig(share=True, prefer="network"),
+            "WakeWord": MeshServiceConfig(share=True, prefer="network"),
+        },
+    )
+    local_services = {
+        "TTS": ServiceAnnouncement(
+            module="TTS",
+            version="1.0.0",
+            methods=[
+                _method_from_topic(TTSMethods.REQUEST),
+                _method_from_topic(TTSMethods.SYNTHESIZE),
+            ],
+        ),
+        "Transcription": ServiceAnnouncement(
+            module="Transcription",
+            version="1.0.0",
+            methods=[
+                _method_from_topic(TranscriptionMethods.PROCESS_AUDIO),
+                _method_from_topic(TranscriptionMethods.TRANSCRIBE),
+            ],
+        ),
+        "WakeWord": ServiceAnnouncement(
+            module="WakeWord",
+            version="1.0.0",
+            methods=[_method_from_topic(WakeWordMethods.PROCESS_AUDIO)],
+        ),
+    }
+
+    graph = build_capability_graph(
+        mesh_config=mesh_config,
+        local_services=local_services,
+        local_peer_id="local-peer",
+    )
+
+    methods = {
+        method.bus_topic: method
+        for service in graph.services
+        for method in service.methods
+    }
+
+    synthesize = methods[TTSMethods.SYNTHESIZE]
+    assert synthesize.policy.safety_class == "standard"
+    assert synthesize.policy.operation_class == "batch_synthesize"
+    assert synthesize.policy.explicit_selector_required is False
+    assert synthesize.policy.consent_required is False
+    assert synthesize.policy.privacy_indicator_required is False
+
+    playback = methods[TTSMethods.REQUEST]
+    assert playback.policy.safety_class == "hardware"
+    assert playback.policy.operation_class == "remote_playback"
+    assert playback.policy.resource_scope == "output_device"
+    assert playback.policy.explicit_selector_required is True
+    assert playback.policy.consent_required is True
+    assert playback.policy.privacy_indicator_required is True
+
+    batch_transcribe = methods[TranscriptionMethods.TRANSCRIBE]
+    assert batch_transcribe.policy.safety_class == "standard"
+    assert batch_transcribe.policy.operation_class == "batch_transcription"
+    assert batch_transcribe.policy.explicit_selector_required is False
+
+    stream_transcribe = methods[TranscriptionMethods.PROCESS_AUDIO]
+    assert stream_transcribe.policy.operation_class == "transcription_streaming"
+    assert stream_transcribe.policy.explicit_selector_required is True
+    assert stream_transcribe.policy.bandwidth_check_required is True
+
+    wakeword = methods[WakeWordMethods.PROCESS_AUDIO]
+    assert wakeword.policy.operation_class == "wakeword_streaming"
+    assert wakeword.policy.explicit_selector_required is True
+    assert wakeword.policy.privacy_indicator_required is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gateway/test_routing_table.py
+++ b/tests/unit/gateway/test_routing_table.py
@@ -7,6 +7,8 @@ from app.services.gateway.mesh.models import PeerManifest, PeerServiceInfo, Peer
 from app.services.gateway.mesh.peer_registry import PeerRegistry
 from app.services.gateway.mesh.routing_table import RoutingTable, _extract_module
 from app.shared.contracts.models.mesh import MeshAddressSelector
+from app.shared.contracts.models.stt import TranscriptionMethods
+from app.shared.contracts.models.tts import TTSMethods
 
 
 class TestExtractModule:
@@ -31,6 +33,7 @@ def mesh_config():
             "TTS": MeshServiceConfig(prefer="network", fallback="local"),
             "DB": MeshServiceConfig(prefer="local"),
             "STT": MeshServiceConfig(prefer="network_only", fallback="error"),
+            "Transcription": MeshServiceConfig(prefer="network", fallback="local"),
             "Scheduler": MeshServiceConfig(prefer="local_only"),
             "Tooling": MeshServiceConfig(prefer="local", require_explicit_selector=True),
         },
@@ -80,7 +83,7 @@ class TestRoutingTableResolve:
     @pytest.mark.asyncio
     async def test_prefer_network_no_peer_falls_back_to_local(self, routing_table):
         """No peers registered, so network preference falls back."""
-        route = routing_table.resolve("TTS.Request")
+        route = routing_table.resolve(TTSMethods.SYNTHESIZE)
         assert route.target == "local"
         assert route.module == "TTS"
 
@@ -91,7 +94,7 @@ class TestRoutingTableResolve:
         await peer_registry.update_manifest("peer-1", peer.manifest)
         await peer_registry.update_latency("peer-1", 20.0)
 
-        route = routing_table.resolve("TTS.Request")
+        route = routing_table.resolve(TTSMethods.SYNTHESIZE)
         assert route.target == "remote"
         assert route.peer_id == "peer-1"
         assert route.module == "TTS"
@@ -110,7 +113,7 @@ class TestRoutingTableResolve:
         await peer_registry.register_peer("peer-1")
         await peer_registry.update_manifest("peer-1", peer.manifest)
 
-        route = routing_table.resolve("TTS.Request", exclude=["peer-1"])
+        route = routing_table.resolve(TTSMethods.SYNTHESIZE, exclude=["peer-1"])
         # Peer excluded, no other peers → fallback
         assert route.target == "local"
 
@@ -163,6 +166,50 @@ class TestRoutingTableResolve:
         assert route.target == "error"
         assert route.error_code == "selector_required"
 
+    def test_remote_playback_requires_explicit_selector(self, routing_table):
+        route = routing_table.resolve(TTSMethods.REQUEST)
+
+        assert route.target == "error"
+        assert route.error_code == "selector_required"
+
+    def test_batch_synthesize_can_use_transparent_routing(self, routing_table):
+        route = routing_table.resolve(TTSMethods.SYNTHESIZE)
+
+        assert route.target == "local"
+        assert route.module == "TTS"
+
+    def test_streaming_transcription_requires_explicit_selector(self, routing_table):
+        route = routing_table.resolve(TranscriptionMethods.PROCESS_AUDIO)
+
+        assert route.target == "error"
+        assert route.error_code == "selector_required"
+
+    def test_batch_transcription_can_use_transparent_routing(self, routing_table):
+        route = routing_table.resolve(TranscriptionMethods.TRANSCRIBE)
+
+        assert route.target == "local"
+        assert route.module == "Transcription"
+
+    @pytest.mark.asyncio
+    async def test_explicit_audio_selector_routes_to_selected_peer(
+        self, routing_table, peer_registry
+    ):
+        peer = _make_negotiated_peer("speaker-peer", ["TTS"], latency_ms=20.0)
+        await peer_registry.register_peer("speaker-peer")
+        await peer_registry.update_manifest("speaker-peer", peer.manifest)
+
+        route = routing_table.resolve(
+            TTSMethods.REQUEST,
+            selector=MeshAddressSelector(
+                peer_id="speaker-peer",
+                hardware_target="living-room-speaker",
+            ),
+        )
+
+        assert route.target == "remote"
+        assert route.peer_id == "speaker-peer"
+        assert route.selector.hardware_target == "living-room-speaker"
+
     def test_conflicting_explicit_selectors_return_error(self, routing_table):
         route = routing_table.resolve(
             "Tooling.ExecuteTool",
@@ -177,7 +224,7 @@ class TestRoutingTableResolveFallback:
     """Tests for RoutingTable.resolve_fallback()."""
 
     def test_fallback_local(self, routing_table):
-        route = routing_table.resolve_fallback("TTS.Request", failed_peer_id="peer-1")
+        route = routing_table.resolve_fallback(TTSMethods.SYNTHESIZE, failed_peer_id="peer-1")
         assert route.target == "local"
 
     @pytest.mark.asyncio
@@ -195,7 +242,7 @@ class TestRoutingTableResolveFallback:
             await peer_registry.update_manifest(pid, manifest)
             await peer_registry.update_latency(pid, lat)
 
-        fallback = routing_table.resolve_fallback("TTS.Request", failed_peer_id="peer-1")
+        fallback = routing_table.resolve_fallback(TTSMethods.SYNTHESIZE, failed_peer_id="peer-1")
         assert fallback.target == "remote"
         assert fallback.peer_id == "peer-2"
 


### PR DESCRIPTION
## Summary

- Adds audio-specific mesh routing boundaries so network-preferred remote playback and live/streaming audio topics require an explicit mesh selector.
- Keeps lower-risk batch `TTS.Synthesize` and `Transcription.Transcribe` transparently routable when operator mesh config permits it.
- Extends capability graph policy metadata with audio operation, resource, consent, privacy indicator, and bandwidth-check hints.
- Adds selector fields to TTS/STT audio request contracts and documents the sharing boundary in `docs/PEER_PAIRING_FLOW.md`.

## Validation

- `env UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy ~/.local/bin/uv run --extra dev ruff check app/shared/contracts/models/gateway.py app/shared/contracts/models/tts.py app/shared/contracts/models/stt.py app/services/gateway/mesh/routing_table.py app/services/gateway/mesh/capability_graph.py tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_capability_graph.py`
- `env UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy ~/.local/bin/uv run --extra dev --extra service-db --extra test-all pytest tests/unit/gateway/test_routing_table.py tests/unit/gateway/test_capability_graph.py -q` (`29 passed, 3 warnings`)

Note: pytest emitted coverage warnings from a stale `.coverage` database, but the targeted tests passed.
