### PR TITLE
Refresh UI mesh planning specs

### DIFF
--- a/.omx/plans/PER-148-ui-sync-mesh-contract-refresh.md
+++ b/.omx/plans/PER-148-ui-sync-mesh-contract-refresh.md
@@ -1,0 +1,74 @@
+# PER-148 UI Sync: Mesh Contract Refresh Plan
+
+## Requirements Summary
+
+- Source issue: PER-148 `[UI-SYNC-001] Refresh UI roadmap, contracts, and mock references against stabilized mesh contracts`.
+- Scope is documentation/spec synchronization only. Do not implement production UI, redesign mock references, or reopen completed mesh work without a concrete inconsistency.
+- Backend evidence read from completed mesh plans `PER-128` through `PER-146`, current Gateway/Auth/Tooling/Scheduler/DB contract models, and mesh docs.
+- The checkout does not contain the previously referenced UI spec files or `modules/ui-mock-reference/`; this task recreates the minimum committed UI planning artifacts and records the missing mock-reference status.
+
+## UX Flow Plan
+
+1. Treat Gateway and service contracts as UI truth sources:
+   - `Gateway.GetMeshStatus` for local mesh state, peer lifecycle, route diagnostics, compatibility failures, provider eligibility, capacity, and stale state.
+   - `Gateway.GetCapabilityGraph` for addressable capabilities, policy metadata, provider/resource identity, and explicit-selector requirements.
+   - Auth mesh peer contracts for stable peer identity, outbound/inbound approval, denial, permissions, and connection state.
+   - Tooling, Orchestrator, DB, Scheduler, TTS/STT, and audit contracts for domain-specific states.
+2. Model distributed UI status as explicit state families: backend-proven, pending, denied, degraded, stale, privacy-blocked, and deferred.
+3. Keep mesh-dependent controls disabled or in a diagnostics-only state unless the backend exposes the target peer/resource, policy decision, and correlation/audit trail needed to support the claim.
+
+## Component Boundaries
+
+- Mesh status surface: consumes `GetMeshStatus`; renders lifecycle and route diagnostics without mutating mesh state.
+- Capability explorer: consumes `GetCapabilityGraph`; shows providers, services, methods, resources, policy flags, and selectors.
+- Peer administration: consumes Auth mesh peer APIs; limited to local admin/trust state, not transparent Auth sharing.
+- Remote action preflight: consumes Tooling/Scheduler/audio policy metadata; requires explicit target selectors and confirmation when policy says so.
+- Diagnostics/audit panel: consumes correlation IDs and redacted audit records; no raw secret or argument display.
+
+## Backend Truth Sources
+
+- Stable identity and bilateral pairing: Auth/Gateway peer records and DataChannel auth/manifest state.
+- Routing and provider state: MeshBus, RoutingTable, PeerRegistry, `GetMeshStatus`, and capability graph output.
+- Tool and orchestrator provenance: `ToolingToolInfo`, `ToolingExecuteToolRequest/Response`, and Orchestrator hidden remote binding semantics.
+- Data/scheduler/audio policy: `docs/DATA_SHARING_POLICY.md`, scheduler ownership fields, and capability graph audio policy metadata.
+- Tracing/audit: `correlation_id` fields propagated through MeshBus, PeerBridge, RPCHandler, service execution, and Auth audit records.
+
+## Accessibility And Focus Behavior
+
+- Distributed-state controls must expose text labels and machine-readable status, not color alone.
+- Any confirmation flow for remote tools, scheduler delegation, playback, or streaming must trap focus in the dialog, return focus to the invoking control, and keep the selected peer/resource visible.
+- Denied, stale, degraded, and privacy-blocked states must include an actionable explanation from backend reason codes where available.
+- Diagnostics can be dense, but tables/lists must keep keyboard navigation and copyable correlation IDs.
+
+## Tauri Readiness
+
+- Future Tauri UI must call local Gateway/service APIs or typed native bridge commands backed by Python services. It must not simulate peer state, route success, pairing success, audio activity, tool execution, DB sync, or scheduler delegation in frontend state alone.
+- True Tauri E2E must exercise the native shell, backend sidecars/services, Gateway/WebRTC/mesh state, isolated profiles, and real correlation/audit paths. Browser-only Playwright can cover isolated UI behavior but cannot prove Tauri IPC or mesh behavior.
+
+## Implementation Steps
+
+1. Recreate missing UI refinement specs:
+   - `.omx/specs/ui-refinement/index.md`
+   - `.omx/specs/ui-refinement/aurora-ui-sdk-contract.md`
+   - `.omx/specs/ui-refinement/aurora-ui-ux-flows.md`
+   - `.omx/specs/ui-refinement/feature-service-availability-graph.md`
+2. Recreate missing production sequencing specs:
+   - `.omx/specs/ui-production-tasks/index.md`
+   - `.omx/specs/ui-production-tasks/backend-gap-crosswalk.md`
+3. Recreate `.omx/specs/mesh-ui-roadmap-integration-review.md` as the bridge from completed mesh contracts to future UI production tasks.
+4. Note that `modules/ui-mock-reference/` is absent in this checkout and therefore no visual/component inventory was possible or needed.
+5. Verify by searching for the new spec anchors, checking the doc diff, and confirming no production UI files changed.
+
+## Acceptance Criteria
+
+- UI specs reflect completed mesh surfaces for diagnostics, stable identity, credentials, reverse pairing, sharing config, E2EE, capability graph, hybrid addressing, provider aggregation, remote Tooling/Orchestrator, DB policy, audio boundaries, scheduler delegation, Auth/Config boundaries, tracing/audit, and chaos/failure expectations.
+- Feature/service availability semantics distinguish backend-proven, pending, denied, degraded, stale, privacy-blocked, and deferred states.
+- Future UI tasks can reference these specs without re-litigating mesh roadmap decisions.
+- Missing UI spec files are recreated and missing mock references are explicitly noted.
+- No production UI wiring is introduced.
+
+## Verification
+
+- `rg -n "backend-proven|privacy-blocked|GetMeshStatus|GetCapabilityGraph|MeshAddressSelector|correlation_id|modules/ui-mock-reference" .omx/specs`
+- `git diff --check`
+- `git status --short`

--- a/.omx/specs/mesh-ui-roadmap-integration-review.md
+++ b/.omx/specs/mesh-ui-roadmap-integration-review.md
@@ -1,0 +1,56 @@
+# Mesh UI Roadmap Integration Review
+
+## Summary
+
+The mesh roadmap through PER-146 gives future UI work enough backend contract surface to start with diagnostics, capability discovery, peer trust state, safe remote-tool flows, ownership-aware scheduler views, data policy explanations, and failure diagnostics. UI production must still be sequenced carefully because several high-risk claims remain intentionally blocked or deferred.
+
+## Completed Mesh Surface To UI Mapping
+
+| Mesh issue | Backend result | UI implication |
+|---|---|---|
+| PER-128 | `Gateway.GetMeshStatus` route/status diagnostics. | UI can render backend-proven mesh status, route decisions, provider eligibility, compatibility, capacity, and stale state. |
+| PER-129 | Stable peer identity separate from WebRTC signaling session IDs. | UI can use stable peer IDs for trust, provenance, and selectors; signaling IDs stay transport-only. |
+| PER-130 | Peer-scoped saved WebRTC tokens. | UI can explain credential reuse per stable peer only after backend auth resolves that peer. |
+| PER-131 | Peer-specific reverse pairing skip. | UI should show bilateral pending/approved/denied state per peer, not global paired/unpaired state. |
+| PER-132 | Mesh sharing config schema/runtime parity. | UI can expose share/capacity/allowlist/version/capability/prefer/fallback/explicit-selector fields when production config UI is in scope. |
+| PER-133 | Optional app-layer DataChannel E2EE and mismatch drop. | UI can surface E2EE enabled/mismatch failure states from diagnostics; no plaintext downgrade claims. |
+| PER-134 | Capability graph core. | UI can build a capability explorer backed by provider/service/method/resource/policy/provenance models. |
+| PER-135 | Hybrid addressing primitives. | UI can build explicit target selectors for peer/provider/service/resource/tool/hardware/data scope. |
+| PER-136 | Provider aggregation diagnostics. | UI should show all candidates and reason codes, not only the selected provider. |
+| PER-137 | Tooling discovery metadata. | UI can show stable tool IDs, provider identity, display aliases, safety class, and provenance. |
+| PER-138 | Remote Tooling execution routing and audit provenance. | UI can execute remote tools only through explicit selector/resource/confirmation paths where policy requires them. |
+| PER-139 | Orchestrator authorized remote tool binding. | UI can show safe remote tools in assistant context; unsafe/confirmation-required remote tools stay gated. |
+| PER-140 | DB/data-sharing policy. | UI can explain remote-query-only and export/import planning states; replication and raw SQL stay blocked. |
+| PER-142 | Audio capability boundaries. | UI must separate batch synthesize/transcribe from remote playback and live audio streaming consent flows. |
+| PER-143 | Scheduler delegation policy. | UI can show namespace, owner, target selector, delegated permissions, policy decision, and correlation. |
+| PER-144 | Auth/Config mesh boundaries. | UI must keep Auth/Config broad admin/mutation local unless future policy exists. |
+| PER-145 | Distributed tracing/audit. | UI can present copyable correlation IDs and redacted audit diagnostics for remote actions and denials. |
+| PER-146 | Chaos/failure-mode coverage. | UI state language must preserve fallback vs explicit hard failure, stale, denied, capacity, auth expiry, and no-route behavior. |
+
+## UI Claims Allowed Now
+
+- "This peer is negotiated/stale/denied/pending" when backed by Gateway/Auth state.
+- "This route is local/remote/none/error" when backed by `GetMeshStatus.routes`.
+- "This provider is ineligible because ..." when backed by provider diagnostics.
+- "This capability requires explicit selector/confirmation/consent/privacy indicator" when backed by capability policy metadata.
+- "This remote tool execution succeeded/failed/was denied/dry-ran" when backed by Tooling response and correlation/audit evidence.
+- "This data feature is remote-query-only or deferred" when backed by data policy.
+
+## UI Claims Still Blocked Or Deferred
+
+- Pairing success from presence alone.
+- Transparent fallback after explicit target failure.
+- Raw SQL, credential, token, config secret, or mesh secret sharing.
+- Bidirectional RAG/chat/scheduler replication.
+- Remote Auth/Config admin as a transparent mesh provider.
+- Dangerous remote tool auto-execution.
+- Remote playback, microphone, wakeword, or live stream state without consent and backend audio evidence.
+- True Tauri E2E from browser-only tests.
+
+## Production Sequencing Recommendation
+
+Start with SDK adapters, mesh diagnostics, peer trust state, and capability explorer. Add remote action preflight before any Tooling, scheduler, data, or audio execution surface. Defer Tauri until the SDK and Gateway-backed UI surfaces have enough fixtures and integration coverage to justify native E2E.
+
+## Verification Notes
+
+This review was produced from the PER-128 through PER-146 plan files, current Gateway/Auth/Tooling/Scheduler/DB/audio contract models, and current docs. The checkout does not contain `modules/ui-mock-reference/`, so no visual/component inventory was performed.

--- a/.omx/specs/ui-production-tasks/backend-gap-crosswalk.md
+++ b/.omx/specs/ui-production-tasks/backend-gap-crosswalk.md
@@ -1,0 +1,43 @@
+# UI Backend Gap Crosswalk
+
+## Purpose
+
+This file lists what UI can rely on now and what must remain blocked or deferred until backend contracts exist.
+
+## Backend-Proven Now
+
+| Area | Proven surface | UI can build |
+|---|---|---|
+| Mesh diagnostics | `Gateway.GetMeshStatus` | Status, route, peer lifecycle, compatibility, provider eligibility, capacity, stale/degraded diagnostics. |
+| Capability topology | `Gateway.GetCapabilityGraph` | Capability explorer, policy flag display, provider/service/method/resource graph. |
+| Stable peer identity | Auth mesh identity and peer records | Peer identity, node name, inbound/outbound trust state, peer-specific credential state after backend auth. |
+| Hybrid addressing | `MeshAddressSelector` on typed payloads | Explicit peer/provider/service/resource/tool/data-scope preflight. |
+| Provider aggregation | PeerRegistry diagnostics projected through Gateway | Candidate vs eligible provider views with reason codes. |
+| Remote tools | Tooling discovery/execution models | Standard remote tools, safe execution status, provider provenance, correlation/audit references. |
+| Orchestrator remote tools | Tooling metadata plus Orchestrator binding semantics | Display which safe remote tools are eligible for assistant planning. |
+| Data policy | `docs/DATA_SHARING_POLICY.md`, DB query contracts | Remote-query-only language, policy education, disabled replication/raw SQL controls. |
+| Scheduler delegation | Scheduler ownership/delegation fields | Namespace/owner/target/delegated-permission/correlation display. |
+| Audio boundaries | Capability graph policy metadata and typed audio selectors | Batch operation availability and explicit privacy/consent requirements. |
+| Auth/Config boundaries | Auth/Config docs and schema defaults | Local peer-admin and local config language; no broad remote sharing. |
+| Tracing/audit | `correlation_id`, Auth audit details | Copyable diagnostics, redacted failure explanations. |
+| Failure behavior | PER-146 chaos expectations and tests | Fallback vs hard-failure state language. |
+
+## Blocked Or Deferred Claims
+
+| Claim | Status | Required backend evidence before UI enables it |
+|---|---|---|
+| Raw SQL across peers | Blocked | This is explicitly prohibited by data-sharing policy. |
+| Bidirectional chat/RAG/scheduler sync | Deferred | Domain sync contracts with namespaces, conflict/delete/tombstone semantics, provenance, and tests. |
+| Remote Auth/Config transparent admin | Blocked by current policy | Explicit remote-admin policy and permission model. |
+| Remote microphone/live listening | Deferred/privacy-blocked | Consent contract, privacy indicator events, bandwidth/capacity checks, backend stream state. |
+| Remote playback/control without target | Privacy-blocked | Explicit peer/device selector, confirmation, backend playback state. |
+| Dangerous remote tool auto-binding | Blocked | Explicit confirmation/resource approval flow and backend decision event. |
+| Peer pairing success from presence alone | Blocked | Authenticated, bilateral trust, manifest negotiation, and stable peer identity evidence. |
+| Tauri E2E from browser tests | Blocked | Native Tauri shell plus backend/native/WebRTC verification harness. |
+| UI mock as production source | Deferred | Restored `modules/ui-mock-reference/` and an issue explicitly authorizing production UI implementation. |
+
+## Current Missing Artifacts
+
+- `.omx/specs/ui-refinement/*` and `.omx/specs/ui-production-tasks/*` were absent before PER-148 and are recreated in this branch.
+- `modules/ui-mock-reference/` is absent in this checkout, so no component inventory was performed.
+- `.omx/specs/deep-interview-mesh-distributed-integration.md` and `.omx/multica/mesh-roadmap-tasks/*` are absent in this checkout; PER-128 through PER-146 plan files, current docs, and committed code contracts were used as evidence.

--- a/.omx/specs/ui-production-tasks/index.md
+++ b/.omx/specs/ui-production-tasks/index.md
@@ -1,0 +1,52 @@
+# Aurora UI Production Task Index
+
+## Sequencing Rule
+
+Future UI production work should start from backend-proven surfaces and preserve issue isolation. Mesh-dependent UI must not simulate backend state or implement speculative controls for missing contracts.
+
+## Recommended Task Order
+
+1. **UI SDK shell and typed adapters**
+   - Build a thin SDK over Gateway/Auth/service APIs.
+   - Normalize `GetMeshStatus`, `GetCapabilityGraph`, Auth peer state, Tooling discovery/execution, scheduler ownership, and audit references.
+   - Verification: contract fixture tests with redaction and reason-code coverage.
+
+2. **Mesh diagnostics/status surface**
+   - Render local status, peers, routes, compatibility, provider candidates, stale/degraded states, and redacted diagnostics.
+   - Verification: UI tests from mocked backend responses plus integration check against real Gateway when available.
+
+3. **Peer trust administration**
+   - Show bilateral pending/approved/denied state and local peer-admin actions.
+   - Verification: Auth contract-backed tests; no broad Auth sharing assumptions.
+
+4. **Capability explorer**
+   - Render service/method/resource graph, provider indexes, policy flags, selector requirements, and blockers.
+   - Verification: graph fixture coverage for local, remote, stale, denied, privacy-blocked, and degraded states.
+
+5. **Remote action preflight**
+   - Add reusable confirmation/selector/resource flow for Tooling, scheduler, playback, and data-sensitive actions.
+   - Verification: focus management, keyboard flow, denial/error states, and correlation ID display.
+
+6. **Remote Tooling and Orchestrator controls**
+   - Bind standard authorized remote tools and gate sensitive/dangerous tools behind preflight.
+   - Verification: hidden unsafe tools, explicit selector execution, audit/correlation display.
+
+7. **Data/memory policy views**
+   - Show remote-query-only and export/import planning states; keep replication/raw SQL blocked.
+   - Verification: policy fixtures and disabled/deferred states.
+
+8. **Audio capability controls**
+   - Show batch synthesize/transcribe routes first; add playback/streaming only with explicit backend consent/state.
+   - Verification: privacy indicators, consent/focus behavior, selector and capacity handling.
+
+9. **Future Tauri client**
+   - Introduce official Tauri v2 shell only when backend/SDK surfaces are ready.
+   - Verification: Tauri WebDriver/native E2E on supported desktop platforms with real backend processes and isolated profiles.
+
+## Non-Goals For Initial UI Production
+
+- No raw cross-peer SQL UI.
+- No DB/RAG/chat bidirectional sync UI.
+- No transparent remote Auth/Config admin UI.
+- No remote microphone/listening UI without backend consent/event contracts.
+- No claim that browser-only Playwright proves Tauri IPC/native/backend behavior.

--- a/.omx/specs/ui-refinement/aurora-ui-sdk-contract.md
+++ b/.omx/specs/ui-refinement/aurora-ui-sdk-contract.md
@@ -1,0 +1,51 @@
+# Aurora UI SDK Contract
+
+## Contract Rule
+
+The UI SDK must be a typed adapter over Gateway/service truth. It may cache responses for rendering, but it must not invent service state, peer state, pairing success, route success, tool execution, audio activity, DB replication, or scheduler delegation.
+
+## Backend Truth Sources
+
+| UI concern | Backend source | UI may claim | UI must not claim |
+|---|---|---|---|
+| Local mesh runtime | `Gateway.GetMeshStatus.local` | Mesh enabled/started, WebRTC started, stable peer ID, node name, configured shared/routed modules. | Remote connectivity or sharing success without peer/route evidence. |
+| Peer lifecycle | `Gateway.GetMeshStatus.peers`, Auth `MeshListPeers`/`MeshGetPeer` | connected, authenticated, negotiated, stale, disconnected, outbound/inbound pending/approved/denied. | A peer is trusted, usable, or paired based only on presence. |
+| Route/provider choice | `Gateway.GetMeshStatus.routes`, PeerRegistry provider diagnostics | local, remote, none, or error route decision with eligible/ineligible providers and reason codes. | Silent fallback success for explicit selectors. |
+| Capability availability | `Gateway.GetCapabilityGraph` | provider peer, service instance, methods, policy flags, address fields, freshness/provenance, provider/candidate indexes. | That a capability is executable when policy flags require missing consent, confirmation, selector, or permission. |
+| Explicit targeting | `MeshAddressSelector` fields on typed payloads | Selected peer/provider/service/resource/tool/data scope when present and backend-accepted. | Resource targeting from display name alone. |
+| Tool discovery/execution | `Tooling.GetTools`, `Tooling.ExecuteTool` | local/remote location, provider identity, stable global tool ID, safety class, confirmation requirement, status/error, correlation ID. | Sensitive/dangerous remote tool execution without confirmation and resource selector. |
+| Orchestrator remote tools | Tooling metadata plus Orchestrator binding behavior | Standard remote tools can be included in planning context when authorized. | That dangerous or confirmation-required remote tools are auto-bound to the LLM. |
+| DB/data | `docs/DATA_SHARING_POLICY.md`, DB query contracts | Remote-query-only or export/import planning states where backend contracts exist. | Raw cross-peer SQL, active replication, or delete propagation. |
+| Scheduler | Scheduler ownership/delegation contract fields | Namespace, owner, target selector, delegated permissions, policy decision, correlation. | Ownership transfer or cross-peer job sync. |
+| Audio | Capability policy metadata and TTS/STT typed selectors | Batch synthesize/transcribe availability; explicit target/consent requirements for playback/streaming. | Remote microphone/listening/speaking/playback state without backend event and consent evidence. |
+| Auth/Config | Auth mesh peer contracts, Config local API policy | Local peer administration and local config state. | Broad transparent Auth/Config sharing or remote config mutation. |
+| Tracing/audit | `correlation_id`, Auth audit records, redacted diagnostics | Correlate a user-visible failure to logs/audit with redacted details. | Raw secrets, tokens, passwords, API keys, or unredacted tool arguments. |
+
+## SDK Shapes Future UI Should Preserve
+
+The SDK should normalize backend responses into small view models without discarding raw IDs:
+
+- `PeerSummary`: `peer_id`, `node_name`, lifecycle state, trust state, latency, stale age, service count, last evidence source.
+- `RouteSummary`: module, decision target, provider peer, reason, fallback, provider candidates, error code.
+- `CapabilitySummary`: service instance, provider peer, method/resource, selector address, policy flags, routable/blockers.
+- `RemoteActionPreflight`: target selector, policy flags, required confirmation/consent/resource fields, expected audit/correlation fields.
+- `AuditReference`: correlation ID, event kind, peer, method/tool/resource, status, redacted detail availability.
+
+## Privacy And Redaction
+
+- The SDK must preserve `secrets_redacted=true` as a displayable diagnostic assertion.
+- Never log or render token values, room passwords, API keys, credential hashes, or unredacted tool arguments.
+- Use hashes/fingerprints only when they come from backend audit details.
+
+## Error Handling
+
+Map backend reason codes directly before adding user-facing copy:
+
+- selector failures: missing target, peer not found, unauthorized, stale/not ready, service missing, incompatible capabilities, at capacity.
+- policy failures: permission denied, confirmation missing, resource selector missing, privacy blocked.
+- routing failures: no route, network-only no provider, explicit selector target failed, fallback used or blocked.
+- transport failures: timeout, send failure, app-layer E2EE mismatch/drop, auth expiry.
+
+## Tauri Boundary
+
+Future Tauri commands should be typed and minimal. They should call Gateway/service APIs or orchestrate Python sidecars, then return backend evidence to the frontend. Tauri IPC must not become a second source of truth for services, mesh, auth, tools, DB, scheduler, or audio.

--- a/.omx/specs/ui-refinement/aurora-ui-ux-flows.md
+++ b/.omx/specs/ui-refinement/aurora-ui-ux-flows.md
@@ -1,0 +1,87 @@
+# Aurora UI UX Flows
+
+## General Interaction Rules
+
+- Display peer/provider/resource identity anywhere a remote action can occur.
+- Keep local vs remote provider explicit; do not hide fallback behind a generic success message.
+- Show pending, denied, degraded, stale, privacy-blocked, and deferred states with backend reason text when available.
+- Disable irreversible or safety-sensitive actions until required selector, consent, confirmation, and permission evidence exists.
+- Surface correlation IDs in expandable diagnostics or copyable metadata, not as permanent visual noise.
+
+## Mesh Overview Flow
+
+1. Load `Gateway.GetMeshStatus`.
+2. Render local mesh status, stable peer ID, node name, shared modules, routed modules, and redaction status.
+3. Render peers grouped by lifecycle: connected/authenticated, negotiated, stale, denied, disconnected.
+4. For each routed module, show local/remote/none/error decision, provider peer, fallback, and provider eligibility reason codes.
+5. Offer a diagnostics details panel for compatibility failures, capacity, active calls, latency, manifest age, and last ping age.
+
+Accessibility:
+- Peer and route status must have text labels and ARIA status/live-region behavior for updates.
+- Keyboard focus should move into details only when the user opens them, then return to the triggering row/button.
+
+## Peer Trust And Pairing Flow
+
+1. Read Auth mesh peer state for stable peer identity, outbound status, inbound status, permissions, and connection state.
+2. Show bilateral state clearly: what this node grants to the peer and what the peer grants back.
+3. Pending approval must stay pending until Auth reports approved or denied.
+4. Denied peers remain visible as denied with a re-approval path only when backend peer-admin permissions allow it.
+5. Reconnect should show saved peer-scoped credential reuse only as a backend-proven state after auth succeeds.
+
+Blocked claims:
+- Do not present presence as pairing success.
+- Do not present a saved legacy/default token as peer-specific trust until the backend resolves a stable peer identity.
+
+## Capability Explorer Flow
+
+1. Load `Gateway.GetCapabilityGraph`.
+2. Render provider peers, service instances, methods, and resources with policy flags.
+3. Show candidate providers separately from currently routable providers so degraded and blocked services are inspectable.
+4. Use policy flags to explain required selectors, confirmation, consent, privacy indicators, bandwidth checks, and local-only status.
+5. For methods/resources with `explicit_selector_required=true`, expose selector construction as a preflight step before any execution UI.
+
+## Remote Tool Flow
+
+1. Discover tools through `Tooling.GetTools`.
+2. Show provider peer, service instance, display name, stable global tool ID, source, safety class, required permissions, and confirmation requirement.
+3. Standard remote tools may be made available to Orchestrator when backend metadata marks them safe and authorized.
+4. Sensitive/dangerous/confirmation-required tools require a preflight screen with target peer/resource, argument summary, confirmation, and expected audit trail.
+5. Execute with explicit selector/resource fields when required.
+6. Display `success`, `denied`, `not_found`, `failed`, or `dry_run` from `ToolingExecuteToolResponse` with correlation ID.
+
+## Data And Memory Flow
+
+Current UI may support:
+- Remote-query-only views for backend-exposed query methods.
+- Export/import planning language where future contracts explicitly exist.
+- Policy explanations for why raw SQL and replication are unavailable.
+
+Current UI must block/defer:
+- Raw cross-peer SQL.
+- Bidirectional RAG/chat/scheduler replication.
+- Delete/forget propagation claims.
+- Trust-table, credential, token, or mesh secret replication.
+
+## Audio Flow
+
+- Batch `TTS.Synthesize` and `Transcription.Transcribe` can be shown as shareable when mesh config and route diagnostics prove an eligible provider.
+- Remote playback/control requires explicit peer/device target and confirmation.
+- Live microphone, wakeword, and streaming transcription require explicit target, consent, visible privacy indicators, and bandwidth/capacity checks.
+- UI must not claim a peer is listening, speaking, muted, or streaming unless backend audio/service events prove it.
+
+## Scheduler Delegation Flow
+
+1. Show namespace, owner peer/principal, target selector, delegated permissions, policy decision, and correlation.
+2. Remote-created jobs should be listed only in the backend-authorized caller scope.
+3. Cancellation must explain denied ownership/policy failures.
+4. Job firing/completion should preserve delegated context in visible diagnostics.
+
+## Failure And Recovery Flow
+
+Use failure-mode expectations from PER-146:
+
+- Transparent routing may fall back when policy allows it; the UI should label the fallback used.
+- Explicit selector failures are hard failures and must not be displayed as fallback success.
+- Stale, denied, unauthorized, or at-capacity providers are not selectable for execution.
+- Network-only services without eligible providers show no-route/error.
+- Forwarded events should not appear as repeated looped events.

--- a/.omx/specs/ui-refinement/feature-service-availability-graph.md
+++ b/.omx/specs/ui-refinement/feature-service-availability-graph.md
@@ -1,0 +1,69 @@
+# Feature And Service Availability Graph Semantics
+
+## Purpose
+
+Future UI should render service availability from backend graph and diagnostic data, not from hardcoded feature flags. The graph is a UI interpretation layer over `Gateway.GetCapabilityGraph`, `Gateway.GetMeshStatus`, Auth peer state, and domain-specific service contracts.
+
+## Availability Inputs
+
+| Input | Use |
+|---|---|
+| `CapabilityGraph.peers` | Peer identity, provider kind, lifecycle status, latency, provenance. |
+| `CapabilityGraph.services` | Service instance identity, module, version, methods, capacity, routability, blockers, policy. |
+| `CapabilityGraph.resources` | Explicitly addressable resource placeholders and future resource ownership. |
+| `provider_index` | Routable providers by module. |
+| `candidate_provider_index` | All known provider candidates, including blocked/degraded candidates. |
+| `GetMeshStatus.routes` | Current routing decisions and provider eligibility reasons. |
+| Auth peer state | Trust, inbound/outbound approval, permissions, connection state. |
+| Domain responses | Tool execution status, scheduler job state, DB query results, audio service events, audit records. |
+
+## Availability State Model
+
+| State | Definition | Common backend evidence |
+|---|---|---|
+| available-local | Local provider exists and policy allows local use. | Local graph provider, local route decision, healthy service. |
+| available-remote | Negotiated remote provider is eligible and policy allows remote use. | Route target remote, eligible provider, capability policy allows. |
+| pending | Waiting for pairing, approval, manifest, confirmation, consent, or in-flight request completion. | Auth pending state, request correlation ID, policy preflight. |
+| denied | Backend rejected by trust, permission, selector, policy, or auth. | Denial response, audit event, provider reason code. |
+| degraded | Usable through fallback, reduced capacity, compatibility warning, or stale secondary provider. | Fallback route, compatibility failure, capacity warning. |
+| stale | Known provider is stale and must not be selected. | Peer status `stale`, ping/manifest age. |
+| privacy-blocked | Feature needs explicit consent/selector/privacy indicator before use. | Capability policy flags or data/audio policy. |
+| unsupported | No backend contract exists in this checkout. | Backend gap crosswalk entry. |
+
+## Rendering Rules
+
+- Show provider and selector identity close to the feature action.
+- Separate "known candidate" from "currently selectable" providers.
+- Keep `route_blockers` and provider `reason_code` available for diagnostics.
+- Treat `secrets_redacted=true` as a property of the diagnostic snapshot; never render secret-like fields even in debug views.
+- Prefer stable peer IDs and service instance IDs for tooltips/details, with node names as labels.
+
+## Domain-Specific Graph Notes
+
+### Mesh Core
+
+`GetMeshStatus` is the source for operational route diagnostics. `GetCapabilityGraph` is the source for inspectable service/method/resource topology.
+
+### Tooling And Orchestrator
+
+Remote tool availability depends on Tooling metadata and policy:
+
+- Standard, authorized remote tools can be selectable.
+- Sensitive, dangerous, or confirmation-required tools are visible only through an explicit preflight/approval path.
+- Orchestrator auto-binding is limited to remote tools that backend metadata marks safe.
+
+### DB/Data
+
+DB availability must be labeled by mode: remote-query-only, export/import planned, replication deferred, or never-share. Raw SQL is always unavailable for mesh UI.
+
+### Audio
+
+Audio availability must distinguish batch operations from physical-device playback and live streams. Playback/streaming require selector, consent, and privacy UI before becoming selectable.
+
+### Scheduler
+
+Scheduler availability is ownership-scoped. A remote scheduler capability is not enough to list/cancel/execute all jobs; namespace and owner filters must be backend-authorized.
+
+### Auth And Config
+
+Auth/Config broad admin and mutation surfaces remain local-admin surfaces. Pairing/login infrastructure is not evidence that Auth or Config are transparently mesh-shareable.

--- a/.omx/specs/ui-refinement/index.md
+++ b/.omx/specs/ui-refinement/index.md
@@ -1,0 +1,54 @@
+# Aurora UI Refinement Index
+
+## Purpose
+
+This directory is the planning source for future Aurora UI production work after the mesh roadmap completed through PER-146. It keeps UI state language tied to backend evidence instead of frontend-only assumptions.
+
+Aurora does not currently have a Tauri client. Current production truth is the Python service layer, Gateway APIs, optional PyQt/UIBridge, WebRTC mesh runtime, Auth/RBAC, and typed message-bus contracts.
+
+## Required Reading For UI Tasks
+
+- `aurora-ui-sdk-contract.md` for backend truth sources, typed surfaces, and claims the UI may or may not make.
+- `aurora-ui-ux-flows.md` for expected user flows, state language, focus behavior, and failure handling.
+- `feature-service-availability-graph.md` for availability semantics and how to render provider/capability state.
+- `../mesh-ui-roadmap-integration-review.md` for how PER-128 through PER-146 changed UI sequencing.
+- `../ui-production-tasks/index.md` and `../ui-production-tasks/backend-gap-crosswalk.md` before starting implementation work.
+
+## Current Mesh-Backed UI Contract Surface
+
+The following backend surfaces are considered stabilized enough for UI planning:
+
+- Mesh status and route diagnostics via `Gateway.GetMeshStatus`.
+- Stable peer identity and bilateral peer trust state via Auth mesh peer contracts.
+- Peer-scoped inbound WebRTC tokens and peer-specific reverse pairing semantics.
+- Mesh sharing config parity for share, capacity, peer allowlists, version, capabilities, route preference, fallback, and explicit selector requirements.
+- Optional DataChannel app-layer E2EE with safe mismatch/drop behavior.
+- Capability graph output via `Gateway.GetCapabilityGraph`.
+- Hybrid addressing through `MeshAddressSelector`.
+- Provider aggregation with eligible and ineligible provider reason codes.
+- Tooling discovery/execution metadata with provider identity, stable tool IDs, safety class, confirmation, resource selector, provenance, status, and `correlation_id`.
+- Orchestrator binding for safe remote tools only, with unsafe/confirmation-required remote tools hidden from automatic model selection.
+- DB/data-sharing policy that prohibits raw cross-peer SQL and defers replication.
+- Audio boundaries that distinguish batch synthesis/transcription from remote playback and live audio streams.
+- Scheduler delegation fields for namespace, owner, target selector, delegated permissions, policy decision, and correlation.
+- Auth/Config mesh boundaries that keep broad admin/mutation local unless future explicit policy exists.
+- Distributed tracing/audit with correlation propagation and redacted diagnostics.
+- Chaos/failure-mode expectations for stale providers, denied selectors, capacity exhaustion, auth expiry, network-only no-route, fallback, and forwarding-loop prevention.
+
+## State Vocabulary
+
+Use this vocabulary consistently in UI specs and future copy:
+
+| State | UI meaning | Required backend evidence |
+|---|---|---|
+| backend-proven | The UI can present the state as true. | Fresh Gateway/Auth/service response or subscribed event with matching identity/correlation. |
+| pending | The operation is requested but not yet completed. | Backend request accepted, pending peer/policy/action state, or in-flight correlation ID. |
+| denied | The backend rejected the request by auth, permission, sharing, selector, or policy. | Structured denial response, reason code, or audit event. |
+| degraded | The feature is available with reduced capability or fallback. | Route diagnostic, health state, compatibility warning, or fallback result. |
+| stale | The peer/provider/service is known but not currently fresh enough to trust. | PeerRegistry/Gateway stale status or heartbeat/manifest age beyond policy. |
+| privacy-blocked | The action is intentionally unavailable until consent, explicit target, or policy is satisfied. | Capability policy flags, data-sharing policy, audio policy, or explicit selector requirement. |
+| deferred | The backend contract for the claim does not exist yet. | Listed in `backend-gap-crosswalk.md`. |
+
+## Mock Reference Status
+
+The issue references `modules/ui-mock-reference/`, but this checkout only contains `modules/openrecall` and `modules/ui`. No mock-reference inventory or visual refresh was performed. Future tasks that restore or introduce the mock should treat it as a component/visual reference only, not production truth.


### PR DESCRIPTION
## Summary

- Recreate the missing UI refinement specs against the completed mesh contract surface.
- Add production UI task sequencing and a backend-gap crosswalk that separates backend-proven, pending, denied, degraded, stale, privacy-blocked, and deferred states.
- Add a mesh/UI integration review mapping PER-128 through PER-146 outcomes to future UI claims and blocked/deferred work.

## Notes

- No production UI wiring was introduced.
- `modules/ui-mock-reference/` is absent in this checkout, so no visual/component inventory was performed.
- The branch is based on `feat/migration-to-modular-services-architecture` to keep the PR to this one docs/spec commit.

## Verification

- `rg -n "backend-proven|privacy-blocked|GetMeshStatus|GetCapabilityGraph|MeshAddressSelector|correlation_id|modules/ui-mock-reference|PER-146|Tauri" .omx/specs .omx/plans/PER-148-ui-sync-mesh-contract-refresh.md`
- `git diff --check`
- `git status --short` (only unrelated pre-existing `tests/test_scheduler.db` remained unstaged)
