### PR TITLE
[PER-155] Add Gateway capability catalog contracts

### DIFF
--- a/app/services/gateway/mesh/capability_catalog.py
+++ b/app/services/gateway/mesh/capability_catalog.py
@@ -217,8 +217,8 @@ def _action_from_method(
     policy = _policy_decision(method.policy, service.route_blockers)
     selector = MeshAddressSelector(
         peer_id=service.peer_id,
-        provider_id=service.peer_id,
-        service_instance_id=f"{service.peer_id}:{service.module}",
+        provider_id=service.service_instance_id,
+        service_instance_id=service.service_instance_id,
     )
     return CapabilityActionInfo(
         action_id=method.method_id,

--- a/app/services/gateway/mesh/capability_catalog.py
+++ b/app/services/gateway/mesh/capability_catalog.py
@@ -1,0 +1,510 @@
+"""Product-facing capability catalog and route explanation projections."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime
+from typing import Any
+
+from app.shared.contracts.models.gateway import (
+    CapabilityActionInfo,
+    CapabilityCatalogRequest,
+    CapabilityCatalogResourceInfo,
+    CapabilityCatalogResponse,
+    CapabilityFreshnessInfo,
+    CapabilityMethodInfo,
+    CapabilityPolicyDecisionInfo,
+    CapabilityPolicyInfo,
+    CapabilityProviderInfo,
+    CapabilityResourceInfo,
+    CapabilityServiceInfo,
+    RouteBlockerInfo,
+    RouteCandidateDecision,
+    RouteExplainRequest,
+    RouteExplainResponse,
+    ServiceAnnouncement,
+)
+from app.shared.contracts.models.mesh import MeshAddressSelector
+
+from .capability_graph import build_capability_graph
+
+_REDACTED_SCHEMA_KEYS = {
+    "api_key",
+    "apikey",
+    "credential",
+    "embedding",
+    "file_path",
+    "password",
+    "path",
+    "private_key",
+    "secret",
+    "token",
+}
+
+
+def build_capability_catalog(
+    *,
+    request: CapabilityCatalogRequest,
+    mesh_config: Any,
+    local_services: dict[str, ServiceAnnouncement] | None = None,
+    peers: list[Any] | None = None,
+    local_peer_id: str | None = None,
+) -> CapabilityCatalogResponse:
+    graph = build_capability_graph(
+        mesh_config=mesh_config,
+        local_services=local_services,
+        peers=peers,
+        local_peer_id=local_peer_id,
+    )
+    module_filter = set(request.modules or [])
+    providers: list[CapabilityProviderInfo] = []
+    actions: list[CapabilityActionInfo] = []
+    resources: list[CapabilityCatalogResourceInfo] = []
+    provider_index: dict[str, list[str]] = {}
+    action_index: dict[str, list[str]] = {}
+
+    for service in graph.services:
+        if module_filter and service.module not in module_filter:
+            continue
+        if not request.include_unavailable and not service.routable:
+            continue
+        provider = _provider_from_service(service)
+        providers.append(provider)
+        provider_index.setdefault(service.module, []).append(provider.provider_id)
+        for method in service.methods:
+            if not request.include_internal and method.exposure not in ("external", "both"):
+                continue
+            action = _action_from_method(
+                method=method,
+                service=service,
+                include_schemas=request.include_schemas,
+            )
+            actions.append(action)
+            action_index.setdefault(service.module, []).append(action.action_id)
+
+    for resource in graph.resources:
+        if module_filter and resource.address.module not in module_filter:
+            continue
+        resources.append(_resource_from_graph(resource))
+
+    return CapabilityCatalogResponse(
+        generated_at=datetime.now(UTC).isoformat(),
+        local_peer_id=graph.local_peer_id,
+        local_node_name=graph.local_node_name,
+        providers=sorted(providers, key=lambda item: item.provider_id),
+        actions=sorted(actions, key=lambda item: item.action_id),
+        resources=sorted(resources, key=lambda item: item.resource_id),
+        provider_index={key: sorted(value) for key, value in sorted(provider_index.items())},
+        action_index={key: sorted(value) for key, value in sorted(action_index.items())},
+        secrets_redacted=True,
+    )
+
+
+def explain_route(
+    *,
+    request: RouteExplainRequest,
+    mesh_config: Any,
+    local_services: dict[str, ServiceAnnouncement] | None = None,
+    registry: Any = None,
+    routing_table: Any = None,
+    local_peer_id: str | None = None,
+) -> RouteExplainResponse:
+    topic = _topic_from_request(request)
+    module = topic.split(".", 1)[0]
+    config = mesh_config.services.get(module)
+    route = (
+        routing_table.resolve(topic, routing_config=config, selector=request.selector)
+        if routing_table
+        else None
+    )
+    candidates: list[RouteCandidateDecision] = []
+    local_candidate = _local_candidate(
+        module=module,
+        local_services=local_services or {},
+        local_peer_id=local_peer_id,
+        route_target=route.target if route else "local",
+    )
+    if local_candidate:
+        candidates.append(local_candidate)
+
+    if registry and request.include_candidates:
+        for candidate in registry.get_provider_candidates(
+            module=module,
+            routing_config=config,
+            version_policy=mesh_config.version_policy,
+            selector=request.selector,
+            include_ineligible=True,
+        ):
+            candidates.append(
+                _remote_candidate_from_registry(
+                    candidate,
+                    selected_peer_id=route.peer_id if route else None,
+                    selected_target=route.target if route else "local",
+                )
+            )
+
+    blockers: list[RouteBlockerInfo] = []
+    selector_valid = True
+    selector_code = ""
+    selector_message = ""
+    if route and route.target == "error":
+        selector_code = route.error_code or "route_error"
+        selector_message = route.error_message or "route resolution failed"
+        selector_valid = not selector_code.startswith("selector_")
+        blockers.append(
+            RouteBlockerInfo(
+                code=selector_code,
+                message=selector_message,
+                security_privacy=_is_security_privacy_blocker(selector_code),
+            )
+        )
+    for candidate in candidates:
+        blockers.extend(candidate.blockers)
+
+    selected_service_instance_id = None
+    selected_provider_id = None
+    for candidate in candidates:
+        if candidate.selected:
+            selected_service_instance_id = candidate.service_instance_id
+            selected_provider_id = candidate.provider_id
+            break
+
+    return RouteExplainResponse(
+        topic=topic,
+        module=module,
+        selected_target=route.target if route else "local",
+        selected_peer_id=route.peer_id if route else None,
+        selected_service_instance_id=selected_service_instance_id,
+        selected_provider_id=selected_provider_id,
+        selector_valid=selector_valid,
+        selector_validation_code=selector_code,
+        selector_validation_message=selector_message,
+        fallback_behavior=_fallback_behavior(config, route.target if route else "local"),
+        candidates=sorted(candidates, key=lambda item: item.provider_id),
+        blockers=blockers,
+        security_privacy_blockers=[b for b in blockers if b.security_privacy],
+        secrets_redacted=True,
+    )
+
+
+def _provider_from_service(service: CapabilityServiceInfo) -> CapabilityProviderInfo:
+    return CapabilityProviderInfo(
+        provider_id=service.service_instance_id,
+        peer_id=service.peer_id,
+        provider_kind=service.provider_kind,
+        status="local" if service.provider_kind == "local" else _status_from_blockers(service),
+        service_instance_id=service.service_instance_id,
+        module=service.module,
+        version=service.version,
+        latency_ms=_finite_float(service.latency_ms),
+        max_concurrent=service.max_concurrent,
+        active_calls=service.active_calls,
+        available_capacity=service.available_capacity,
+        eligible=service.routable,
+        reason_code="" if service.routable else _first_blocker(service.route_blockers),
+        reason="" if service.routable else "; ".join(service.route_blockers),
+        policy=_policy_decision(service.policy, service.route_blockers),
+        freshness=_freshness(service),
+    )
+
+
+def _action_from_method(
+    *,
+    method: CapabilityMethodInfo,
+    service: CapabilityServiceInfo,
+    include_schemas: bool,
+) -> CapabilityActionInfo:
+    policy = _policy_decision(method.policy, service.route_blockers)
+    selector = MeshAddressSelector(
+        peer_id=service.peer_id,
+        provider_id=service.peer_id,
+        service_instance_id=f"{service.peer_id}:{service.module}",
+    )
+    return CapabilityActionInfo(
+        action_id=method.method_id,
+        module=method.module,
+        method=method.name,
+        topic=method.bus_topic,
+        provider_id=service.service_instance_id,
+        peer_id=service.peer_id,
+        provider_kind=service.provider_kind,
+        service_instance_id=service.service_instance_id,
+        selector=selector,
+        bindability=_bindability(policy=policy, service=service),
+        sdk_operation_kind=policy.operation_class or "bus_method",
+        route_hints=_route_hints(service, policy),
+        route_blockers=list(service.route_blockers),
+        summary=method.summary,
+        input_schema=_redact_schema(method.input_model, method.input_schema)
+        if include_schemas
+        else None,
+        output_schema=_redact_schema(method.output_model, method.output_schema)
+        if include_schemas
+        else None,
+        policy=policy,
+        freshness=_freshness(service),
+    )
+
+
+def _resource_from_graph(resource: CapabilityResourceInfo) -> CapabilityCatalogResourceInfo:
+    return CapabilityCatalogResourceInfo(
+        resource_id=resource.resource_id,
+        resource_type=resource.resource_type,
+        owner_peer_id=resource.owner_peer_id,
+        service_instance_id=resource.service_instance_id,
+        namespace=resource.namespace,
+        display_name=resource.display_name,
+        capabilities=list(resource.capabilities),
+        selector=MeshAddressSelector(
+            peer_id=resource.address.peer_id,
+            service_instance_id=resource.address.service_instance_id,
+            resource_namespace=resource.namespace,
+            data_scope=resource.address.namespace,
+        ),
+        policy=_policy_decision(resource.policy, []),
+        freshness=_freshness_from_parts(
+            source=resource.provenance.source,
+            manifest_time=resource.provenance.manifest_timestamp,
+            registry_digest=resource.provenance.registry_digest,
+        ),
+    )
+
+
+def _policy_decision(
+    policy: CapabilityPolicyInfo,
+    denial_reasons: list[str],
+) -> CapabilityPolicyDecisionInfo:
+    return CapabilityPolicyDecisionInfo(
+        required_permissions=list(policy.required_perms),
+        trust_tier=policy.trust_tier,
+        safety_class=policy.safety_class,
+        explicit_selector_required=policy.explicit_selector_required,
+        consent_required=policy.consent_required,
+        privacy_indicator_required=policy.privacy_indicator_required,
+        bandwidth_check_required=policy.bandwidth_check_required,
+        approval_required=policy.confirmation_required,
+        selector_required=policy.explicit_selector_required,
+        mesh_visible=policy.mesh_visible,
+        local_only=policy.local_only,
+        allowed_peers=list(policy.allowed_peers) if policy.allowed_peers is not None else None,
+        operation_class=policy.operation_class,
+        resource_scope=policy.resource_scope,
+        denial_reasons=list(denial_reasons),
+    )
+
+
+def _freshness(service: CapabilityServiceInfo) -> CapabilityFreshnessInfo:
+    return _freshness_from_parts(
+        source=service.provenance.source,
+        manifest_time=service.provenance.manifest_timestamp,
+        registry_digest=service.provenance.registry_digest or service.digest,
+        stale=any(blocker.startswith("peer_status:stale") for blocker in service.route_blockers),
+    )
+
+
+def _freshness_from_parts(
+    *,
+    source: str,
+    manifest_time: str | None,
+    registry_digest: str,
+    stale: bool = False,
+) -> CapabilityFreshnessInfo:
+    return CapabilityFreshnessInfo(
+        source=source,
+        manifest_time=manifest_time,
+        stale=stale,
+        registry_digest=registry_digest,
+    )
+
+
+def _local_candidate(
+    *,
+    module: str,
+    local_services: dict[str, ServiceAnnouncement],
+    local_peer_id: str | None,
+    route_target: str,
+) -> RouteCandidateDecision | None:
+    announcement = local_services.get(module)
+    if not announcement:
+        return None
+    peer_id = local_peer_id or "local"
+    service_instance_id = f"local:{peer_id}:{module}"
+    return RouteCandidateDecision(
+        provider_id=service_instance_id,
+        peer_id=peer_id,
+        provider_kind="local",
+        service_instance_id=service_instance_id,
+        module=module,
+        version=announcement.version,
+        included=True,
+        selected=route_target == "local",
+        reason_code="local_available",
+        reason="local service is available",
+        latency_ms=0.0,
+    )
+
+
+def _remote_candidate_from_registry(
+    candidate: Any,
+    *,
+    selected_peer_id: str | None,
+    selected_target: str,
+) -> RouteCandidateDecision:
+    peer = candidate.peer
+    service = candidate.service
+    service_instance_id = f"remote:{peer.peer_id}:{service.module}"
+    available_capacity = None
+    if service.max_concurrent > 0:
+        available_capacity = max(service.max_concurrent - peer.active_calls, 0)
+    blockers = []
+    if not candidate.eligible:
+        blockers.append(
+            RouteBlockerInfo(
+                code=candidate.reason_code or "provider_ineligible",
+                message=candidate.reason or "provider is not eligible",
+                provider_id=service_instance_id,
+                peer_id=peer.peer_id,
+                security_privacy=_is_security_privacy_blocker(candidate.reason_code),
+            )
+        )
+    return RouteCandidateDecision(
+        provider_id=service_instance_id,
+        peer_id=peer.peer_id,
+        provider_kind="remote",
+        service_instance_id=service_instance_id,
+        module=service.module,
+        version=service.version,
+        included=candidate.eligible,
+        selected=selected_target == "remote" and selected_peer_id == peer.peer_id,
+        reason_code=candidate.reason_code,
+        reason=candidate.reason,
+        latency_ms=_finite_float(peer.latency_ms),
+        active_calls=peer.active_calls,
+        max_concurrent=service.max_concurrent,
+        available_capacity=available_capacity,
+        blockers=blockers,
+    )
+
+
+def _topic_from_request(request: RouteExplainRequest) -> str:
+    if request.topic:
+        return request.topic
+    if request.module and request.method:
+        return f"{request.module}.{request.method}"
+    if request.module:
+        return f"{request.module}.Diagnostic"
+    return "Gateway.Diagnostic"
+
+
+def _fallback_behavior(config: Any | None, selected_target: str) -> str:
+    if config is None:
+        return "local_default"
+    if selected_target == "remote":
+        return f"remote_selected; fallback={config.fallback}"
+    if selected_target == "local":
+        return f"local_selected; fallback={config.fallback}"
+    if selected_target == "none":
+        return "no_route"
+    if selected_target == "error":
+        return f"hard_error; fallback={config.fallback}"
+    return selected_target
+
+
+def _bindability(
+    *,
+    policy: CapabilityPolicyDecisionInfo,
+    service: CapabilityServiceInfo,
+) -> str:
+    if not service.routable:
+        return "unavailable"
+    if policy.approval_required or policy.consent_required:
+        return "approval-required"
+    if policy.explicit_selector_required or policy.privacy_indicator_required:
+        return "ui-only"
+    return "model-bindable"
+
+
+def _route_hints(
+    service: CapabilityServiceInfo,
+    policy: CapabilityPolicyDecisionInfo,
+) -> list[str]:
+    hints = [service.provider_kind]
+    if policy.explicit_selector_required:
+        hints.append("explicit_selector_required")
+    if policy.approval_required:
+        hints.append("approval_required")
+    if service.routable:
+        hints.append("routable")
+    return hints
+
+
+def _status_from_blockers(service: CapabilityServiceInfo) -> str:
+    for blocker in service.route_blockers:
+        if blocker.startswith("peer_status:"):
+            return blocker.split(":", 1)[1]
+    return "blocked" if service.route_blockers else "negotiated"
+
+
+def _first_blocker(blockers: list[str]) -> str:
+    return blockers[0].split(":", 1)[0] if blockers else ""
+
+
+def _redact_schema(model_name: str | None, schema: dict[str, Any] | None) -> dict[str, Any] | None:
+    if schema is None:
+        return None
+    if model_name and _is_sensitive_key(model_name):
+        return {"type": "object", "description": "redacted"}
+    redacted = _redact_schema_node(schema)
+    return redacted if isinstance(redacted, dict) else {"type": "object", "description": "redacted"}
+
+
+def _redact_schema_node(value: Any, key: str = "") -> Any:
+    if _is_sensitive_key(key):
+        return {"type": "string", "description": "redacted", "writeOnly": True}
+    if isinstance(value, dict):
+        return {
+            child_key: _redact_schema_node(child_value, child_key)
+            for child_key, child_value in value.items()
+            if child_key != "examples"
+        }
+    if isinstance(value, list):
+        return [_redact_schema_node(item, key) for item in value]
+    if isinstance(value, str) and _looks_sensitive_value(value):
+        return "redacted"
+    return value
+
+
+def _is_sensitive_key(key: str | None) -> bool:
+    if not key:
+        return False
+    normalized = key.lower().replace("-", "_")
+    return any(part in normalized for part in _REDACTED_SCHEMA_KEYS)
+
+
+def _looks_sensitive_value(value: str) -> bool:
+    lowered = value.lower()
+    return any(part in lowered for part in ("secret", "token", "password", "api_key"))
+
+
+def _is_security_privacy_blocker(code: str | None) -> bool:
+    if not code:
+        return False
+    return any(
+        token in code
+        for token in (
+            "unauthorized",
+            "not_allowed",
+            "peer_not_found",
+            "selector_required",
+            "selector_peer",
+            "privacy",
+            "consent",
+            "permission",
+        )
+    )
+
+
+def _finite_float(value: float | None) -> float | None:
+    if value is None or not math.isfinite(value):
+        return None
+    return float(value)

--- a/app/services/gateway/mesh/capability_graph.py
+++ b/app/services/gateway/mesh/capability_graph.py
@@ -300,6 +300,8 @@ def _method_to_graph(
         summary=method.summary,
         input_model=method.input_model,
         output_model=method.output_model,
+        input_schema=method.input_schema,
+        output_schema=method.output_schema,
         policy=policy,
         address=CapabilityAddressInfo(
             peer_id=peer_id,
@@ -358,7 +360,7 @@ def _policy_for_module(
         or module in _HARDWARE_OR_AUDIO_MODULES
         or safety_class != "standard"
     )
-    return CapabilityPolicyInfo(
+    policy = CapabilityPolicyInfo(
         trust_tier="local" if provider_kind == "local" else "mesh_peer",
         safety_class=safety_class,
         allowed_peers=list(sharing_config.allowed_peers)
@@ -369,12 +371,16 @@ def _policy_for_module(
         and safety_class in {"hardware", "data", "admin"},
         consent_required=module in _HARDWARE_OR_AUDIO_MODULES,
         privacy_indicator_required=module in _HARDWARE_OR_AUDIO_MODULES,
-        bandwidth_check_required=module in {"AudioInput", "STTCoordinator", "WakeWord", "Transcription"},
+        bandwidth_check_required=module
+        in {"AudioInput", "STTCoordinator", "WakeWord", "Transcription"},
         operation_class="audio_service" if module in _HARDWARE_OR_AUDIO_MODULES else None,
         resource_scope="audio" if module in _HARDWARE_OR_AUDIO_MODULES else None,
         mesh_visible=bool(sharing_config.share) if sharing_config else provider_kind == "remote",
         local_only=provider_kind == "local" and not (sharing_config and sharing_config.share),
     )
+    if provider_kind == "remote" and safety_class == "delegated_action":
+        policy.confirmation_required = True
+    return policy
 
 
 def _remote_route_blockers(

--- a/app/services/gateway/mesh/peer_registry.py
+++ b/app/services/gateway/mesh/peer_registry.py
@@ -579,22 +579,38 @@ def _selector_peer_id(
         return None, None
 
     peer_ids: list[str] = []
-    for value in (selector.peer_id, selector.provider_id):
-        if value and value not in peer_ids:
-            peer_ids.append(value)
-
-    if selector.service_instance_id:
-        service_peer = selector.service_instance_id
-        if ":" in service_peer:
-            service_peer, service_module = service_peer.split(":", 1)
-            if service_module and service_module != module:
-                return None, (
-                    f"service_instance_id '{selector.service_instance_id}' targets "
-                    f"{service_module}, not {module}"
-                )
-        if service_peer and service_peer not in peer_ids:
-            peer_ids.append(service_peer)
+    for value, field_name in (
+        (selector.peer_id, "peer_id"),
+        (selector.provider_id, "provider_id"),
+        (selector.service_instance_id, "service_instance_id"),
+    ):
+        peer_id, error = _parse_selector_peer_id(value, field_name, module)
+        if error:
+            return None, error
+        if peer_id and peer_id not in peer_ids:
+            peer_ids.append(peer_id)
 
     if len(peer_ids) > 1:
         return None, f"selector names multiple peer/provider targets: {', '.join(peer_ids)}"
     return (peer_ids[0], None) if peer_ids else (None, None)
+
+
+def _parse_selector_peer_id(
+    value: str | None,
+    field_name: str,
+    module: str,
+) -> tuple[str | None, str | None]:
+    if not value:
+        return None, None
+    if ":" not in value:
+        return value, None
+
+    parts = value.split(":")
+    if len(parts) == 3 and parts[0] in {"local", "remote"}:
+        _, peer_id, service_module = parts
+    else:
+        peer_id, service_module = value.split(":", 1)
+
+    if service_module and service_module != module:
+        return None, f"{field_name} '{value}' targets {service_module}, not {module}"
+    return peer_id, None

--- a/app/services/gateway/mesh/routing_table.py
+++ b/app/services/gateway/mesh/routing_table.py
@@ -78,10 +78,10 @@ class RoutingTable:
         if not routing_config:
             return RouteDecision(target="local", module=module)
 
-        if (
-            _requires_explicit_audio_selector(topic)
-            and routing_config.prefer in {"network", "network_only"}
-        ):
+        if _requires_explicit_audio_selector(topic) and routing_config.prefer in {
+            "network",
+            "network_only",
+        }:
             return _route_error(
                 module=module,
                 selector=selector,
@@ -195,8 +195,7 @@ class RoutingTable:
                 selector=selector,
                 code="selector_peer_stale" if peer.status == "stale" else "selector_peer_not_ready",
                 message=(
-                    f"{module} selector peer/provider '{peer_id}' is {peer.status}, "
-                    "not negotiated"
+                    f"{module} selector peer/provider '{peer_id}' is {peer.status}, not negotiated"
                 ),
             )
 
@@ -397,7 +396,11 @@ def _selector_peer_id(selector: MeshAddressSelector, module: str) -> tuple[str |
     if selector.service_instance_id:
         service_peer = selector.service_instance_id
         if ":" in service_peer:
-            service_peer, service_module = service_peer.split(":", 1)
+            parts = service_peer.split(":")
+            if len(parts) == 3 and parts[0] in {"local", "remote"}:
+                _, service_peer, service_module = parts
+            else:
+                service_peer, service_module = service_peer.split(":", 1)
             if service_module and service_module != module:
                 return None, (
                     f"service_instance_id '{selector.service_instance_id}' targets "

--- a/app/services/gateway/mesh/routing_table.py
+++ b/app/services/gateway/mesh/routing_table.py
@@ -165,7 +165,7 @@ class RoutingTable:
         routing_config: MeshServiceConfig | None,
         selector: MeshAddressSelector,
     ) -> RouteDecision:
-        peer_id, conflict_error = _selector_peer_id(selector, module)
+        peer_id, conflict_error, provider_kind = _selector_target(selector, module)
         if conflict_error:
             return _route_error(
                 module=module,
@@ -180,6 +180,9 @@ class RoutingTable:
                 code="selector_missing_provider",
                 message=f"{module} selector does not name a peer/provider/service instance",
             )
+
+        if provider_kind == "local":
+            return RouteDecision(target="local", module=module, selector=selector)
 
         peer = self._registry.get_peer(peer_id)
         if not peer:
@@ -385,33 +388,62 @@ def _requires_explicit_audio_selector(topic: str) -> bool:
     return topic in _EXPLICIT_AUDIO_TOPICS
 
 
-def _selector_peer_id(selector: MeshAddressSelector, module: str) -> tuple[str | None, str | None]:
-    """Resolve selector peer aliases into a single peer id."""
+def _selector_target(
+    selector: MeshAddressSelector,
+    module: str,
+) -> tuple[str | None, str | None, str | None]:
+    """Resolve selector provider aliases into a peer id and provider kind."""
 
     peer_ids: list[str] = []
-    for value in (selector.peer_id, selector.provider_id):
-        if value and value not in peer_ids:
-            peer_ids.append(value)
-
-    if selector.service_instance_id:
-        service_peer = selector.service_instance_id
-        if ":" in service_peer:
-            parts = service_peer.split(":")
-            if len(parts) == 3 and parts[0] in {"local", "remote"}:
-                _, service_peer, service_module = parts
-            else:
-                service_peer, service_module = service_peer.split(":", 1)
-            if service_module and service_module != module:
-                return None, (
-                    f"service_instance_id '{selector.service_instance_id}' targets "
-                    f"{service_module}, not {module}"
-                )
-        if service_peer and service_peer not in peer_ids:
-            peer_ids.append(service_peer)
+    provider_kinds: list[str] = []
+    for value, field_name in (
+        (selector.peer_id, "peer_id"),
+        (selector.provider_id, "provider_id"),
+        (selector.service_instance_id, "service_instance_id"),
+    ):
+        peer_id, error, provider_kind = _parse_selector_target(value, field_name, module)
+        if error:
+            return None, error, None
+        if peer_id and peer_id not in peer_ids:
+            peer_ids.append(peer_id)
+        if provider_kind and provider_kind not in provider_kinds:
+            provider_kinds.append(provider_kind)
 
     if len(peer_ids) > 1:
-        return None, f"selector names multiple peer/provider targets: {', '.join(peer_ids)}"
-    return (peer_ids[0], None) if peer_ids else (None, None)
+        return None, f"selector names multiple peer/provider targets: {', '.join(peer_ids)}", None
+    if len(provider_kinds) > 1:
+        return None, (
+            f"selector names multiple provider kinds: {', '.join(provider_kinds)}"
+        ), None
+    return (peer_ids[0], None, provider_kinds[0] if provider_kinds else None) if peer_ids else (
+        None,
+        None,
+        None,
+    )
+
+
+def _parse_selector_target(
+    value: str | None,
+    field_name: str,
+    module: str,
+) -> tuple[str | None, str | None, str | None]:
+    if not value:
+        return None, None, None
+    if ":" not in value:
+        return value, None, None
+
+    parts = value.split(":")
+    if len(parts) == 3 and parts[0] in {"local", "remote"}:
+        provider_kind, peer_id, service_module = parts
+    else:
+        provider_kind = None
+        peer_id, service_module = value.split(":", 1)
+
+    if service_module and service_module != module:
+        return None, (
+            f"{field_name} '{value}' targets {service_module}, not {module}"
+        ), None
+    return peer_id, None, provider_kind
 
 
 def _route_error(

--- a/app/services/gateway/service.py
+++ b/app/services/gateway/service.py
@@ -22,6 +22,8 @@ from app.shared.config.models import (
 from app.shared.contracts.models.auth import AuthMethods
 from app.shared.contracts.models.common import EmptyInput
 from app.shared.contracts.models.gateway import (
+    CapabilityCatalogRequest,
+    CapabilityCatalogResponse,
     CapabilityGraph,
     GatewayMethods,
     GetMeshStatusResponse,
@@ -32,6 +34,8 @@ from app.shared.contracts.models.gateway import (
     MeshPeerServiceDiagnostic,
     MeshRouteDiagnostic,
     MeshRouteProviderDiagnostic,
+    RouteExplainRequest,
+    RouteExplainResponse,
 )
 from app.shared.contracts.registry import method_contract
 from app.shared.services.base_service import BaseService
@@ -279,6 +283,63 @@ class GatewayService(BaseService):
             mesh_config=settings.mesh,
             local_services=local_services,
             peers=peers,
+            local_peer_id=self._mesh_peer_id,
+        )
+
+    @method_contract(
+        method_id=GatewayMethods.GET_CAPABILITY_CATALOG,
+        summary="Get canonical executable capability catalog",
+        input_model=CapabilityCatalogRequest,
+        output_model=CapabilityCatalogResponse,
+        exposure="external",
+        method_type="manage",
+        required_perms=["Gateway.manage"],
+    )
+    async def get_capability_catalog(
+        self,
+        data: CapabilityCatalogRequest,
+    ) -> CapabilityCatalogResponse:
+        """Return a product-facing local + remote capability catalog."""
+        from app.services.gateway.mesh.capability_catalog import build_capability_catalog
+
+        settings = await self._get_gateway_config()
+        local_services = {}
+        if self._registry_aggregator:
+            local_services = self._registry_aggregator.snapshot_services()
+
+        peers = self._mesh_peer_registry.get_all_peers() if self._mesh_peer_registry else []
+        return build_capability_catalog(
+            request=data,
+            mesh_config=settings.mesh,
+            local_services=local_services,
+            peers=peers,
+            local_peer_id=self._mesh_peer_id,
+        )
+
+    @method_contract(
+        method_id=GatewayMethods.EXPLAIN_ROUTE,
+        summary="Explain mesh route selection and provider eligibility",
+        input_model=RouteExplainRequest,
+        output_model=RouteExplainResponse,
+        exposure="external",
+        method_type="manage",
+        required_perms=["Gateway.manage"],
+    )
+    async def explain_route(self, data: RouteExplainRequest) -> RouteExplainResponse:
+        """Return selected target, candidates, and route blockers for a selector."""
+        from app.services.gateway.mesh.capability_catalog import explain_route
+
+        settings = await self._get_gateway_config()
+        local_services = {}
+        if self._registry_aggregator:
+            local_services = self._registry_aggregator.snapshot_services()
+
+        return explain_route(
+            request=data,
+            mesh_config=settings.mesh,
+            local_services=local_services,
+            registry=self._mesh_peer_registry,
+            routing_table=self._mesh_routing_table,
             local_peer_id=self._mesh_peer_id,
         )
 

--- a/app/shared/contracts/models/gateway.py
+++ b/app/shared/contracts/models/gateway.py
@@ -44,6 +44,8 @@ class GatewayMethods:
     GET_SERVICE_HEALTH = f"{GatewayModule.NAME}.GetServiceHealth"
     GET_MESH_STATUS = f"{GatewayModule.NAME}.GetMeshStatus"
     GET_CAPABILITY_GRAPH = f"{GatewayModule.NAME}.GetCapabilityGraph"
+    GET_CAPABILITY_CATALOG = f"{GatewayModule.NAME}.GetCapabilityCatalog"
+    EXPLAIN_ROUTE = f"{GatewayModule.NAME}.ExplainRoute"
 
 
 # =============================================================================
@@ -329,6 +331,8 @@ class CapabilityMethodInfo(IOModel):
     summary: str = ""
     input_model: str | None = None
     output_model: str | None = None
+    input_schema: dict[str, Any] | None = None
+    output_schema: dict[str, Any] | None = None
     policy: CapabilityPolicyInfo = Field(default_factory=CapabilityPolicyInfo)
     address: CapabilityAddressInfo
     provenance: CapabilityProvenanceInfo = Field(default_factory=CapabilityProvenanceInfo)
@@ -409,6 +413,185 @@ class CapabilityGraph(IOModel):
             "namespace",
         ]
     )
+    secrets_redacted: bool = True
+
+
+class CapabilityFreshnessInfo(IOModel):
+    """Source and staleness metadata for catalog entries."""
+
+    source: str = "unknown"
+    manifest_time: str | None = None
+    last_probe_age_s: float | None = None
+    ttl_s: float | None = None
+    stale: bool = False
+    registry_digest: str = ""
+
+
+class CapabilityPolicyDecisionInfo(IOModel):
+    """Policy facts needed by SDK/UI bindability decisions."""
+
+    required_permissions: list[str] = Field(default_factory=list)
+    trust_tier: str = "unknown"
+    safety_class: str = "standard"
+    explicit_selector_required: bool = False
+    consent_required: bool = False
+    privacy_indicator_required: bool = False
+    bandwidth_check_required: bool = False
+    approval_required: bool = False
+    selector_required: bool = False
+    mesh_visible: bool = False
+    local_only: bool = False
+    allowed_peers: list[str] | None = None
+    operation_class: str | None = None
+    resource_scope: str | None = None
+    denial_reasons: list[str] = Field(default_factory=list)
+
+
+class CapabilityProviderInfo(IOModel):
+    """One local or remote provider for a capability module."""
+
+    provider_id: str
+    peer_id: str
+    provider_kind: str = "remote"
+    node_name: str = ""
+    status: str = "unknown"
+    service_instance_id: str
+    module: str
+    version: str = ""
+    latency_ms: float | None = None
+    max_concurrent: int = 0
+    active_calls: int = 0
+    available_capacity: int | None = None
+    eligible: bool = False
+    reason_code: str = ""
+    reason: str = ""
+    policy: CapabilityPolicyDecisionInfo = Field(default_factory=CapabilityPolicyDecisionInfo)
+    freshness: CapabilityFreshnessInfo = Field(default_factory=CapabilityFreshnessInfo)
+
+
+class CapabilityActionInfo(IOModel):
+    """Executable or explainable capability action for SDK/UI consumers."""
+
+    action_id: str
+    module: str
+    method: str
+    topic: str | None = None
+    tool_id: str | None = None
+    resource_id: str | None = None
+    provider_id: str
+    peer_id: str
+    provider_kind: str = "remote"
+    service_instance_id: str
+    # Runtime value is app.shared.contracts.models.mesh.MeshAddressSelector.
+    selector: Any
+    bindability: str = "unavailable"
+    sdk_operation_kind: str = "bus_method"
+    route_hints: list[str] = Field(default_factory=list)
+    route_blockers: list[str] = Field(default_factory=list)
+    summary: str = ""
+    input_schema: dict[str, Any] | None = None
+    output_schema: dict[str, Any] | None = None
+    policy: CapabilityPolicyDecisionInfo = Field(default_factory=CapabilityPolicyDecisionInfo)
+    freshness: CapabilityFreshnessInfo = Field(default_factory=CapabilityFreshnessInfo)
+
+
+class CapabilityCatalogResourceInfo(IOModel):
+    """Addressable resource advertised through the capability catalog."""
+
+    resource_id: str
+    resource_type: str
+    owner_peer_id: str
+    service_instance_id: str | None = None
+    namespace: str | None = None
+    display_name: str = ""
+    capabilities: list[str] = Field(default_factory=list)
+    # Runtime value is app.shared.contracts.models.mesh.MeshAddressSelector.
+    selector: Any
+    policy: CapabilityPolicyDecisionInfo = Field(default_factory=CapabilityPolicyDecisionInfo)
+    freshness: CapabilityFreshnessInfo = Field(default_factory=CapabilityFreshnessInfo)
+
+
+class CapabilityCatalogRequest(IOModel):
+    """Request a canonical executable capability catalog."""
+
+    modules: list[str] | None = None
+    include_unavailable: bool = True
+    include_internal: bool = False
+    include_schemas: bool = True
+
+
+class CapabilityCatalogResponse(IOModel):
+    """Canonical SDK/UI capability catalog."""
+
+    generated_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    local_peer_id: str | None = None
+    local_node_name: str = ""
+    providers: list[CapabilityProviderInfo] = Field(default_factory=list)
+    actions: list[CapabilityActionInfo] = Field(default_factory=list)
+    resources: list[CapabilityCatalogResourceInfo] = Field(default_factory=list)
+    provider_index: dict[str, list[str]] = Field(default_factory=dict)
+    action_index: dict[str, list[str]] = Field(default_factory=dict)
+    secrets_redacted: bool = True
+
+
+class RouteBlockerInfo(IOModel):
+    """Route blocker or selector validation problem."""
+
+    code: str
+    message: str
+    severity: str = "error"
+    provider_id: str | None = None
+    peer_id: str | None = None
+    security_privacy: bool = False
+
+
+class RouteCandidateDecision(IOModel):
+    """Eligibility and selection decision for one route candidate."""
+
+    provider_id: str
+    peer_id: str
+    provider_kind: str = "remote"
+    service_instance_id: str
+    module: str
+    version: str = ""
+    included: bool = False
+    selected: bool = False
+    reason_code: str = ""
+    reason: str = ""
+    latency_ms: float | None = None
+    active_calls: int = 0
+    max_concurrent: int = 0
+    available_capacity: int | None = None
+    blockers: list[RouteBlockerInfo] = Field(default_factory=list)
+
+
+class RouteExplainRequest(IOModel):
+    """Explain how Gateway would route a topic/module selector."""
+
+    topic: str | None = None
+    module: str | None = None
+    method: str | None = None
+    # Runtime value is app.shared.contracts.models.mesh.MeshAddressSelector.
+    selector: Any | None = None
+    include_candidates: bool = True
+
+
+class RouteExplainResponse(IOModel):
+    """Route selection explanation for SDK route sheets."""
+
+    topic: str
+    module: str
+    selected_target: str = "local"
+    selected_peer_id: str | None = None
+    selected_service_instance_id: str | None = None
+    selected_provider_id: str | None = None
+    selector_valid: bool = True
+    selector_validation_code: str = ""
+    selector_validation_message: str = ""
+    fallback_behavior: str = ""
+    candidates: list[RouteCandidateDecision] = Field(default_factory=list)
+    blockers: list[RouteBlockerInfo] = Field(default_factory=list)
+    security_privacy_blockers: list[RouteBlockerInfo] = Field(default_factory=list)
     secrets_redacted: bool = True
 
 

--- a/tests/unit/gateway/test_capability_catalog.py
+++ b/tests/unit/gateway/test_capability_catalog.py
@@ -139,6 +139,8 @@ async def test_catalog_exposes_multiple_providers_bindability_and_redacted_schem
 
     peer_a_action = next(action for action in catalog.actions if action.peer_id == "peer-a")
     assert peer_a_action.selector.peer_id == "peer-a"
+    assert peer_a_action.selector.provider_id == "remote:peer-a:Tooling"
+    assert peer_a_action.selector.service_instance_id == peer_a_action.service_instance_id
     assert peer_a_action.service_instance_id == "remote:peer-a:Tooling"
     assert peer_a_action.bindability == "approval-required"
     assert peer_a_action.policy.safety_class == "delegated_action"
@@ -152,6 +154,9 @@ async def test_catalog_exposes_multiple_providers_bindability_and_redacted_schem
     assert peer_c_provider.reason_code == "peer_not_allowed"
 
     local_action = next(action for action in catalog.actions if action.peer_id == "local-peer")
+    assert local_action.service_instance_id == "local:local-peer:Tooling"
+    assert local_action.selector.provider_id == "local:local-peer:Tooling"
+    assert local_action.selector.service_instance_id == local_action.service_instance_id
     assert local_action.input_schema["properties"]["query"]["type"] == "string"
     assert local_action.input_schema["properties"]["api_token"]["description"] == "redacted"
     assert local_action.input_schema["properties"]["file_path"]["description"] == "redacted"
@@ -224,6 +229,133 @@ async def test_route_explain_reports_selected_remote_stale_denied_and_local_cand
     assert by_peer["peer-denied"].reason_code == "peer_not_allowed"
     assert by_peer["peer-denied"].blockers[0].security_privacy is True
     assert by_peer["peer-stale"].reason_code == "peer_stale"
+
+
+@pytest.mark.asyncio
+async def test_catalog_selectors_round_trip_through_route_explain():
+    mesh_config = MeshConfig(
+        enabled=True,
+        node_name="local-node",
+        peer_selection="lowest_latency",
+        services={
+            "Tooling": MeshServiceConfig(
+                share=True,
+                prefer="network",
+                fallback="local",
+                allowed_peers=["peer-a", "peer-stale"],
+                required_capabilities=["tools"],
+            ),
+        },
+    )
+    registry = PeerRegistry(mesh_config)
+    routing_table = RoutingTable(mesh_config, registry)
+
+    await registry.register_peer("peer-a", "alpha")
+    await registry.update_manifest(
+        "peer-a",
+        PeerManifest(peer_id="peer-a", shared_services=[_remote_service("Tooling", "1.0.0")]),
+    )
+    await registry.update_latency("peer-a", 5.0)
+
+    await registry.register_peer("peer-denied", "denied")
+    await registry.update_manifest(
+        "peer-denied",
+        PeerManifest(
+            peer_id="peer-denied",
+            shared_services=[_remote_service("Tooling", "1.0.0")],
+        ),
+    )
+
+    await registry.register_peer("peer-stale", "stale")
+    await registry.update_manifest(
+        "peer-stale",
+        PeerManifest(
+            peer_id="peer-stale",
+            shared_services=[_remote_service("Tooling", "1.0.0")],
+        ),
+    )
+    registry.get_peer("peer-stale").status = "stale"
+
+    local_services = {
+        "Tooling": ServiceAnnouncement(
+            module="Tooling",
+            version="local",
+            methods=[_method("Tooling")],
+        )
+    }
+    catalog = build_capability_catalog(
+        request=CapabilityCatalogRequest(modules=["Tooling"]),
+        mesh_config=mesh_config,
+        local_services=local_services,
+        peers=registry.get_all_peers(),
+        local_peer_id="local-peer",
+    )
+    actions_by_peer = {action.peer_id: action for action in catalog.actions}
+
+    local_response = explain_route(
+        request=RouteExplainRequest(
+            topic="Tooling.Execute",
+            selector=actions_by_peer["local-peer"].selector,
+        ),
+        mesh_config=mesh_config,
+        local_services=local_services,
+        registry=registry,
+        routing_table=routing_table,
+        local_peer_id="local-peer",
+    )
+    assert local_response.selected_target == "local"
+    assert local_response.selector_valid is True
+    assert local_response.selected_service_instance_id == "local:local-peer:Tooling"
+    assert local_response.selected_provider_id == "local:local-peer:Tooling"
+
+    remote_response = explain_route(
+        request=RouteExplainRequest(
+            topic="Tooling.Execute",
+            selector=actions_by_peer["peer-a"].selector,
+        ),
+        mesh_config=mesh_config,
+        local_services=local_services,
+        registry=registry,
+        routing_table=routing_table,
+        local_peer_id="local-peer",
+    )
+    assert remote_response.selected_target == "remote"
+    assert remote_response.selected_peer_id == "peer-a"
+    assert remote_response.selector_valid is True
+    assert remote_response.selected_service_instance_id == "remote:peer-a:Tooling"
+    assert remote_response.selected_provider_id == "remote:peer-a:Tooling"
+
+    denied_response = explain_route(
+        request=RouteExplainRequest(
+            topic="Tooling.Execute",
+            selector=actions_by_peer["peer-denied"].selector,
+        ),
+        mesh_config=mesh_config,
+        local_services=local_services,
+        registry=registry,
+        routing_table=routing_table,
+        local_peer_id="local-peer",
+    )
+    assert denied_response.selected_target == "error"
+    assert denied_response.selector_valid is False
+    assert denied_response.selector_validation_code == "selector_peer_unauthorized"
+    assert any(blocker.code == "peer_not_allowed" for blocker in denied_response.blockers)
+
+    stale_response = explain_route(
+        request=RouteExplainRequest(
+            topic="Tooling.Execute",
+            selector=actions_by_peer["peer-stale"].selector,
+        ),
+        mesh_config=mesh_config,
+        local_services=local_services,
+        registry=registry,
+        routing_table=routing_table,
+        local_peer_id="local-peer",
+    )
+    assert stale_response.selected_target == "error"
+    assert stale_response.selector_valid is False
+    assert stale_response.selector_validation_code == "selector_peer_stale"
+    assert any(blocker.code == "peer_stale" for blocker in stale_response.blockers)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gateway/test_capability_catalog.py
+++ b/tests/unit/gateway/test_capability_catalog.py
@@ -291,6 +291,8 @@ async def test_catalog_selectors_round_trip_through_route_explain():
         local_peer_id="local-peer",
     )
     actions_by_peer = {action.peer_id: action for action in catalog.actions}
+    for action in actions_by_peer.values():
+        assert action.selector.service_instance_id == action.service_instance_id
 
     local_response = explain_route(
         request=RouteExplainRequest(
@@ -307,6 +309,12 @@ async def test_catalog_selectors_round_trip_through_route_explain():
     assert local_response.selector_valid is True
     assert local_response.selected_service_instance_id == "local:local-peer:Tooling"
     assert local_response.selected_provider_id == "local:local-peer:Tooling"
+    local_route = routing_table.resolve(
+        "Tooling.Execute",
+        routing_config=mesh_config.services["Tooling"],
+        selector=actions_by_peer["local-peer"].selector,
+    )
+    assert local_route.target == "local"
 
     remote_response = explain_route(
         request=RouteExplainRequest(
@@ -324,6 +332,13 @@ async def test_catalog_selectors_round_trip_through_route_explain():
     assert remote_response.selector_valid is True
     assert remote_response.selected_service_instance_id == "remote:peer-a:Tooling"
     assert remote_response.selected_provider_id == "remote:peer-a:Tooling"
+    remote_route = routing_table.resolve(
+        "Tooling.Execute",
+        routing_config=mesh_config.services["Tooling"],
+        selector=actions_by_peer["peer-a"].selector,
+    )
+    assert remote_route.target == "remote"
+    assert remote_route.peer_id == "peer-a"
 
     denied_response = explain_route(
         request=RouteExplainRequest(
@@ -340,6 +355,13 @@ async def test_catalog_selectors_round_trip_through_route_explain():
     assert denied_response.selector_valid is False
     assert denied_response.selector_validation_code == "selector_peer_unauthorized"
     assert any(blocker.code == "peer_not_allowed" for blocker in denied_response.blockers)
+    denied_route = routing_table.resolve(
+        "Tooling.Execute",
+        routing_config=mesh_config.services["Tooling"],
+        selector=actions_by_peer["peer-denied"].selector,
+    )
+    assert denied_route.target == "error"
+    assert denied_route.error_code == "selector_peer_unauthorized"
 
     stale_response = explain_route(
         request=RouteExplainRequest(
@@ -356,6 +378,13 @@ async def test_catalog_selectors_round_trip_through_route_explain():
     assert stale_response.selector_valid is False
     assert stale_response.selector_validation_code == "selector_peer_stale"
     assert any(blocker.code == "peer_stale" for blocker in stale_response.blockers)
+    stale_route = routing_table.resolve(
+        "Tooling.Execute",
+        routing_config=mesh_config.services["Tooling"],
+        selector=actions_by_peer["peer-stale"].selector,
+    )
+    assert stale_route.target == "error"
+    assert stale_route.error_code == "selector_peer_stale"
 
 
 @pytest.mark.asyncio
@@ -400,4 +429,63 @@ def test_gateway_service_registers_capability_catalog_and_explain_contracts():
     assert methods[GatewayMethods.GET_CAPABILITY_CATALOG].exposure == "external"
     assert methods[GatewayMethods.GET_CAPABILITY_CATALOG].method_type == "manage"
     assert methods[GatewayMethods.EXPLAIN_ROUTE].required_perms == ["Gateway.manage"]
+    clear_registry()
+
+
+@pytest.mark.asyncio
+async def test_gateway_openapi_exposes_capability_catalog_and_explain_routes():
+    fastapi = pytest.importorskip("fastapi")
+
+    from app.services.gateway.route_generator import RouteGenerator
+
+    clear_registry()
+    GatewayService()
+    gateway = list_modules()["Gateway"]
+
+    class _GatewayRegistry:
+        def on_registry_change(self, _callback):
+            return None
+
+        async def get_external_methods(self):
+            methods = []
+            for method in gateway.methods:
+                if method.exposure not in {"external", "both"}:
+                    continue
+                input_schema = (
+                    method.input_model.model_json_schema() if method.input_model else None
+                )
+                output_schema = (
+                    method.output_model.model_json_schema() if method.output_model else None
+                )
+                methods.append(
+                    (
+                        "Gateway",
+                        MethodInfo(
+                            name=method.name,
+                            summary=method.summary,
+                            bus_topic=method.bus_topic,
+                            exposure=method.exposure,
+                            input_model=method.input_model.__name__ if method.input_model else None,
+                            output_model=method.output_model.__name__
+                            if method.output_model
+                            else None,
+                            required_perms=method.required_perms,
+                            method_type=method.method_type,
+                            input_schema=input_schema,
+                            output_schema=output_schema,
+                        ),
+                    )
+                )
+            return methods
+
+    app = fastapi.FastAPI()
+    router = fastapi.APIRouter()
+    generator = RouteGenerator(bus=object(), registry=_GatewayRegistry())
+    generator.set_router(router)
+    await generator.start()
+    app.include_router(router)
+
+    openapi_paths = app.openapi()["paths"]
+    assert "/api/Gateway/GetCapabilityCatalog" in openapi_paths
+    assert "/api/Gateway/ExplainRoute" in openapi_paths
     clear_registry()

--- a/tests/unit/gateway/test_capability_catalog.py
+++ b/tests/unit/gateway/test_capability_catalog.py
@@ -1,0 +1,271 @@
+"""Unit tests for Gateway capability catalog and route explain contracts."""
+
+import pytest
+
+from app.services.gateway.config import MeshConfig, MeshServiceConfig
+from app.services.gateway.mesh.capability_catalog import build_capability_catalog, explain_route
+from app.services.gateway.mesh.models import PeerManifest, PeerServiceInfo
+from app.services.gateway.mesh.peer_registry import PeerRegistry
+from app.services.gateway.mesh.routing_table import RoutingTable
+from app.services.gateway.service import GatewayService
+from app.shared.contracts.models.gateway import (
+    CapabilityCatalogRequest,
+    GatewayMethods,
+    MethodInfo,
+    RouteExplainRequest,
+    ServiceAnnouncement,
+)
+from app.shared.contracts.models.mesh import MeshAddressSelector
+from app.shared.contracts.registry import clear_registry, list_modules
+
+
+def _method(
+    module: str,
+    name: str = "Execute",
+    method_type: str = "use",
+    input_schema: dict | None = None,
+) -> MethodInfo:
+    return MethodInfo(
+        name=name,
+        summary=f"{module} {name}",
+        bus_topic=f"{module}.{name}",
+        exposure="external",
+        method_type=method_type,
+        required_perms=[f"{module}.{name}"],
+        input_model=f"{name}Request",
+        output_model=f"{name}Response",
+        input_schema=input_schema,
+        output_schema={"type": "object", "properties": {"ok": {"type": "boolean"}}},
+    )
+
+
+def _remote_service(module: str, version: str, max_concurrent: int = 4) -> PeerServiceInfo:
+    return PeerServiceInfo(
+        module=module,
+        version=version,
+        capabilities=["tools", "basic"],
+        methods=[_method(module)],
+        max_concurrent=max_concurrent,
+        digest=f"digest-{module}-{version}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_catalog_exposes_multiple_providers_bindability_and_redacted_schemas():
+    mesh_config = MeshConfig(
+        enabled=True,
+        node_name="local-node",
+        services={
+            "Tooling": MeshServiceConfig(
+                share=True,
+                prefer="network",
+                allowed_peers=["peer-a", "peer-b"],
+                required_capabilities=["tools"],
+            ),
+        },
+    )
+    registry = PeerRegistry(mesh_config)
+
+    await registry.register_peer("peer-a", "alpha")
+    await registry.update_manifest(
+        "peer-a",
+        PeerManifest(
+            peer_id="peer-a",
+            node_name="alpha",
+            timestamp="2026-06-18T19:00:00Z",
+            shared_services=[_remote_service("Tooling", "1.0.0")],
+        ),
+    )
+    await registry.update_latency("peer-a", 10.0)
+
+    await registry.register_peer("peer-b", "beta")
+    await registry.update_manifest(
+        "peer-b",
+        PeerManifest(
+            peer_id="peer-b",
+            node_name="beta",
+            timestamp="2026-06-18T19:01:00Z",
+            shared_services=[_remote_service("Tooling", "2.0.0", max_concurrent=1)],
+        ),
+    )
+    await registry.increment_active_calls("peer-b")
+
+    await registry.register_peer("peer-c", "gamma")
+    await registry.update_manifest(
+        "peer-c",
+        PeerManifest(
+            peer_id="peer-c",
+            node_name="gamma",
+            timestamp="2026-06-18T19:02:00Z",
+            shared_services=[_remote_service("Tooling", "3.0.0")],
+        ),
+    )
+
+    local_services = {
+        "Tooling": ServiceAnnouncement(
+            module="Tooling",
+            version="9.0.0",
+            methods=[
+                _method(
+                    "Tooling",
+                    input_schema={
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "api_token": {"type": "string", "default": "secret-token"},
+                            "file_path": {"type": "string", "default": "/home/user/private"},
+                        },
+                    },
+                )
+            ],
+        )
+    }
+
+    catalog = build_capability_catalog(
+        request=CapabilityCatalogRequest(modules=["Tooling"]),
+        mesh_config=mesh_config,
+        local_services=local_services,
+        peers=registry.get_all_peers(),
+        local_peer_id="local-peer",
+    )
+
+    assert catalog.secrets_redacted is True
+    assert catalog.provider_index["Tooling"] == [
+        "local:local-peer:Tooling",
+        "remote:peer-a:Tooling",
+        "remote:peer-b:Tooling",
+        "remote:peer-c:Tooling",
+    ]
+
+    peer_a_action = next(action for action in catalog.actions if action.peer_id == "peer-a")
+    assert peer_a_action.selector.peer_id == "peer-a"
+    assert peer_a_action.service_instance_id == "remote:peer-a:Tooling"
+    assert peer_a_action.bindability == "approval-required"
+    assert peer_a_action.policy.safety_class == "delegated_action"
+    assert peer_a_action.policy.required_permissions == ["Tooling.Execute"]
+    assert peer_a_action.freshness.registry_digest == "digest-Tooling-1.0.0"
+
+    peer_c_provider = next(
+        provider for provider in catalog.providers if provider.peer_id == "peer-c"
+    )
+    assert peer_c_provider.eligible is False
+    assert peer_c_provider.reason_code == "peer_not_allowed"
+
+    local_action = next(action for action in catalog.actions if action.peer_id == "local-peer")
+    assert local_action.input_schema["properties"]["query"]["type"] == "string"
+    assert local_action.input_schema["properties"]["api_token"]["description"] == "redacted"
+    assert local_action.input_schema["properties"]["file_path"]["description"] == "redacted"
+    dumped = catalog.model_dump_json()
+    assert "secret-token" not in dumped
+    assert "/home/user/private" not in dumped
+
+
+@pytest.mark.asyncio
+async def test_route_explain_reports_selected_remote_stale_denied_and_local_candidates():
+    mesh_config = MeshConfig(
+        enabled=True,
+        node_name="local-node",
+        peer_selection="lowest_latency",
+        services={
+            "Tooling": MeshServiceConfig(
+                share=True,
+                prefer="network",
+                fallback="local",
+                allowed_peers=["peer-a", "peer-stale"],
+                required_capabilities=["tools"],
+            ),
+        },
+    )
+    registry = PeerRegistry(mesh_config)
+    routing_table = RoutingTable(mesh_config, registry)
+
+    await registry.register_peer("peer-a", "alpha")
+    await registry.update_manifest(
+        "peer-a",
+        PeerManifest(peer_id="peer-a", shared_services=[_remote_service("Tooling", "1.0.0")]),
+    )
+    await registry.update_latency("peer-a", 15.0)
+
+    await registry.register_peer("peer-denied", "denied")
+    await registry.update_manifest(
+        "peer-denied",
+        PeerManifest(
+            peer_id="peer-denied",
+            shared_services=[_remote_service("Tooling", "1.0.0")],
+        ),
+    )
+
+    await registry.register_peer("peer-stale", "stale")
+    await registry.update_manifest(
+        "peer-stale",
+        PeerManifest(peer_id="peer-stale", shared_services=[_remote_service("Tooling", "1.0.0")]),
+    )
+    registry.get_peer("peer-stale").status = "stale"
+
+    response = explain_route(
+        request=RouteExplainRequest(topic="Tooling.Execute"),
+        mesh_config=mesh_config,
+        local_services={
+            "Tooling": ServiceAnnouncement(module="Tooling", version="local", methods=[])
+        },
+        registry=registry,
+        routing_table=routing_table,
+        local_peer_id="local-peer",
+    )
+
+    assert response.selected_target == "remote"
+    assert response.selected_peer_id == "peer-a"
+    assert response.selected_provider_id == "remote:peer-a:Tooling"
+    assert response.fallback_behavior == "remote_selected; fallback=local"
+
+    by_peer = {candidate.peer_id: candidate for candidate in response.candidates}
+    assert by_peer["local-peer"].included is True
+    assert by_peer["peer-a"].selected is True
+    assert by_peer["peer-denied"].reason_code == "peer_not_allowed"
+    assert by_peer["peer-denied"].blockers[0].security_privacy is True
+    assert by_peer["peer-stale"].reason_code == "peer_stale"
+
+
+@pytest.mark.asyncio
+async def test_route_explain_reports_selector_validation_failure():
+    mesh_config = MeshConfig(
+        enabled=True,
+        services={"Tooling": MeshServiceConfig(share=True, prefer="network")},
+    )
+    registry = PeerRegistry(mesh_config)
+    routing_table = RoutingTable(mesh_config, registry)
+
+    await registry.register_peer("peer-a", "alpha")
+    await registry.update_manifest(
+        "peer-a",
+        PeerManifest(peer_id="peer-a", shared_services=[_remote_service("Tooling", "1.0.0")]),
+    )
+
+    response = explain_route(
+        request=RouteExplainRequest(
+            topic="Tooling.Execute",
+            selector=MeshAddressSelector(peer_id="missing-peer"),
+        ),
+        mesh_config=mesh_config,
+        registry=registry,
+        routing_table=routing_table,
+    )
+
+    assert response.selected_target == "error"
+    assert response.selector_valid is False
+    assert response.selector_validation_code == "selector_peer_not_found"
+    assert response.security_privacy_blockers[0].code == "selector_peer_not_found"
+
+
+def test_gateway_service_registers_capability_catalog_and_explain_contracts():
+    clear_registry()
+    GatewayService()
+    gateway = list_modules()["Gateway"]
+    methods = {method.bus_topic: method for method in gateway.methods}
+
+    assert GatewayMethods.GET_CAPABILITY_CATALOG in methods
+    assert GatewayMethods.EXPLAIN_ROUTE in methods
+    assert methods[GatewayMethods.GET_CAPABILITY_CATALOG].exposure == "external"
+    assert methods[GatewayMethods.GET_CAPABILITY_CATALOG].method_type == "manage"
+    assert methods[GatewayMethods.EXPLAIN_ROUTE].required_perms == ["Gateway.manage"]
+    clear_registry()


### PR DESCRIPTION
## Summary
- Add typed Gateway capability catalog and route-explain contracts for SDK/UI route sheets.
- Register `Gateway.GetCapabilityCatalog` and `Gateway.ExplainRoute` as external manage methods.
- Build catalog/explain projections from existing registry, capability graph, peer registry, and routing-table decisions with schema redaction.

## Validation
- `.venv/bin/ruff check app/shared/contracts/models/gateway.py app/services/gateway/service.py app/services/gateway/mesh/capability_graph.py app/services/gateway/mesh/capability_catalog.py app/services/gateway/mesh/routing_table.py tests/unit/gateway/test_capability_catalog.py`
- `.venv/bin/python -m pytest tests/unit/gateway/test_capability_graph.py tests/unit/gateway/test_capability_catalog.py -q` (9 passed, 3 existing deprecation warnings)

## Notes
- `uv` is not installed on this runtime PATH, so validation used the repository `.venv` Python.
- The worktree has unrelated pre-existing local changes that were not staged or included in this PR.
