### PR TITLE
[PER-150] Add UI SDK typed adapters

### DIFF
--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,9 +1,17 @@
 """UI service module for Aurora.
 
-This module handles UI bridge functionality for connecting
-the core application with optional UI components.
+The PyQt bridge is optional; keep package imports lightweight so headless SDK
+and backend tests do not require PyQt6.
 """
 
-from app.ui.bridge_service import UIBridge
+from typing import Any
 
 __all__ = ["UIBridge"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "UIBridge":
+        from app.ui.bridge_service import UIBridge
+
+        return UIBridge
+    raise AttributeError(name)

--- a/app/ui/sdk/__init__.py
+++ b/app/ui/sdk/__init__.py
@@ -1,0 +1,50 @@
+"""Typed UI SDK adapters over Aurora backend contract models."""
+
+from app.ui.sdk.adapters import (
+    normalize_audit_events,
+    normalize_auth_peers,
+    normalize_capability_graph,
+    normalize_mesh_status,
+    normalize_scheduler_jobs,
+    normalize_tool_execution,
+    normalize_tools,
+)
+from app.ui.sdk.models import (
+    AuditReference,
+    AvailabilityState,
+    CapabilityGraphView,
+    CapabilitySummary,
+    DeferredClaim,
+    MeshStatusView,
+    PeerSummary,
+    RemoteActionPreflight,
+    RouteSummary,
+    SchedulerJobSummary,
+    ToolExecutionSummary,
+    ToolSummary,
+)
+from app.ui.sdk.redaction import redact_sensitive, summarize_arguments
+
+__all__ = [
+    "AuditReference",
+    "AvailabilityState",
+    "CapabilityGraphView",
+    "CapabilitySummary",
+    "DeferredClaim",
+    "MeshStatusView",
+    "PeerSummary",
+    "RemoteActionPreflight",
+    "RouteSummary",
+    "SchedulerJobSummary",
+    "ToolExecutionSummary",
+    "ToolSummary",
+    "normalize_audit_events",
+    "normalize_auth_peers",
+    "normalize_capability_graph",
+    "normalize_mesh_status",
+    "normalize_scheduler_jobs",
+    "normalize_tool_execution",
+    "normalize_tools",
+    "redact_sensitive",
+    "summarize_arguments",
+]

--- a/app/ui/sdk/adapters.py
+++ b/app/ui/sdk/adapters.py
@@ -1,0 +1,502 @@
+"""Pure adapters from backend contract models to UI SDK view models."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import BaseModel
+
+from app.shared.contracts.models.gateway import (
+    CapabilityGraph,
+    CapabilityPolicyInfo,
+    CapabilityServiceInfo,
+    GetMeshStatusResponse,
+    MeshRouteDiagnostic,
+)
+from app.shared.contracts.models.mesh import MeshAddressSelector, MeshPeerInfo, MeshPeerListResponse
+from app.shared.contracts.models.scheduler import SchedulerJobInfo, SchedulerListJobsResponse
+from app.shared.contracts.models.tooling import (
+    ToolingExecuteToolResponse,
+    ToolingGetToolsResponse,
+    ToolingToolInfo,
+)
+from app.ui.sdk.models import (
+    AuditReference,
+    AvailabilityState,
+    CapabilityGraphView,
+    CapabilitySummary,
+    DeferredClaim,
+    MeshStatusView,
+    PeerSummary,
+    RemoteActionPreflight,
+    RouteSummary,
+    SchedulerJobSummary,
+    ToolExecutionSummary,
+    ToolSummary,
+)
+from app.ui.sdk.redaction import redact_sensitive
+
+DEFERRED_CLAIMS: tuple[DeferredClaim, ...] = (
+    DeferredClaim(
+        claim="raw_sql_across_peers",
+        status="blocked",
+        required_backend_evidence="Explicitly prohibited by data-sharing policy.",
+    ),
+    DeferredClaim(
+        claim="bidirectional_chat_rag_scheduler_sync",
+        status="deferred",
+        required_backend_evidence="Domain sync contracts with namespace, conflict, delete, provenance, and tests.",
+    ),
+    DeferredClaim(
+        claim="remote_auth_config_transparent_admin",
+        status="blocked",
+        required_backend_evidence="Explicit remote-admin policy and permission model.",
+    ),
+    DeferredClaim(
+        claim="remote_microphone_live_listening",
+        status="privacy-blocked",
+        required_backend_evidence="Consent contract, privacy indicator events, capacity checks, and stream state.",
+    ),
+    DeferredClaim(
+        claim="remote_playback_without_target",
+        status="privacy-blocked",
+        required_backend_evidence="Explicit peer/device selector, confirmation, and backend playback state.",
+    ),
+    DeferredClaim(
+        claim="dangerous_remote_tool_auto_binding",
+        status="blocked",
+        required_backend_evidence="Explicit confirmation/resource approval flow and backend decision event.",
+    ),
+    DeferredClaim(
+        claim="pairing_success_from_presence",
+        status="blocked",
+        required_backend_evidence="Authenticated bilateral trust, manifest negotiation, and stable peer identity.",
+    ),
+    DeferredClaim(
+        claim="tauri_e2e_from_browser_tests",
+        status="blocked",
+        required_backend_evidence="Native Tauri shell plus backend/native/WebRTC verification harness.",
+    ),
+)
+
+
+def normalize_mesh_status(payload: GetMeshStatusResponse | dict[str, Any]) -> MeshStatusView:
+    """Normalize Gateway.GetMeshStatus into UI-safe status summaries."""
+
+    status = _model(payload, GetMeshStatusResponse)
+    return MeshStatusView(
+        local_peer_id=status.local.peer_id,
+        local_node_name=status.local.node_name,
+        mesh_enabled=status.local.mesh_enabled,
+        mesh_started=status.local.mesh_started,
+        webrtc_started=status.local.webrtc_started,
+        peers=[
+            PeerSummary(
+                peer_id=peer.peer_id,
+                node_name=peer.node_name,
+                lifecycle_state=_peer_lifecycle_state(
+                    peer.status,
+                    peer.last_ping_age_s,
+                    peer.last_manifest_age_s,
+                ),
+                trust_state="backend-proven"
+                if peer.status in {"authenticated", "negotiated", "connected"}
+                else "pending",
+                connection_status=peer.status,
+                latency_ms=peer.latency_ms,
+                stale_age_s=peer.last_manifest_age_s if peer.status == "stale" else None,
+                service_count=len(peer.services),
+                last_evidence_source="Gateway.GetMeshStatus",
+                reason_codes=_peer_reason_codes(peer.status),
+            )
+            for peer in status.peers
+        ],
+        routes=[_route_summary(route) for route in status.routes],
+        compatibility_failures=[failure.model_dump() for failure in status.compatibility_failures],
+        secrets_redacted=status.secrets_redacted,
+    )
+
+
+def normalize_auth_peers(
+    payload: MeshPeerListResponse | list[MeshPeerInfo] | dict[str, Any],
+) -> list[PeerSummary]:
+    """Normalize Auth mesh peer trust records."""
+
+    if isinstance(payload, dict):
+        peers = MeshPeerListResponse.model_validate(payload).peers
+    elif isinstance(payload, MeshPeerListResponse):
+        peers = payload.peers
+    else:
+        peers = payload
+    return [_auth_peer_summary(peer) for peer in peers]
+
+
+def normalize_capability_graph(payload: CapabilityGraph | dict[str, Any]) -> CapabilityGraphView:
+    """Normalize Gateway.GetCapabilityGraph for capability/status screens."""
+
+    graph = _model(payload, CapabilityGraph)
+    capabilities: list[CapabilitySummary] = []
+    for service in graph.services:
+        capabilities.append(_service_capability(service))
+        for method in service.methods:
+            capabilities.append(
+                CapabilitySummary(
+                    capability_id=method.method_id,
+                    kind="method",
+                    module=method.module,
+                    service_instance_id=service.service_instance_id,
+                    provider_peer_id=method.address.peer_id,
+                    method=method.name,
+                    selector=_selector_from_address(method.address.model_dump()),
+                    availability=_policy_availability(
+                        method.policy,
+                        service.routable,
+                        service.route_blockers,
+                    ),
+                    policy_flags=_policy_flags(method.policy),
+                    blockers=_policy_blockers(method.policy, service.route_blockers),
+                    provenance=method.provenance.model_dump(),
+                )
+            )
+    for resource in graph.resources:
+        capabilities.append(
+            CapabilitySummary(
+                capability_id=resource.resource_id,
+                kind="resource",
+                module=resource.address.module,
+                service_instance_id=resource.service_instance_id,
+                provider_peer_id=resource.owner_peer_id,
+                resource_id=resource.resource_id,
+                selector=_selector_from_address(resource.address.model_dump()),
+                availability=_policy_availability(resource.policy, True, []),
+                policy_flags=_policy_flags(resource.policy),
+                blockers=_policy_blockers(resource.policy, []),
+                provenance=resource.provenance.model_dump(),
+            )
+        )
+    return CapabilityGraphView(
+        local_peer_id=graph.local_peer_id,
+        local_node_name=graph.local_node_name,
+        capabilities=capabilities,
+        provider_index=graph.provider_index,
+        candidate_provider_index=graph.candidate_provider_index,
+        deferred_claims=list(DEFERRED_CLAIMS),
+        secrets_redacted=graph.secrets_redacted,
+    )
+
+
+def normalize_tools(payload: ToolingGetToolsResponse | dict[str, Any]) -> list[ToolSummary]:
+    """Normalize Tooling.GetTools metadata."""
+
+    response = _model(payload, ToolingGetToolsResponse)
+    return [_tool_summary(tool) for tool in response.tools]
+
+
+def normalize_tool_execution(
+    payload: ToolingExecuteToolResponse | dict[str, Any],
+) -> ToolExecutionSummary:
+    """Normalize Tooling.ExecuteTool response without exposing result payloads."""
+
+    response = _model(payload, ToolingExecuteToolResponse)
+    availability = _execution_availability(response.status, response.error_code, response.ok)
+    return ToolExecutionSummary(
+        ok=response.ok,
+        status=response.status,
+        availability=availability,
+        error_code=response.error_code,
+        error=response.error,
+        provider_peer_id=response.provider_peer_id,
+        global_tool_id=response.global_tool_id,
+        audit=AuditReference(
+            correlation_id=response.correlation_id,
+            event_kind="Tooling.ExecuteTool",
+            peer_id=response.provider_peer_id,
+            tool_id=response.global_tool_id,
+            status=response.status,
+        ),
+    )
+
+
+def normalize_scheduler_jobs(
+    payload: SchedulerListJobsResponse | list[SchedulerJobInfo] | dict[str, Any],
+) -> list[SchedulerJobSummary]:
+    """Normalize Scheduler.ListJobs ownership/delegation fields."""
+
+    if isinstance(payload, dict):
+        jobs = SchedulerListJobsResponse.model_validate(payload).jobs
+    elif isinstance(payload, SchedulerListJobsResponse):
+        jobs = payload.jobs
+    else:
+        jobs = payload
+    return [
+        SchedulerJobSummary(
+            job_id=job.job_id,
+            name=job.name,
+            namespace=job.namespace,
+            owner_peer_id=job.owner_peer_id,
+            owner_principal_id=job.owner_principal_id,
+            target_selector=MeshAddressSelector(
+                peer_id=job.target_peer_id,
+                resource_namespace=job.target_resource_namespace,
+            )
+            if job.target_peer_id or job.target_resource_namespace
+            else None,
+            delegated_permissions=job.delegated_permissions,
+            policy_decision_id=job.policy_decision_id,
+            availability="available-remote" if job.target_peer_id else "available-local",
+            audit=AuditReference(
+                correlation_id=job.correlation_id,
+                event_kind="Scheduler.Job",
+                peer_id=job.target_peer_id or job.owner_peer_id,
+                status=job.status,
+            ),
+        )
+        for job in jobs
+    ]
+
+
+def normalize_audit_events(events: list[dict[str, Any]]) -> list[AuditReference]:
+    """Normalize Auth audit rows and redact details."""
+
+    return [_audit_reference(event) for event in events]
+
+
+def _model(payload: BaseModel | dict[str, Any], model_type: type[BaseModel]) -> Any:
+    if isinstance(payload, model_type):
+        return payload
+    return model_type.model_validate(payload)
+
+
+def _route_summary(route: MeshRouteDiagnostic) -> RouteSummary:
+    reason_codes = [provider.reason_code for provider in route.providers if provider.reason_code]
+    fallback_used = (
+        route.decision_target == "local"
+        and route.prefer.startswith("network")
+        and route.fallback == "local"
+    )
+    return RouteSummary(
+        module=route.module,
+        availability=_route_availability(route, fallback_used),
+        decision_target=route.decision_target,
+        provider_peer_id=route.decision_peer_id,
+        reason=route.reason,
+        fallback=route.fallback,
+        fallback_used=fallback_used,
+        provider_candidates=[
+            {
+                "peer_id": provider.peer_id,
+                "node_name": provider.node_name,
+                "eligible": provider.eligible,
+                "reason_code": provider.reason_code,
+                "reason": provider.reason,
+            }
+            for provider in route.providers
+        ],
+        reason_codes=reason_codes,
+    )
+
+
+def _route_availability(route: MeshRouteDiagnostic, fallback_used: bool) -> AvailabilityState:
+    if route.decision_target == "remote":
+        return "available-remote"
+    if route.decision_target == "local":
+        return "degraded" if fallback_used else "available-local"
+    if route.decision_target == "none":
+        return "no-route"
+    return "hard-failure"
+
+
+def _peer_lifecycle_state(status: str, ping_age: float | None, manifest_age: float | None) -> str:
+    if status == "stale" or (manifest_age is not None and manifest_age > 120):
+        return "stale"
+    if status == "denied":
+        return "denied"
+    if status in {"pending", "connecting"}:
+        return "pending"
+    if status in {"error", "failed"}:
+        return "hard-failure"
+    if ping_age is not None and ping_age > 60:
+        return "degraded"
+    return "backend-proven"
+
+
+def _peer_reason_codes(status: str) -> list[str]:
+    if status in {"stale", "denied", "pending", "error", "failed"}:
+        return [status]
+    return []
+
+
+def _auth_peer_summary(peer: MeshPeerInfo) -> PeerSummary:
+    trust_state = _trust_state(peer.outbound_status, peer.inbound_status)
+    return PeerSummary(
+        peer_id=peer.peer_id,
+        node_name=peer.node_name,
+        lifecycle_state="backend-proven" if peer.connection_status == "connected" else "degraded",
+        trust_state=trust_state,
+        connection_status=peer.connection_status,
+        outbound_status=peer.outbound_status,
+        inbound_status=peer.inbound_status,
+        last_evidence_source="Auth.MeshListPeers",
+        reason_codes=[
+            state
+            for state in (peer.outbound_status, peer.inbound_status)
+            if state in {"pending", "denied"}
+        ],
+    )
+
+
+def _trust_state(outbound: str, inbound: str) -> str:
+    if "denied" in {outbound, inbound}:
+        return "denied"
+    if outbound == "approved" and inbound == "approved":
+        return "backend-proven"
+    if "pending" in {outbound, inbound} or "unknown" in {outbound, inbound}:
+        return "pending"
+    return "degraded"
+
+
+def _service_capability(service: CapabilityServiceInfo) -> CapabilitySummary:
+    return CapabilitySummary(
+        capability_id=service.service_instance_id,
+        kind="service",
+        module=service.module,
+        service_instance_id=service.service_instance_id,
+        provider_peer_id=service.peer_id,
+        selector=_selector_from_address(service.address.model_dump()),
+        availability=_policy_availability(service.policy, service.routable, service.route_blockers),
+        policy_flags=_policy_flags(service.policy),
+        blockers=_policy_blockers(service.policy, service.route_blockers),
+        provenance=service.provenance.model_dump(),
+    )
+
+
+def _policy_flags(policy: CapabilityPolicyInfo) -> dict[str, bool]:
+    return {
+        "explicit_selector_required": policy.explicit_selector_required,
+        "confirmation_required": policy.confirmation_required,
+        "consent_required": policy.consent_required,
+        "privacy_indicator_required": policy.privacy_indicator_required,
+        "bandwidth_check_required": policy.bandwidth_check_required,
+        "local_only": policy.local_only,
+    }
+
+
+def _policy_blockers(policy: CapabilityPolicyInfo, route_blockers: list[str]) -> list[str]:
+    blockers = list(route_blockers)
+    for field, required in _policy_flags(policy).items():
+        if required and field != "local_only":
+            blockers.append(field)
+    if policy.local_only:
+        blockers.append("local_only")
+    return blockers
+
+
+def _policy_availability(
+    policy: CapabilityPolicyInfo,
+    routable: bool,
+    route_blockers: list[str],
+) -> AvailabilityState:
+    if "stale" in route_blockers or "peer_stale" in route_blockers:
+        return "stale"
+    if any("denied" in blocker or "unauthorized" in blocker for blocker in route_blockers):
+        return "denied"
+    if policy.consent_required or policy.privacy_indicator_required:
+        return "privacy-blocked"
+    if policy.explicit_selector_required or policy.confirmation_required:
+        return "pending"
+    if not routable:
+        return "no-route"
+    return "available-local" if policy.local_only else "available-remote"
+
+
+def _tool_summary(tool: ToolingToolInfo) -> ToolSummary:
+    policy_flags = {
+        "confirmation_required": tool.confirmation_required,
+        "explicit_selector_required": tool.execution_location == "remote",
+        "resource_selector_required": tool.safety_class in {"sensitive", "dangerous"},
+    }
+    blockers = [
+        field
+        for field, required in policy_flags.items()
+        if required and field != "explicit_selector_required"
+    ]
+    availability: AvailabilityState = "available-local"
+    if tool.execution_location == "remote":
+        availability = "pending" if blockers else "available-remote"
+    return ToolSummary(
+        name=tool.name,
+        display_name=tool.display_name,
+        global_tool_id=tool.global_tool_id,
+        provider_peer_id=tool.provider_peer_id,
+        provider_service_instance_id=tool.provider_service_instance_id,
+        execution_location=tool.execution_location,
+        source_type=tool.source_type,
+        safety_class=tool.safety_class,
+        required_permissions=tool.required_permissions,
+        confirmation_required=tool.confirmation_required,
+        availability=availability,
+        preflight=RemoteActionPreflight(
+            target_selector=MeshAddressSelector(
+                peer_id=tool.provider_peer_id,
+                service_instance_id=tool.provider_service_instance_id,
+                tool_id=tool.global_tool_id,
+            ),
+            policy_flags=policy_flags,
+            required_fields=blockers,
+            availability=availability,
+            blockers=blockers,
+            expected_audit_fields=["correlation_id", "peer_id", "tool_id", "status"],
+        )
+        if tool.execution_location == "remote"
+        else None,
+    )
+
+
+def _execution_availability(
+    status: str | None, error_code: str | None, ok: bool
+) -> AvailabilityState:
+    if ok and status in {"success", "dry_run"}:
+        return "available-remote"
+    if status == "denied" or (error_code and "denied" in error_code):
+        return "denied"
+    if error_code in {"no_route", "network_no_provider"}:
+        return "no-route"
+    if error_code in {"privacy_blocked", "consent_required", "confirmation_missing"}:
+        return "privacy-blocked"
+    return "hard-failure"
+
+
+def _selector_from_address(address: dict[str, Any]) -> MeshAddressSelector:
+    return MeshAddressSelector(
+        peer_id=address.get("peer_id"),
+        service_instance_id=address.get("service_instance_id"),
+        resource_namespace=address.get("namespace"),
+        tool_id=address.get("tool_id"),
+    )
+
+
+def _audit_reference(event: dict[str, Any]) -> AuditReference:
+    details = _parse_details(event.get("details"))
+    return AuditReference(
+        correlation_id=event.get("correlation_id") or details.get("correlation_id"),
+        event_kind=str(event.get("event") or event.get("event_kind") or ""),
+        peer_id=event.get("peer_id") or details.get("peer_id") or details.get("target_peer_id"),
+        method=details.get("method"),
+        tool_id=details.get("tool_id") or details.get("global_tool_id"),
+        resource_id=details.get("resource_id"),
+        status=event.get("status") or details.get("status"),
+        details_redacted=redact_sensitive(details),
+    )
+
+
+def _parse_details(details: Any) -> dict[str, Any]:
+    if isinstance(details, dict):
+        return details
+    if isinstance(details, str) and details:
+        try:
+            parsed = json.loads(details)
+        except json.JSONDecodeError:
+            return {"message": details}
+        return parsed if isinstance(parsed, dict) else {"value": parsed}
+    return {}

--- a/app/ui/sdk/models.py
+++ b/app/ui/sdk/models.py
@@ -1,0 +1,188 @@
+"""Stable view models for future Aurora UI surfaces."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from app.shared.contracts.models.mesh import MeshAddressSelector
+
+EvidenceState = Literal[
+    "backend-proven",
+    "pending",
+    "denied",
+    "degraded",
+    "stale",
+    "privacy-blocked",
+    "deferred",
+    "no-route",
+    "hard-failure",
+]
+
+AvailabilityState = Literal[
+    "available-local",
+    "available-remote",
+    "pending",
+    "denied",
+    "degraded",
+    "stale",
+    "privacy-blocked",
+    "unsupported",
+    "no-route",
+    "hard-failure",
+]
+
+
+class AuditReference(BaseModel):
+    """Copyable audit/tracing reference with redacted details only."""
+
+    correlation_id: str | None = None
+    event_kind: str = ""
+    peer_id: str | None = None
+    method: str | None = None
+    tool_id: str | None = None
+    resource_id: str | None = None
+    status: str | None = None
+    details_redacted: dict[str, Any] = Field(default_factory=dict)
+
+
+class PeerSummary(BaseModel):
+    """UI-safe mesh peer status from Gateway diagnostics and/or Auth peer state."""
+
+    peer_id: str
+    node_name: str = ""
+    lifecycle_state: EvidenceState = "backend-proven"
+    trust_state: EvidenceState = "pending"
+    connection_status: str = "unknown"
+    outbound_status: str | None = None
+    inbound_status: str | None = None
+    latency_ms: float | None = None
+    stale_age_s: float | None = None
+    service_count: int = 0
+    last_evidence_source: str = "unknown"
+    reason_codes: list[str] = Field(default_factory=list)
+
+
+class RouteSummary(BaseModel):
+    """Normalized route decision and provider eligibility diagnostics."""
+
+    module: str
+    availability: AvailabilityState
+    decision_target: str = "none"
+    provider_peer_id: str | None = None
+    reason: str = ""
+    fallback: str = ""
+    fallback_used: bool = False
+    provider_candidates: list[dict[str, Any]] = Field(default_factory=list)
+    reason_codes: list[str] = Field(default_factory=list)
+
+
+class CapabilitySummary(BaseModel):
+    """Normalized service, method, or resource capability."""
+
+    capability_id: str
+    kind: Literal["service", "method", "resource"]
+    module: str | None = None
+    service_instance_id: str | None = None
+    provider_peer_id: str
+    method: str | None = None
+    resource_id: str | None = None
+    selector: MeshAddressSelector | None = None
+    availability: AvailabilityState
+    policy_flags: dict[str, bool] = Field(default_factory=dict)
+    blockers: list[str] = Field(default_factory=list)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+
+
+class RemoteActionPreflight(BaseModel):
+    """Reusable preflight data for remote actions before any execution UI."""
+
+    target_selector: MeshAddressSelector | None = None
+    policy_flags: dict[str, bool] = Field(default_factory=dict)
+    required_fields: list[str] = Field(default_factory=list)
+    availability: AvailabilityState = "pending"
+    blockers: list[str] = Field(default_factory=list)
+    expected_audit_fields: list[str] = Field(
+        default_factory=lambda: ["correlation_id", "peer_id", "status"]
+    )
+    argument_summary: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolSummary(BaseModel):
+    """UI-safe Tooling discovery metadata."""
+
+    name: str
+    display_name: str
+    global_tool_id: str
+    provider_peer_id: str
+    provider_service_instance_id: str
+    execution_location: Literal["local", "remote"]
+    source_type: str
+    safety_class: str
+    required_permissions: list[str] = Field(default_factory=list)
+    confirmation_required: bool = False
+    availability: AvailabilityState
+    preflight: RemoteActionPreflight | None = None
+
+
+class ToolExecutionSummary(BaseModel):
+    """UI-safe Tooling execution result."""
+
+    ok: bool
+    status: str | None = None
+    availability: AvailabilityState
+    error_code: str | None = None
+    error: str | None = None
+    provider_peer_id: str | None = None
+    global_tool_id: str | None = None
+    audit: AuditReference = Field(default_factory=AuditReference)
+
+
+class SchedulerJobSummary(BaseModel):
+    """Ownership-aware scheduler job view."""
+
+    job_id: str
+    name: str
+    namespace: str
+    owner_peer_id: str
+    owner_principal_id: str
+    target_selector: MeshAddressSelector | None = None
+    delegated_permissions: list[str] = Field(default_factory=list)
+    policy_decision_id: str | None = None
+    availability: AvailabilityState = "available-local"
+    audit: AuditReference = Field(default_factory=AuditReference)
+
+
+class DeferredClaim(BaseModel):
+    """Backend gap surfaced as explicitly blocked/deferred, not available."""
+
+    claim: str
+    status: Literal["blocked", "deferred", "privacy-blocked", "unsupported"]
+    required_backend_evidence: str
+
+
+class MeshStatusView(BaseModel):
+    """Normalized mesh status payload for future status/diagnostics screens."""
+
+    local_peer_id: str | None = None
+    local_node_name: str = ""
+    mesh_enabled: bool = False
+    mesh_started: bool = False
+    webrtc_started: bool = False
+    peers: list[PeerSummary] = Field(default_factory=list)
+    routes: list[RouteSummary] = Field(default_factory=list)
+    compatibility_failures: list[dict[str, Any]] = Field(default_factory=list)
+    secrets_redacted: bool = True
+
+
+class CapabilityGraphView(BaseModel):
+    """Normalized capability graph plus blocked/deferred backend gaps."""
+
+    local_peer_id: str | None = None
+    local_node_name: str = ""
+    capabilities: list[CapabilitySummary] = Field(default_factory=list)
+    provider_index: dict[str, list[str]] = Field(default_factory=dict)
+    candidate_provider_index: dict[str, list[str]] = Field(default_factory=dict)
+    deferred_claims: list[DeferredClaim] = Field(default_factory=list)
+    secrets_redacted: bool = True

--- a/app/ui/sdk/redaction.py
+++ b/app/ui/sdk/redaction.py
@@ -1,0 +1,60 @@
+"""Redaction helpers shared by UI SDK adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+SENSITIVE_KEY_FRAGMENTS = (
+    "api_key",
+    "apikey",
+    "argument",
+    "authorization",
+    "broker_secret",
+    "cookie",
+    "credential",
+    "inbound_token",
+    "mesh_secret",
+    "password",
+    "raw_sql",
+    "refresh_token",
+    "room_password",
+    "secret",
+    "token",
+)
+
+MASK = "<redacted>"
+
+
+def is_sensitive_key(key: str) -> bool:
+    """Return True when a field name should never be rendered raw."""
+
+    normalized = key.lower().replace("-", "_")
+    return any(fragment in normalized for fragment in SENSITIVE_KEY_FRAGMENTS)
+
+
+def redact_sensitive(value: Any) -> Any:
+    """Recursively redact secret-like fields while preserving structure."""
+
+    if isinstance(value, Mapping):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_str = str(key)
+            redacted[key_str] = MASK if is_sensitive_key(key_str) else redact_sensitive(item)
+        return redacted
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        return [redact_sensitive(item) for item in value]
+    return value
+
+
+def summarize_arguments(arguments: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return argument metadata without exposing any raw argument values."""
+
+    if not arguments:
+        return {"argument_keys": [], "redacted_arguments": {}}
+    return {
+        "argument_keys": sorted(str(key) for key in arguments),
+        "redacted_arguments": {str(key): MASK for key in arguments},
+    }

--- a/tests/unit/ui/test_sdk_adapters.py
+++ b/tests/unit/ui/test_sdk_adapters.py
@@ -1,0 +1,339 @@
+"""Fixture tests for the UI SDK typed adapters."""
+
+from app.shared.contracts.models.gateway import (
+    CapabilityAddressInfo,
+    CapabilityGraph,
+    CapabilityMethodInfo,
+    CapabilityPolicyInfo,
+    CapabilityProvenanceInfo,
+    CapabilityServiceInfo,
+    GetMeshStatusResponse,
+    MeshLocalStatus,
+    MeshPeerDiagnostic,
+    MeshRouteDiagnostic,
+    MeshRouteProviderDiagnostic,
+)
+from app.shared.contracts.models.mesh import MeshPeerInfo, MeshPeerListResponse
+from app.shared.contracts.models.scheduler import SchedulerJobInfo, SchedulerListJobsResponse
+from app.shared.contracts.models.tooling import (
+    ToolingExecuteToolResponse,
+    ToolingGetToolsResponse,
+    ToolingToolInfo,
+    ToolingToolProvenance,
+)
+from app.ui.sdk import (
+    normalize_audit_events,
+    normalize_auth_peers,
+    normalize_capability_graph,
+    normalize_mesh_status,
+    normalize_scheduler_jobs,
+    normalize_tool_execution,
+    normalize_tools,
+    redact_sensitive,
+    summarize_arguments,
+)
+
+
+def test_mesh_status_normalizes_route_reason_codes_and_redaction_flag():
+    status = GetMeshStatusResponse(
+        local=MeshLocalStatus(
+            mesh_enabled=True,
+            mesh_started=True,
+            webrtc_started=True,
+            peer_id="local-peer",
+            node_name="desktop",
+        ),
+        peers=[
+            MeshPeerDiagnostic(
+                peer_id="peer-ok", node_name="lab", status="connected", latency_ms=12.0
+            ),
+            MeshPeerDiagnostic(
+                peer_id="peer-stale",
+                node_name="old",
+                status="stale",
+                last_manifest_age_s=500.0,
+            ),
+        ],
+        routes=[
+            MeshRouteDiagnostic(
+                module="Tooling",
+                prefer="network",
+                fallback="local",
+                decision_target="remote",
+                decision_peer_id="peer-ok",
+                providers=[
+                    MeshRouteProviderDiagnostic(
+                        peer_id="peer-ok",
+                        eligible=True,
+                        reason_code="eligible",
+                    ),
+                    MeshRouteProviderDiagnostic(
+                        peer_id="peer-stale",
+                        eligible=False,
+                        reason_code="stale",
+                        reason="manifest too old",
+                    ),
+                ],
+            ),
+            MeshRouteDiagnostic(
+                module="DB",
+                prefer="network_only",
+                fallback="error",
+                decision_target="none",
+                reason="no eligible provider",
+            ),
+        ],
+        secrets_redacted=True,
+    )
+
+    view = normalize_mesh_status(status)
+
+    assert view.local_peer_id == "local-peer"
+    assert view.secrets_redacted is True
+    assert {peer.peer_id: peer.lifecycle_state for peer in view.peers}["peer-stale"] == "stale"
+    tooling = next(route for route in view.routes if route.module == "Tooling")
+    assert tooling.availability == "available-remote"
+    assert tooling.provider_peer_id == "peer-ok"
+    assert "stale" in tooling.reason_codes
+    db = next(route for route in view.routes if route.module == "DB")
+    assert db.availability == "no-route"
+
+
+def test_auth_peer_state_preserves_bilateral_pending_denied_without_pairing_claim():
+    peers = MeshPeerListResponse(
+        peers=[
+            MeshPeerInfo(
+                id="1",
+                peer_id="peer-pending",
+                node_name="pending",
+                outbound_status="approved",
+                inbound_status="pending",
+                connection_status="connected",
+            ),
+            MeshPeerInfo(
+                id="2",
+                peer_id="peer-denied",
+                node_name="denied",
+                outbound_status="denied",
+                inbound_status="approved",
+                connection_status="connected",
+            ),
+        ],
+        total=2,
+    )
+
+    summaries = {peer.peer_id: peer for peer in normalize_auth_peers(peers)}
+
+    assert summaries["peer-pending"].trust_state == "pending"
+    assert summaries["peer-denied"].trust_state == "denied"
+    assert summaries["peer-pending"].last_evidence_source == "Auth.MeshListPeers"
+
+
+def test_capability_graph_covers_privacy_blocked_pending_denied_stale_and_deferred_claims():
+    graph = CapabilityGraph(
+        local_peer_id="local-peer",
+        local_node_name="desktop",
+        services=[
+            _service("local:local-peer:Tooling", "local-peer", local_only=True, routable=True),
+            _service("remote:peer-ok:Tooling", "peer-ok", routable=True),
+            _service("remote:peer-stale:TTS", "peer-stale", module="TTS", route_blockers=["stale"]),
+            _service(
+                "remote:peer-denied:DB",
+                "peer-denied",
+                module="DB",
+                route_blockers=["permission_denied"],
+            ),
+            _service(
+                "remote:peer-audio:WakeWord",
+                "peer-audio",
+                module="WakeWord",
+                policy=CapabilityPolicyInfo(consent_required=True, privacy_indicator_required=True),
+                routable=True,
+            ),
+            _service(
+                "remote:peer-tool:Tooling",
+                "peer-tool",
+                policy=CapabilityPolicyInfo(
+                    explicit_selector_required=True, confirmation_required=True
+                ),
+                routable=True,
+            ),
+        ],
+        provider_index={"Tooling": ["local:local-peer:Tooling", "remote:peer-ok:Tooling"]},
+        candidate_provider_index={
+            "Tooling": [
+                "local:local-peer:Tooling",
+                "remote:peer-ok:Tooling",
+                "remote:peer-tool:Tooling",
+            ]
+        },
+        secrets_redacted=True,
+    )
+
+    view = normalize_capability_graph(graph)
+    by_id = {cap.capability_id: cap for cap in view.capabilities if cap.kind == "service"}
+
+    assert by_id["local:local-peer:Tooling"].availability == "available-local"
+    assert by_id["remote:peer-ok:Tooling"].availability == "available-remote"
+    assert by_id["remote:peer-stale:TTS"].availability == "stale"
+    assert by_id["remote:peer-denied:DB"].availability == "denied"
+    assert by_id["remote:peer-audio:WakeWord"].availability == "privacy-blocked"
+    assert by_id["remote:peer-tool:Tooling"].availability == "pending"
+    assert "confirmation_required" in by_id["remote:peer-tool:Tooling"].blockers
+    assert any(
+        claim.claim == "raw_sql_across_peers" and claim.status == "blocked"
+        for claim in view.deferred_claims
+    )
+    assert any(
+        claim.claim == "remote_microphone_live_listening" and claim.status == "privacy-blocked"
+        for claim in view.deferred_claims
+    )
+
+
+def test_tooling_discovery_execution_and_argument_redaction():
+    response = ToolingGetToolsResponse(
+        tools=[
+            ToolingToolInfo(
+                name="raspi_lamp_on",
+                local_name="lamp_on",
+                global_tool_id="raspi:tool:lamp_on",
+                provider_peer_id="raspi",
+                provider_service_instance_id="remote:raspi:Tooling",
+                namespace="raspi",
+                display_name="raspi.lamp_on",
+                source_type="mesh_peer",
+                execution_location="remote",
+                safety_class="dangerous",
+                required_permissions=["Tooling.ExecuteTool"],
+                confirmation_required=True,
+                provenance=ToolingToolProvenance(
+                    provider_peer_id="raspi",
+                    provider_service_instance_id="remote:raspi:Tooling",
+                    provider_kind="mesh_peer",
+                    source="core",
+                    advertised_name="lamp_on",
+                ),
+            )
+        ],
+        count=1,
+    )
+
+    tool = normalize_tools(response)[0]
+    assert tool.availability == "pending"
+    assert tool.preflight is not None
+    assert tool.preflight.target_selector.peer_id == "raspi"
+    assert "confirmation_required" in tool.preflight.required_fields
+
+    execution = normalize_tool_execution(
+        ToolingExecuteToolResponse(
+            ok=False,
+            status="denied",
+            error_code="permission_denied",
+            correlation_id="corr-1",
+            provider_peer_id="raspi",
+            global_tool_id="raspi:tool:lamp_on",
+        )
+    )
+    assert execution.availability == "denied"
+    assert execution.audit.correlation_id == "corr-1"
+    assert summarize_arguments({"target": "lamp", "token": "secret"}) == {
+        "argument_keys": ["target", "token"],
+        "redacted_arguments": {"target": "<redacted>", "token": "<redacted>"},
+    }
+
+
+def test_scheduler_ownership_and_audit_references_are_normalized():
+    jobs = SchedulerListJobsResponse(
+        jobs=[
+            SchedulerJobInfo(
+                job_id="job-1",
+                name="remote cleanup",
+                schedule="0 * * * *",
+                action="Tooling.ExecuteTool",
+                enabled=True,
+                namespace="lab",
+                owner_peer_id="desktop",
+                owner_principal_id="admin",
+                target_peer_id="raspi",
+                target_resource_namespace="bench",
+                delegated_permissions=["Tooling.ExecuteTool"],
+                policy_decision_id="policy-1",
+                correlation_id="corr-scheduler",
+            )
+        ],
+        total=1,
+    )
+
+    job = normalize_scheduler_jobs(jobs)[0]
+
+    assert job.availability == "available-remote"
+    assert job.target_selector.peer_id == "raspi"
+    assert job.target_selector.resource_namespace == "bench"
+    assert job.audit.correlation_id == "corr-scheduler"
+
+
+def test_audit_and_redaction_never_surface_secret_or_raw_argument_values():
+    references = normalize_audit_events(
+        [
+            {
+                "event": "tool.execute",
+                "details": (
+                    '{"correlation_id":"corr-2","peer_id":"raspi",'
+                    '"arguments":{"target":"lamp"},"token":"abc","api_key":"key"}'
+                ),
+            }
+        ]
+    )
+
+    details = references[0].details_redacted
+    assert references[0].correlation_id == "corr-2"
+    assert details["token"] == "<redacted>"
+    assert details["api_key"] == "<redacted>"
+    assert details["arguments"] == "<redacted>"
+    assert "lamp" not in str(details)
+    assert redact_sensitive({"password": "pw", "safe": "value"}) == {
+        "password": "<redacted>",
+        "safe": "value",
+    }
+
+
+def _service(
+    service_instance_id: str,
+    peer_id: str,
+    module: str = "Tooling",
+    policy: CapabilityPolicyInfo | None = None,
+    route_blockers: list[str] | None = None,
+    routable: bool = False,
+    local_only: bool = False,
+) -> CapabilityServiceInfo:
+    policy = policy or CapabilityPolicyInfo(local_only=local_only)
+    return CapabilityServiceInfo(
+        service_instance_id=service_instance_id,
+        peer_id=peer_id,
+        provider_kind="local" if peer_id == "local-peer" else "remote",
+        module=module,
+        routable=routable,
+        route_blockers=route_blockers or [],
+        policy=policy,
+        address=CapabilityAddressInfo(
+            peer_id=peer_id,
+            module=module,
+            service_instance_id=service_instance_id,
+        ),
+        provenance=CapabilityProvenanceInfo(source="fixture", peer_id=peer_id),
+        methods=[
+            CapabilityMethodInfo(
+                method_id=f"{module}.Run",
+                module=module,
+                name="Run",
+                policy=policy,
+                address=CapabilityAddressInfo(
+                    peer_id=peer_id,
+                    module=module,
+                    service_instance_id=service_instance_id,
+                    method="Run",
+                ),
+                provenance=CapabilityProvenanceInfo(source="fixture", peer_id=peer_id),
+            )
+        ],
+    )


### PR DESCRIPTION
## Summary
- Add a typed `app.ui.sdk` shell with pure adapters for Gateway mesh status, capability graph, Auth mesh peers, Tooling discovery/execution, scheduler ownership, and audit references.
- Normalize backend-proven availability states including pending, denied, degraded, stale, privacy-blocked, no-route, hard-failure, and blocked/deferred backend-gap claims.
- Add redaction helpers so secrets and raw tool arguments are not surfaced by SDK summaries.
- Make `app.ui` import the optional PyQt `UIBridge` lazily so headless SDK imports do not require PyQt6.

## Validation
- `.venv/bin/python -m pytest tests/unit/ui/test_sdk_adapters.py`
- `.venv/bin/ruff check app/ui/__init__.py app/ui/sdk/__init__.py app/ui/sdk/models.py app/ui/sdk/redaction.py app/ui/sdk/adapters.py tests/unit/ui/test_sdk_adapters.py`
- Contract consistency import check against Gateway/Auth/Mesh/Tooling/Scheduler model constants.

## Notes
- No production UI screens, Tauri shell, or remote action execution UI were added.
- Existing dirty `tests/test_scheduler.db` was left unstaged.
