### PR TITLE
PER-158: Add orchestrator tool approval interrupts

### DIFF
--- a/.omx/plans/PER-158-mesh-gap-006-orchestrator-sdk-approval.md
+++ b/.omx/plans/PER-158-mesh-gap-006-orchestrator-sdk-approval.md
@@ -1,0 +1,64 @@
+# PER-158 / MESH-GAP-006 Plan
+
+## Sources
+
+- Multica issue PER-158 / MESH-GAP-006.
+- `.omx/multica/mesh-production-gap-tasks/06-mesh-gap-006-mesh-gap-p3-integrate-orchestrator-and-sdk-with-capability-catalog-aggregate-tools-and-app.md`
+- `.omx/plans/mesh-production-e2e-integration-gap-plan.md`
+- `.omx/specs/deep-interview-mesh-distributed-integration.md`
+- `.omx/specs/ui-refinement/aurora-ui-sdk-contract.md`
+- `.omx/specs/ui-production-tasks/tasks/SDK-006-implement-capability-graph-engine.md`
+- `.omx/specs/ui-production-tasks/tasks/SDK-012-implement-route-privacy-policy-engine.md`
+- `.omx/specs/ui-production-tasks/tasks/UIA-003-wire-tool-approval-cards-and-tool-result-display.md`
+
+## Scope
+
+Implement the orchestrator/backend slice now available on `feat/mesh-full-services-integrations`:
+
+- Use the aggregate Tooling catalog for safe local plus remote binding.
+- Preserve hidden provider metadata from catalog discovery through execution.
+- Add an orchestrator approval interrupt payload for approval-required local and remote tools.
+- Keep local-only fallback behavior when aggregate catalog is unavailable.
+- Update SDK/UI planning specs to require the client APIs and event stream over the concrete Gateway/Tooling methods already landed.
+
+Do not scaffold a production `@aurora/client` package in this task because the repo currently has only UI/SDK planning artifacts and mock reference files; SDK package creation remains owned by `SDK-001`.
+
+## Code Paths
+
+- `app/services/orchestrator/tool_bindings.py`
+- `app/services/orchestrator/agents/chatbot.py`
+- `app/services/orchestrator/graph.py`
+- `app/services/orchestrator/state.py`
+- `app/shared/contracts/models/tooling.py`
+- `.omx/specs/ui-production-tasks/tasks/SDK-006-implement-capability-graph-engine.md`
+- `.omx/specs/ui-production-tasks/tasks/SDK-012-implement-route-privacy-policy-engine.md`
+- `.omx/specs/ui-production-tasks/tasks/UIA-003-wire-tool-approval-cards-and-tool-result-display.md`
+- `tests/unit/orchestrator/test_tool_bindings.py`
+- `tests/unit/orchestrator/test_graph.py`
+- `tests/unit/orchestrator/test_chatbot.py`
+
+## Invariants
+
+- Bus-only service interaction with typed `ToolingMethods` constants and IO models.
+- Unsafe or approval-required tools are not auto-bound to the LLM.
+- Approval interrupts preserve global tool id, provider peer id, service instance id, mesh selector, policy decision id, correlation id, and approval request id.
+- No broad Auth/Config/raw DB/audio exposure changes.
+
+## Steps
+
+1. Extend orchestrator binding metadata to track non-bindable approval candidates from catalog `blocked_tools`.
+2. Have chatbot keep safe bindable tools for LLM context and store approval candidates in graph state.
+3. In graph tool execution, detect a tool call matching an approval candidate, request approval via `Tooling.RequestApproval`, and return a structured tool message payload instead of executing the tool.
+4. Add tests for safe remote execution metadata, unsafe local/remote approval interrupts, deterministic name collisions, and local-only fallback.
+5. Update SDK/UI task specs with concrete `client.capabilities`, `client.routes`, `client.tools`, and approval event stream requirements tied to Gateway/Tooling contracts.
+6. Run focused pytest coverage and then commit/PR to `feat/mesh-full-services-integrations`.
+
+## Verification
+
+- `uv run pytest tests/unit/orchestrator/test_tool_bindings.py tests/unit/orchestrator/test_chatbot.py tests/unit/orchestrator/test_graph.py -q`
+- `uv run pytest tests/unit/tooling/test_service.py tests/unit/gateway/test_capability_catalog.py -q`
+
+## Risks
+
+- A model cannot select a tool that is not bound. Mitigation: approval candidates remain in state for UI/session-driven approval requests; bound LLM tools remain safe only.
+- SDK implementation is planning-only in this repo. Mitigation: update the authoritative task specs and call out the absence of a package in handoff.

--- a/.omx/specs/ui-production-tasks/tasks/SDK-006-implement-capability-graph-engine.md
+++ b/.omx/specs/ui-production-tasks/tasks/SDK-006-implement-capability-graph-engine.md
@@ -96,6 +96,9 @@ This task is now downstream of `.omx/multica/mesh-production-gap-tasks/03-mesh-g
 
 Additional requirements:
 
+- Expose the capability catalog through `client.capabilities.listCatalog(options)` over `Gateway.GetCapabilityCatalog`, preserving raw action/provider IDs, selector fields, bindability, policy flags, freshness, blockers, and `secrets_redacted`.
+- Expose aggregate tool inventory through `client.tools.listCatalog(options)` over `Tooling.GetToolCatalog`, returning bindable tools and approval/blocked candidates as separate collections rather than dropping blocked capabilities.
+- Add `client.capabilities.explain(featureId)` as an SDK projection over the cached catalog node plus the latest provider/route blockers; it must include the next backend-backed repair action when available.
 - Consume the backend typed capability catalog once `Gateway.GetCapabilityCatalog` / equivalent lands, including local node, remote peer, transport, service, method, tool, model, audio, scheduler, and data/RAG capabilities.
 - Merge capability facts from local HTTP Gateway, Tauri native manifest, mobile native manifest, persisted peers, live WebRTC sessions, and policy results into one deterministic feature-state graph.
 - Preserve provider identity in feature states: `local`, `remote:<peer_id>`, `native:<platform>`, `cloud`, `unavailable`, and `blocked` must be distinguishable.
@@ -110,3 +113,4 @@ Additional acceptance criteria:
 - UI tasks can ask `AuroraClient.capabilities.explain(featureId)` and receive a stable explanation with provider candidates and next repair action.
 - Capability graph tests prove that local and remote tool providers coexist and remain separately selectable.
 - Capability graph tests prove explicit selector policy blocks unsafe fallback.
+- SDK fixtures include `Tooling.GetToolCatalog` responses with `blocked_tools` for approval-required local and remote tools, and graph tests prove those become approval-card candidates rather than bindable model tools.

--- a/.omx/specs/ui-production-tasks/tasks/SDK-012-implement-route-privacy-policy-engine.md
+++ b/.omx/specs/ui-production-tasks/tasks/SDK-012-implement-route-privacy-policy-engine.md
@@ -96,6 +96,13 @@ This task is now downstream of `MESH-GAP-002`, `MESH-GAP-003`, and `MESH-GAP-005
 
 Additional requirements:
 
+- Expose `client.routes.explain(request)` over `Gateway.ExplainRoute`; SDK route decisions must cite backend `selected`, `candidates`, `reason_code`, fallback, freshness, and explicit-selector blockers rather than recomputing mesh policy.
+- Expose Tooling preflight APIs with typed request/response wrappers:
+  - `client.tools.prepareExecution(request)` -> `Tooling.PrepareExecution`
+  - `client.tools.requestApproval(request)` -> `Tooling.RequestApproval`
+  - `client.tools.confirmExecution(request)` -> `Tooling.ConfirmExecution`
+  - `client.tools.execute(request)` -> `Tooling.ExecuteTool`
+- Preserve approval binding fields end to end: global tool ID, provider peer ID, service instance ID, route selector, args hash, resource selector hash, policy decision ID, approval request ID, approval token expiry, approver principal, and correlation ID.
 - Consume route explain output (`Gateway.ExplainRoute` / equivalent) rather than independently guessing backend routing decisions.
 - Model explicit resource selectors as required for tools, DB/RAG namespaces, audio/STT/TTS sessions, scheduler ownership, hardware/device access, model runtime selection, and admin mutations when policy marks them safety-sensitive.
 - Treat internal/local tools and remote mesh tools uniformly through the approval policy engine: both can require user approval, admin confirmation, dry-run preview, deny, or approve-all scope.
@@ -107,3 +114,4 @@ Additional acceptance criteria:
 
 - `RouteSheet` and approval cards can show exact backend route decisions, not duplicated SDK guesses.
 - Tests cover local dangerous tool approval, remote dangerous tool approval, approve-all session behavior, expired approvals, route denial, replay/mismatched args rejection, and explicit selector missing errors.
+- SDK conformance tests cover HTTP transport, Tauri-local mock transport, and mesh mock transport for the four Tooling execution APIs and route explain.

--- a/.omx/specs/ui-production-tasks/tasks/UIA-003-wire-tool-approval-cards-and-tool-result-display.md
+++ b/.omx/specs/ui-production-tasks/tasks/UIA-003-wire-tool-approval-cards-and-tool-result-display.md
@@ -90,6 +90,13 @@ This UI must support the production approval harness from `MESH-GAP-005` and the
 
 Additional requirements:
 
+- Render orchestrator approval interrupts with payload type `tool_approval_request` as first-class tool cards. Required fields are `approval_request_id`, `correlation_id`, `policy_decision_id`, `global_tool_id`, `provider_peer_id`, `provider_service_instance_id`, `mesh_selector`, `arguments`, `args_schema`, `approval_mode`, `expires_at`, `safety_class`, `execution_location`, `reason_code`, and `reason`.
+- Approval cards must call SDK methods only:
+  - request/preflight state through `client.tools.prepareExecution()` or the orchestrator-provided interrupt payload,
+  - approval through `client.tools.requestApproval()` when the card is created outside orchestrator,
+  - admin/user decision through `client.tools.confirmExecution()`,
+  - final execution through `client.tools.execute()` with the returned approval token.
+- Subscribe to the SDK event stream for `tool.approval.requested`, `tool.approval.approved`, `tool.approval.denied`, `tool.execution.executed`, and `tool.execution.failed`; events must be correlated by `correlation_id` and `approval_request_id`.
 - Show provider choice when a tool exists locally and on one or more peers. Default selection must follow route/privacy policy and explicit selector requirements.
 - Render approval cards for local/internal tools, remote mesh tools, MCP/plugin tools, and cloud/external tools using one visual grammar.
 - Show risk class, data egress, mutating/admin flags, peer/provider, trust tier, transport, args diff/hash, dry-run preview, requested approval scope, TTL, and audit destination.
@@ -108,3 +115,4 @@ Additional mock/component references:
 Additional acceptance criteria:
 
 - Component tests cover local dangerous tool, remote dangerous tool, duplicated local+remote tool, approve-all session, approve-all peer, dry-run-only, denied, expired approval, replay rejection, and service unavailable.
+- Component tests verify orchestrator `tool_approval_request` payloads render without a direct backend fetch and preserve hidden provider metadata for the follow-up SDK calls.

--- a/.omx/specs/ui-refinement/aurora-ui-sdk-contract.md
+++ b/.omx/specs/ui-refinement/aurora-ui-sdk-contract.md
@@ -29,7 +29,16 @@ The SDK should normalize backend responses into small view models without discar
 - `RouteSummary`: module, decision target, provider peer, reason, fallback, provider candidates, error code.
 - `CapabilitySummary`: service instance, provider peer, method/resource, selector address, policy flags, routable/blockers.
 - `RemoteActionPreflight`: target selector, policy flags, required confirmation/consent/resource fields, expected audit/correlation fields.
+- `ToolApprovalRequest`: approval request ID, correlation ID, policy decision ID, global tool ID, provider peer/service IDs, mesh/resource selectors, args schema/hash, approval mode, expiry, status, denial reason, and required follow-up action.
 - `AuditReference`: correlation ID, event kind, peer, method/tool/resource, status, redacted detail availability.
+
+Required high-level client namespaces once `@aurora/client` is implemented:
+
+- `client.capabilities.listCatalog()` over `Gateway.GetCapabilityCatalog`.
+- `client.routes.explain()` over `Gateway.ExplainRoute`.
+- `client.tools.listCatalog()` over `Tooling.GetToolCatalog`.
+- `client.tools.prepareExecution()`, `client.tools.requestApproval()`, `client.tools.confirmExecution()`, and `client.tools.execute()` over the matching Tooling contracts.
+- Approval/tool execution events for requested, approved, denied, executed, and failed states, correlated by backend IDs.
 
 ## Privacy And Redaction
 

--- a/app/services/orchestrator/agents/chatbot.py
+++ b/app/services/orchestrator/agents/chatbot.py
@@ -6,7 +6,10 @@ from app.helpers.getUseHardwareAcceleration import get_use_hardware_acceleration
 from app.messaging import MessageBus
 from app.messaging.priority_helpers import get_interactive_priority
 from app.services.orchestrator.state import State
-from app.services.orchestrator.tool_bindings import build_tool_bindings
+from app.services.orchestrator.tool_bindings import (
+    build_tool_approval_candidates,
+    build_tool_bindings,
+)
 from app.shared.config.interface import ConfigAPI
 from app.shared.config.keys import ConfigKeys
 from app.shared.config.models import (
@@ -388,6 +391,7 @@ async def chatbot(state: State, bus: MessageBus):
         )
 
     tool_bindings = {}
+    approval_candidates = {}
     if not result.ok:
         log_error(f"Failed to get tools from ToolingService: {result.error}")
         tools = []
@@ -403,6 +407,9 @@ async def chatbot(state: State, bus: MessageBus):
             if not tool_schemas:
                 log_warning("No tools returned from ToolingService")
             tools, tool_bindings = build_tool_bindings(tool_schemas)
+            approval_candidates = build_tool_approval_candidates(
+                result.data.get("blocked_tools", [])
+            )
             log_debug(f"Loaded {len(tools)} tools for LLM binding")
         else:
             log_error(f"Unexpected result.data type: {type(result.data)}")
@@ -435,4 +442,5 @@ async def chatbot(state: State, bus: MessageBus):
             )
         ],
         "tool_bindings": tool_bindings,
+        "approval_candidates": approval_candidates,
     }

--- a/app/services/orchestrator/graph.py
+++ b/app/services/orchestrator/graph.py
@@ -4,6 +4,7 @@ This module manages the conversational flow using LangGraph, coordinating
 between the chatbot agent and tool execution via the message bus.
 """
 
+import json
 from typing import Any, Literal, Union
 
 from langchain_core.messages import AnyMessage, ToolMessage
@@ -18,7 +19,11 @@ from app.messaging.priority_helpers import get_interactive_priority
 from app.services.orchestrator.agents.chatbot import chatbot
 from app.services.orchestrator.state import State
 from app.shared.contracts.models.mesh import MeshAddressSelector
-from app.shared.contracts.models.tooling import ToolingExecuteToolRequest, ToolingMethods
+from app.shared.contracts.models.tooling import (
+    ToolingExecuteToolRequest,
+    ToolingMethods,
+    ToolingRequestApprovalRequest,
+)
 from app.shared.contracts.models.tts import TTSMethods
 from app.shared.messaging.models.tts_models import TTSRequest
 
@@ -101,12 +106,29 @@ class GraphOrchestrator:
 
         tool_messages = []
         tool_bindings = state.get("tool_bindings", {})
+        approval_candidates = state.get("approval_candidates", {})
 
         # Execute each tool call via bus
         for tool_call in last_message.tool_calls:
             tool_name = tool_call["name"]
             tool_args = tool_call.get("args", {})
             tool_id = tool_call.get("id", "")
+            candidate = (
+                approval_candidates.get(tool_name, {})
+                if isinstance(approval_candidates, dict)
+                else {}
+            )
+            if candidate:
+                tool_messages.append(
+                    await self._request_tool_approval(
+                        tool_name=tool_name,
+                        tool_args=tool_args,
+                        tool_call_id=tool_id,
+                        candidate=candidate,
+                    )
+                )
+                continue
+
             binding = tool_bindings.get(tool_name, {}) if isinstance(tool_bindings, dict) else {}
             request = self._tool_execution_request(tool_name, tool_args, binding)
 
@@ -154,6 +176,56 @@ class GraphOrchestrator:
 
         return {"messages": tool_messages}
 
+    async def _request_tool_approval(
+        self,
+        *,
+        tool_name: str,
+        tool_args: dict[str, Any],
+        tool_call_id: str,
+        candidate: dict[str, Any],
+    ) -> ToolMessage:
+        """Create an approval request instead of executing a blocked tool."""
+
+        request = self._tool_approval_request(tool_name, tool_args, candidate)
+        log_debug(f"Requesting tool approval via bus: {tool_name}")
+
+        try:
+            result = await self.bus.request(
+                ToolingMethods.REQUEST_APPROVAL,
+                request,
+                timeout=10.0,
+                priority=get_interactive_priority(),
+            )
+        except Exception as e:
+            error_msg = f"Failed to request tool approval via bus: {str(e)}"
+            log_error(error_msg, exc_info=True)
+            return ToolMessage(
+                content=json.dumps(
+                    {
+                        "type": "tool_approval_request",
+                        "status": "failed",
+                        "tool_name": tool_name,
+                        "error": error_msg,
+                    },
+                    sort_keys=True,
+                ),
+                tool_call_id=tool_call_id,
+                name=tool_name,
+            )
+
+        approval_payload = self._approval_payload(
+            tool_name=tool_name,
+            tool_args=tool_args,
+            candidate=candidate,
+            result_data=result.data if result.ok else None,
+            error=result.error if not result.ok else None,
+        )
+        return ToolMessage(
+            content=json.dumps(approval_payload, sort_keys=True),
+            tool_call_id=tool_call_id,
+            name=tool_name,
+        )
+
     @staticmethod
     def _tool_execution_request(
         tool_name: str, tool_args: dict[str, Any], binding: dict[str, Any]
@@ -173,6 +245,58 @@ class GraphOrchestrator:
             arguments=tool_args,
             mesh_selector=mesh_selector,
         )
+
+    @classmethod
+    def _tool_approval_request(
+        cls, tool_name: str, tool_args: dict[str, Any], candidate: dict[str, Any]
+    ) -> ToolingRequestApprovalRequest:
+        """Build a Tooling approval request from hidden candidate metadata."""
+
+        execution_request = cls._tool_execution_request(tool_name, tool_args, candidate)
+        return ToolingRequestApprovalRequest(**execution_request.model_dump())
+
+    @staticmethod
+    def _approval_payload(
+        *,
+        tool_name: str,
+        tool_args: dict[str, Any],
+        candidate: dict[str, Any],
+        result_data: Any,
+        error: str | None,
+    ) -> dict[str, Any]:
+        """Return a structured UI/session approval card payload."""
+
+        if hasattr(result_data, "model_dump"):
+            data = result_data.model_dump()
+        elif isinstance(result_data, dict):
+            data = result_data
+        else:
+            data = {}
+
+        policy_decision = data.get("policy_decision") or {}
+        return {
+            "type": "tool_approval_request",
+            "status": "requested" if data.get("ok") else "failed",
+            "tool_name": tool_name,
+            "display_name": candidate.get("display_name") or tool_name,
+            "description": candidate.get("description") or "",
+            "arguments": tool_args,
+            "args_schema": candidate.get("args_schema") or {},
+            "approval_request_id": data.get("approval_request_id"),
+            "expires_at": data.get("expires_at"),
+            "correlation_id": data.get("correlation_id"),
+            "policy_decision_id": policy_decision.get("decision_id"),
+            "approval_mode": policy_decision.get("approval_mode"),
+            "reason_code": candidate.get("reason_code"),
+            "reason": error or data.get("error") or candidate.get("reason"),
+            "provider_peer_id": candidate.get("provider_peer_id"),
+            "provider_service_instance_id": candidate.get("provider_service_instance_id"),
+            "global_tool_id": candidate.get("global_tool_id"),
+            "mesh_selector": candidate.get("mesh_selector"),
+            "safety_class": candidate.get("safety_class"),
+            "execution_location": candidate.get("execution_location"),
+            "required_permissions": candidate.get("required_permissions") or [],
+        }
 
     def _tools_end_condition(
         self,

--- a/app/services/orchestrator/state.py
+++ b/app/services/orchestrator/state.py
@@ -1,7 +1,6 @@
-from typing import Annotated
+from typing import Annotated, NotRequired, TypedDict
 
 from langgraph.graph.message import add_messages
-from typing_extensions import NotRequired, TypedDict
 
 
 # New messages from both the user and the assistant are persisted in the state
@@ -11,3 +10,4 @@ class State(TypedDict):
     # (in this case, it appends messages to the list, rather than overwriting them)
     messages: Annotated[list, add_messages]
     tool_bindings: NotRequired[dict]
+    approval_candidates: NotRequired[dict]

--- a/app/services/orchestrator/tool_bindings.py
+++ b/app/services/orchestrator/tool_bindings.py
@@ -7,8 +7,8 @@ from typing import Any
 from langchain_core.tools import StructuredTool
 from pydantic import Field, create_model
 
-
 ToolBinding = dict[str, Any]
+ApprovalCandidate = dict[str, Any]
 
 
 def build_tool_bindings(
@@ -43,16 +43,61 @@ def build_tool_bindings(
     return tools, bindings
 
 
+def build_tool_approval_candidates(
+    blocked_tool_schemas: list[dict[str, Any]],
+) -> dict[str, ApprovalCandidate]:
+    """Build UI/session approval candidates from non-bindable catalog tools."""
+
+    candidates: dict[str, ApprovalCandidate] = {}
+    for blocked in blocked_tool_schemas:
+        tool_schema = blocked.get("tool") if isinstance(blocked, dict) else None
+        if not isinstance(tool_schema, dict) or not _requires_approval_interrupt(
+            tool_schema, blocked
+        ):
+            continue
+
+        candidate_name = _unique_tool_name(
+            str(tool_schema.get("name") or tool_schema.get("local_name") or "approval_tool"),
+            candidates,
+        )
+        candidates[candidate_name] = {
+            **_execution_binding(tool_schema, candidate_name),
+            "approval_required": True,
+            "reason_code": blocked.get("reason_code"),
+            "reason": blocked.get("reason"),
+            "display_name": tool_schema.get("display_name") or candidate_name,
+            "description": tool_schema.get("description") or "",
+            "args_schema": tool_schema.get("args_schema") or tool_schema.get("schema") or {},
+            "required_permissions": list(tool_schema.get("required_permissions") or []),
+        }
+
+    return candidates
+
+
 def _is_safe_to_bind(schema: dict[str, Any]) -> bool:
     """Return whether a discovered tool may be advertised to the LLM."""
-
-    is_remote = _is_remote_tool(schema)
-    if not is_remote:
-        return True
 
     safety_class = schema.get("safety_class") or "standard"
     confirmation_required = bool(schema.get("confirmation_required"))
     return safety_class == "standard" and not confirmation_required
+
+
+def _requires_approval_interrupt(
+    schema: dict[str, Any], blocked_metadata: dict[str, Any]
+) -> bool:
+    """Return whether a blocked catalog tool should surface as an approval card."""
+
+    safety_class = schema.get("safety_class") or "standard"
+    reason_code = blocked_metadata.get("reason_code")
+    return bool(schema.get("confirmation_required")) or safety_class in {
+        "sensitive",
+        "dangerous",
+    } or reason_code in {
+        "confirmation_required",
+        "safety_class_sensitive",
+        "safety_class_dangerous",
+        "approval_required",
+    }
 
 
 def _is_remote_tool(schema: dict[str, Any]) -> bool:

--- a/tests/unit/orchestrator/test_chatbot.py
+++ b/tests/unit/orchestrator/test_chatbot.py
@@ -172,26 +172,44 @@ class TestChatbotToolRetrieval:
                             "description": "A test tool",
                             "args_schema": {"properties": {}, "required": []},
                         }
-                    ]
+                    ],
+                    "blocked_tools": [
+                        {
+                            "reason_code": "confirmation_required",
+                            "reason": "tool requires approval before it can be model-bound",
+                            "tool": {
+                                "name": "delete_file",
+                                "local_name": "delete_file",
+                                "global_tool_id": "local:Tooling:tool:delete_file",
+                                "provider_peer_id": "local",
+                                "provider_service_instance_id": "local:Tooling",
+                                "display_name": "delete_file",
+                                "description": "Delete a file.",
+                                "args_schema": {"properties": {}, "required": []},
+                                "execution_location": "local",
+                                "source_type": "local",
+                                "safety_class": "dangerous",
+                                "confirmation_required": True,
+                            },
+                        }
+                    ],
                 },
             ),  # Tool retrieval
         ]
 
         with (
             _patch_llm_for_chatbot(),
-            patch(
-                "app.services.orchestrator.agents.chatbot.ToolingGetToolCatalogRequest"
-            ) as mock_catalog_request,
+            patch("app.services.orchestrator.agents.chatbot.ToolingGetToolCatalogRequest"),
         ):
             result = await chatbot(mock_state, bus=mock_bus)
 
             # Verify tools were requested via bus
             assert mock_bus.request.call_count >= 2
             assert mock_bus.request.call_args_list[1][0][0] == ToolingMethods.GET_TOOL_CATALOG
-            mock_catalog_request.assert_called_once()
 
             # LLM was called to produce a response
             assert "messages" in result
+            assert result["approval_candidates"]["delete_file"]["approval_required"] is True
 
     @pytest.mark.asyncio
     async def test_chatbot_falls_back_to_legacy_get_tools(self, mock_bus, mock_state):
@@ -246,7 +264,7 @@ class TestChatbotLLMIntegration:
                 "app.services.orchestrator.agents.chatbot._initialize_llm", new_callable=AsyncMock
             ),
             patch("app.services.orchestrator.agents.chatbot.llm", None),
-            contextlib.suppress(ValueError),
+            contextlib.suppress(ValueError, ModuleNotFoundError),
         ):
             # Should raise or handle gracefully; accept either
             await chatbot(mock_state, bus=mock_bus)

--- a/tests/unit/orchestrator/test_graph.py
+++ b/tests/unit/orchestrator/test_graph.py
@@ -1,5 +1,6 @@
 """Unit tests for GraphOrchestrator."""
 
+import json
 import sys
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -175,6 +176,143 @@ class TestGraphOrchestratorToolExecution:
         assert request.mesh_selector.service_instance_id == "remote:raspi-lab:Tooling"
         assert request.mesh_selector.tool_id == request.tool_name
         assert result["messages"][0].content == "remote result"
+
+    @pytest.mark.asyncio
+    async def test_approval_required_remote_tool_requests_approval(
+        self, graph_orchestrator, mock_bus
+    ):
+        """Blocked remote tool selections create approval interrupts."""
+        from langchain_core.messages import AIMessage
+
+        from app.messaging import QueryResult
+        from app.shared.contracts.models.tooling import ToolingMethods
+
+        mock_bus.request.return_value = QueryResult(
+            ok=True,
+            data={
+                "ok": True,
+                "approval_request_id": "approval-123",
+                "expires_at": 12345.0,
+                "correlation_id": "corr-123",
+                "policy_decision": {
+                    "decision_id": "decision-123",
+                    "approval_mode": "ask_each_time",
+                },
+            },
+        )
+
+        ai_message = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "raspi-lab_unlock_door",
+                    "args": {"door": "front"},
+                    "id": "tool_approval",
+                }
+            ],
+        )
+        state = State(
+            messages=[ai_message],
+            approval_candidates={
+                "raspi-lab_unlock_door": {
+                    "tool_name": "raspi-lab:remote_raspi-lab_Tooling:tool:unlock_door",
+                    "global_tool_id": "raspi-lab:remote_raspi-lab_Tooling:tool:unlock_door",
+                    "provider_peer_id": "raspi-lab",
+                    "provider_service_instance_id": "remote:raspi-lab:Tooling",
+                    "display_name": "raspi-lab.unlock_door",
+                    "description": "Unlock a door.",
+                    "args_schema": {"type": "object", "properties": {}},
+                    "execution_location": "remote",
+                    "safety_class": "dangerous",
+                    "required_permissions": ["Tooling.ExecuteTool"],
+                    "reason_code": "confirmation_required",
+                    "reason": "approval required",
+                    "mesh_selector": {
+                        "peer_id": "raspi-lab",
+                        "provider_id": "raspi-lab",
+                        "service_instance_id": "remote:raspi-lab:Tooling",
+                        "tool_id": "raspi-lab:remote_raspi-lab_Tooling:tool:unlock_door",
+                    },
+                }
+            },
+        )
+
+        result = await graph_orchestrator._execute_tools_via_bus(state)
+
+        mock_bus.request.assert_called_once()
+        assert mock_bus.request.await_args.args[0] == ToolingMethods.REQUEST_APPROVAL
+        request = mock_bus.request.await_args.args[1]
+        assert request.tool_name == "raspi-lab:remote_raspi-lab_Tooling:tool:unlock_door"
+        assert request.arguments == {"door": "front"}
+        assert request.mesh_selector.peer_id == "raspi-lab"
+        payload = json.loads(result["messages"][0].content)
+        assert payload["type"] == "tool_approval_request"
+        assert payload["status"] == "requested"
+        assert payload["approval_request_id"] == "approval-123"
+        assert payload["policy_decision_id"] == "decision-123"
+        assert payload["provider_peer_id"] == "raspi-lab"
+        assert payload["global_tool_id"] == request.tool_name
+
+    @pytest.mark.asyncio
+    async def test_approval_required_local_tool_requests_approval(
+        self, graph_orchestrator, mock_bus
+    ):
+        """Local approval-required tools use the same interrupt path."""
+        from langchain_core.messages import AIMessage
+
+        from app.messaging import QueryResult
+        from app.shared.contracts.models.tooling import ToolingMethods
+
+        mock_bus.request.return_value = QueryResult(
+            ok=True,
+            data={
+                "ok": True,
+                "approval_request_id": "local-approval",
+                "correlation_id": "local-corr",
+                "policy_decision": {
+                    "decision_id": "local-decision",
+                    "approval_mode": "allow_once",
+                },
+            },
+        )
+
+        ai_message = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "delete_file",
+                    "args": {"path": "/tmp/example"},
+                    "id": "tool_local_approval",
+                }
+            ],
+        )
+        state = State(
+            messages=[ai_message],
+            approval_candidates={
+                "delete_file": {
+                    "tool_name": "delete_file",
+                    "global_tool_id": "local:Tooling:tool:delete_file",
+                    "provider_peer_id": "local",
+                    "provider_service_instance_id": "local:Tooling",
+                    "display_name": "delete_file",
+                    "execution_location": "local",
+                    "safety_class": "dangerous",
+                    "reason_code": "confirmation_required",
+                    "reason": "approval required",
+                }
+            },
+        )
+
+        result = await graph_orchestrator._execute_tools_via_bus(state)
+
+        mock_bus.request.assert_called_once()
+        assert mock_bus.request.await_args.args[0] == ToolingMethods.REQUEST_APPROVAL
+        request = mock_bus.request.await_args.args[1]
+        assert request.tool_name == "delete_file"
+        assert request.mesh_selector is None
+        payload = json.loads(result["messages"][0].content)
+        assert payload["approval_request_id"] == "local-approval"
+        assert payload["execution_location"] == "local"
 
     @pytest.mark.asyncio
     async def test_execute_tools_no_tool_calls(self, graph_orchestrator):

--- a/tests/unit/orchestrator/test_tool_bindings.py
+++ b/tests/unit/orchestrator/test_tool_bindings.py
@@ -1,6 +1,9 @@
 """Unit tests for orchestrator Tooling binding metadata."""
 
-from app.services.orchestrator.tool_bindings import build_tool_bindings
+from app.services.orchestrator.tool_bindings import (
+    build_tool_approval_candidates,
+    build_tool_bindings,
+)
 
 
 def test_build_tool_bindings_keeps_local_and_safe_remote_tools():
@@ -75,6 +78,31 @@ def test_build_tool_bindings_hides_remote_confirmation_required_tools():
     assert bindings == {}
 
 
+def test_build_tool_bindings_hides_local_confirmation_required_tools():
+    """High-risk local tools also require approval instead of model binding."""
+
+    tools, bindings = build_tool_bindings(
+        [
+            {
+                "name": "delete_file",
+                "local_name": "delete_file",
+                "global_tool_id": "local:Tooling:tool:delete_file",
+                "provider_peer_id": "local",
+                "provider_service_instance_id": "local:Tooling",
+                "description": "Delete a file.",
+                "args_schema": {"type": "object", "properties": {}},
+                "execution_location": "local",
+                "source_type": "local",
+                "safety_class": "dangerous",
+                "confirmation_required": True,
+            }
+        ]
+    )
+
+    assert tools == []
+    assert bindings == {}
+
+
 def test_build_tool_bindings_resolves_duplicate_names_deterministically():
     """Unexpected duplicate bind names are suffixed while preserving provider IDs."""
 
@@ -110,3 +138,42 @@ def test_build_tool_bindings_resolves_duplicate_names_deterministically():
     assert [tool.name for tool in tools] == ["remote_status", "remote_status_2"]
     assert bindings["remote_status"]["tool_name"] == "peer-a:service:tool:status"
     assert bindings["remote_status_2"]["tool_name"] == "peer-b:service:tool:status"
+
+
+def test_build_tool_approval_candidates_preserves_provider_metadata():
+    """Blocked unsafe tools become UI/session approval candidates."""
+
+    candidates = build_tool_approval_candidates(
+        [
+            {
+                "reason_code": "confirmation_required",
+                "reason": "tool requires approval before it can be model-bound",
+                "tool": {
+                    "name": "raspi-lab_unlock_door",
+                    "local_name": "unlock_door",
+                    "global_tool_id": "raspi-lab:service:tool:unlock_door",
+                    "provider_peer_id": "raspi-lab",
+                    "provider_service_instance_id": "remote:raspi-lab:Tooling",
+                    "display_name": "raspi-lab.unlock_door",
+                    "description": "Unlock a door.",
+                    "args_schema": {
+                        "type": "object",
+                        "properties": {"door": {"type": "string"}},
+                    },
+                    "execution_location": "remote",
+                    "source_type": "mesh_peer",
+                    "safety_class": "dangerous",
+                    "confirmation_required": True,
+                    "required_permissions": ["Tooling.ExecuteTool"],
+                },
+            }
+        ]
+    )
+
+    candidate = candidates["raspi-lab_unlock_door"]
+    assert candidate["approval_required"] is True
+    assert candidate["tool_name"] == "raspi-lab:service:tool:unlock_door"
+    assert candidate["mesh_selector"]["peer_id"] == "raspi-lab"
+    assert candidate["mesh_selector"]["service_instance_id"] == "remote:raspi-lab:Tooling"
+    assert candidate["global_tool_id"] == "raspi-lab:service:tool:unlock_door"
+    assert candidate["reason_code"] == "confirmation_required"


### PR DESCRIPTION
## Summary

- Adds orchestrator approval candidates from aggregate Tooling catalog `blocked_tools` so approval-required local and remote tools are not model-bound but can surface as structured approval-card payloads.
- Routes approval-required tool calls through `Tooling.RequestApproval` instead of `Tooling.ExecuteTool`, preserving global tool ID, provider peer/service IDs, mesh selector, policy decision ID, correlation ID, and approval request metadata.
- Updates SDK/UI planning specs to pin the required `client.capabilities`, `client.routes`, `client.tools`, and approval event surfaces over existing Gateway/Tooling contracts.

## Notes

The repo does not currently contain a production `@aurora/client` package; SDK implementation remains owned by the SDK scaffold tasks. This PR updates the authoritative SDK/UI task specs and implements the backend/orchestrator slice available on the mesh integration branch.

The worktree contains unrelated unstaged changes in DB/Gateway/STT/Scheduler/docs/assets from other task lanes; only the PER-158 files are committed here.

## Verification

- `.venv/bin/ruff check app/services/orchestrator/agents/chatbot.py app/services/orchestrator/graph.py app/services/orchestrator/state.py app/services/orchestrator/tool_bindings.py tests/unit/orchestrator/test_tool_bindings.py tests/unit/orchestrator/test_chatbot.py tests/unit/orchestrator/test_graph.py`
- `.venv/bin/python -m pytest tests/unit/orchestrator/test_tool_bindings.py tests/unit/orchestrator/test_chatbot.py tests/unit/orchestrator/test_graph.py -q` -> 28 passed, 4 existing warnings
- `.venv/bin/python -m pytest tests/unit/tooling/test_service.py tests/unit/gateway/test_capability_catalog.py -q` -> 54 passed, 4 existing warnings

`uv` was unavailable in this runtime (`zsh: command not found: uv`), so verification used the repo `.venv` Python.
