### PR TITLE
PER-159 Add RAG namespace provenance contracts

### DIFF
--- a/.omx/plans/PER-159-db-rag-namespace-provenance.md
+++ b/.omx/plans/PER-159-db-rag-namespace-provenance.md
@@ -1,0 +1,50 @@
+# PER-159 DB/RAG Namespace Provenance Plan
+
+## Requirements Summary
+
+- Add DB/RAG contracts for namespace catalog, provenance lookup, namespace export, namespace import, and policy-aware remote search.
+- Preserve Aurora bus-first contracts: typed `DBMethods`, `IOModel` request/response models, and `@method_contract` handlers.
+- Keep raw SQL internal-only and do not expose Auth credentials, mesh secrets, trust state, embeddings, private filesystem paths, or unrelated peer/user records.
+- Make remote RAG access explicit: sensitive namespace remote searches require a namespace/data-scope selector and return a policy denial instead of silently falling back.
+- Export/import snapshots preserve source/owner peer, namespace, record ID, principal marker, timestamps, schema version, policy decision, correlation ID, and tombstone metadata.
+
+## Source Context
+
+- Issue PER-159 acceptance criteria and backend requirements.
+- `docs/DATA_SHARING_POLICY.md`: domain matrix and no-raw-SQL/privacy requirements.
+- `.omx/specs/deep-interview-mesh-distributed-integration.md`: Phase 4 data-sharing mode guidance.
+- `.omx/plans/mesh-production-e2e-integration-gap-plan.md`: DB/RAG production gap requirements.
+- `.omx/specs/ui-production-tasks/tasks/BE-017-add-memory-rag-provenance-export-delete-contracts.md`: UI/SDK contract expectations.
+- `app/shared/contracts/models/db.py`: current DB/RAG method constants and IO models.
+- `app/services/db/service.py`: current internal RAG store/get/list/delete, external RAG search, and internal SQL execution.
+- `tests/unit/db/test_service.py`: current DB service unit-test pattern.
+
+## Acceptance Criteria
+
+- `DBMethods` includes namespace list, remote search, provenance, export namespace, and import namespace contracts.
+- Namespace catalog response reports namespace, owner/source peer, availability, policy, allowed operations, export/import support, privacy class, and explicit-selector requirement.
+- Remote search denies sensitive namespace requests when no explicit `mesh_selector.resource_namespace` or `mesh_selector.data_scope` matches the requested namespace.
+- Allowed search returns redacted items with provenance and no raw embeddings, secrets, credential material, private paths, or unrelated peer records.
+- Export returns a provenance-preserving snapshot with tombstone fields when present.
+- Import refuses to overwrite an existing owner namespace unless explicitly allowed and preserves imported provenance in a separate namespace.
+- `DB.ExecuteSQL` remains internal/manage.
+
+## Implementation Steps
+
+1. Extend `app/shared/contracts/models/db.py` with RAG sharing policy/provenance/snapshot models and new typed methods.
+2. Add DB service helpers for namespace normalization, provenance construction, redaction, policy checks, export/import metadata, and conflict detection.
+3. Register new `@method_contract` handlers in `app/services/db/service.py` with appropriate `both` read/search exposure and `manage` export/import permissions.
+4. Add focused tests in `tests/unit/db/test_service.py` covering catalog, denied/allowed remote search, redaction, export/import provenance/conflict behavior, and raw SQL exposure inventory.
+5. Update `docs/DATA_SHARING_POLICY.md` to document implemented contract names, policy behavior, and deferred replication/sync semantics.
+
+## Verification
+
+- `uv run pytest tests/unit/db/test_service.py -q`
+- `uv run pytest tests/unit/contracts -q` if contract registry tests are impacted.
+- Manual registry assertions in unit tests for exposure and raw SQL internal-only behavior.
+
+## Risks And Mitigations
+
+- RAG store has limited native namespace inventory. Mitigation: catalog known local namespaces plus imported/export metadata and include unavailable state when RAG is disabled.
+- Existing RAG items may lack provenance metadata. Mitigation: synthesize safe fallback provenance with redacted principal marker and current local owner marker.
+- Export/import is a snapshot path, not full replication. Mitigation: document one-way/bidirectional sync as deferred and make tombstone behavior explicit.

--- a/app/services/db/service.py
+++ b/app/services/db/service.py
@@ -232,6 +232,7 @@ class DBService(BaseService):
         selector: Any | None,
         *,
         operation: str,
+        require_explicit_selector: bool = False,
     ) -> tuple[bool, str | None, DBRAGNamespacePolicy]:
         policy = self._namespace_policy(namespace)
         if policy.sharing_mode == "never":
@@ -239,13 +240,13 @@ class DBService(BaseService):
         if operation not in policy.allowed_operations:
             return False, f"operation {operation} is not allowed for namespace {namespace}", policy
         if (
-            self._is_remote_selector(selector)
+            (require_explicit_selector or self._is_remote_selector(selector))
             and policy.explicit_selector_required
             and not self._selector_matches_namespace(namespace, selector)
         ):
             return (
                 False,
-                "remote RAG access requires mesh_selector.resource_namespace "
+                "remote RAG access requires explicit mesh_selector.resource_namespace "
                 "or mesh_selector.data_scope matching the requested namespace",
                 policy,
             )
@@ -705,7 +706,7 @@ class DBService(BaseService):
         input_model=DBRAGSearchRequest,
         output_model=DBRAGListResponse,
         summary="Search RAG store",
-        exposure="both",
+        exposure="internal",
         method_type="use",
     )
     async def rag_search(self, query: DBRAGSearchRequest) -> DBRAGListResponse:
@@ -898,7 +899,10 @@ class DBService(BaseService):
         policy_decision_id = self._new_policy_decision_id(query.policy_decision_id)
         correlation_id = self._new_correlation_id(query.correlation_id)
         allowed, denial_reason, _policy = self._validate_rag_access(
-            query.namespace, query.mesh_selector, operation="search"
+            query.namespace,
+            query.mesh_selector,
+            operation="search",
+            require_explicit_selector=True,
         )
         if not allowed:
             return DBRAGSearchRemoteResponse(

--- a/app/services/db/service.py
+++ b/app/services/db/service.py
@@ -9,7 +9,10 @@ This service:
 
 from __future__ import annotations
 
+from copy import deepcopy
+from datetime import UTC, datetime
 from typing import Any
+from uuid import uuid4
 
 from app.helpers.aurora_logger import log_debug, log_error, log_info, log_warning
 from app.messaging import Envelope, QueryResult
@@ -54,10 +57,25 @@ from app.shared.contracts.models.db import (
     DBMethods,
     DBModule,
     DBRAGDeleteRequest,
+    DBRAGExportNamespaceRequest,
+    DBRAGExportNamespaceResponse,
+    DBRAGExportRecord,
+    DBRAGGetProvenanceRequest,
+    DBRAGGetProvenanceResponse,
     DBRAGGetRequest,
+    DBRAGImportNamespaceRequest,
+    DBRAGImportNamespaceResponse,
     DBRAGItemResponse,
+    DBRAGListNamespacesRequest,
+    DBRAGListNamespacesResponse,
     DBRAGListRequest,
     DBRAGListResponse,
+    DBRAGNamespaceInfo,
+    DBRAGNamespacePolicy,
+    DBRAGProvenance,
+    DBRAGProvenanceItem,
+    DBRAGSearchRemoteRequest,
+    DBRAGSearchRemoteResponse,
     DBRAGSearchRequest,
     DBRAGStoreRequest,
     DBRevokeTokenRequest,
@@ -140,6 +158,251 @@ class DBService(BaseService):
         # Database path changes would require restart, but that's handled by supervisor
         # Just log the reload event
         log_debug(f"DB service reloaded for section: {config_section}")
+
+    def _namespace_to_tuple(self, namespace: str | tuple[str, ...]) -> tuple[str, ...]:
+        """Normalize dotted or legacy pipe-delimited namespace strings."""
+        if isinstance(namespace, tuple):
+            return namespace
+        separator = "|" if "|" in namespace else "."
+        return tuple(part for part in namespace.split(separator) if part)
+
+    def _namespace_to_string(self, namespace: str | tuple[str, ...]) -> str:
+        """Normalize namespace values to the public dotted representation."""
+        if isinstance(namespace, tuple):
+            return ".".join(namespace)
+        return namespace.replace("|", ".")
+
+    def _now_iso(self) -> str:
+        return datetime.now(UTC).isoformat()
+
+    def _new_policy_decision_id(self, supplied: str | None = None) -> str:
+        return supplied or f"rag-policy-{uuid4()}"
+
+    def _new_correlation_id(self, supplied: str | None = None) -> str:
+        return supplied or f"rag-correlation-{uuid4()}"
+
+    def _namespace_policy(self, namespace: str) -> DBRAGNamespacePolicy:
+        """Return conservative policy metadata for a namespace."""
+        namespace = self._namespace_to_string(namespace)
+        if namespace.startswith(("auth", "mesh.credentials", "trust", "secrets")):
+            return DBRAGNamespacePolicy(
+                sharing_mode="never",
+                privacy_class="secret",
+                allowed_operations=[],
+                explicit_selector_required=True,
+                denial_reason="namespace is local-authoritative and cannot be shared",
+            )
+        if namespace.startswith("tools"):
+            return DBRAGNamespacePolicy(
+                sharing_mode="remote_query",
+                privacy_class="internal",
+                allowed_operations=["list", "search"],
+                explicit_selector_required=True,
+                export_supported=False,
+                import_supported=False,
+                delete_supported=False,
+            )
+        return DBRAGNamespacePolicy(
+            sharing_mode="export_import",
+            privacy_class="personal",
+            allowed_operations=["list", "search", "provenance", "export", "import"],
+            explicit_selector_required=True,
+            export_supported=True,
+            import_supported=True,
+            delete_supported=False,
+            requires_admin_approval=True,
+        )
+
+    def _selector_matches_namespace(self, namespace: str, selector: Any | None) -> bool:
+        if selector is None:
+            return False
+        expected = self._namespace_to_string(namespace)
+        resource_namespace = getattr(selector, "resource_namespace", None)
+        data_scope = getattr(selector, "data_scope", None)
+        return expected in {resource_namespace, data_scope}
+
+    def _is_remote_selector(self, selector: Any | None) -> bool:
+        if selector is None:
+            return False
+        return bool(getattr(selector, "peer_id", None) or getattr(selector, "provider_id", None))
+
+    def _validate_rag_access(
+        self,
+        namespace: str,
+        selector: Any | None,
+        *,
+        operation: str,
+    ) -> tuple[bool, str | None, DBRAGNamespacePolicy]:
+        policy = self._namespace_policy(namespace)
+        if policy.sharing_mode == "never":
+            return False, policy.denial_reason, policy
+        if operation not in policy.allowed_operations:
+            return False, f"operation {operation} is not allowed for namespace {namespace}", policy
+        if (
+            self._is_remote_selector(selector)
+            and policy.explicit_selector_required
+            and not self._selector_matches_namespace(namespace, selector)
+        ):
+            return (
+                False,
+                "remote RAG access requires mesh_selector.resource_namespace "
+                "or mesh_selector.data_scope matching the requested namespace",
+                policy,
+            )
+        return True, None, policy
+
+    def _extract_stored_provenance(self, value: Any) -> DBRAGProvenance | None:
+        if not isinstance(value, dict):
+            return None
+        raw = value.get("_aurora_provenance")
+        if not isinstance(raw, dict):
+            return None
+        try:
+            return DBRAGProvenance.model_validate(raw)
+        except Exception:
+            log_debug("Ignoring malformed stored RAG provenance metadata")
+            return None
+
+    def _build_provenance(
+        self,
+        *,
+        namespace: str,
+        key: str,
+        value: Any,
+        item: Any | None = None,
+        source_peer_id: str = "local",
+        owner_peer_id: str = "local",
+        origin_principal_id: str | None = None,
+        policy_decision_id: str,
+        correlation_id: str,
+    ) -> DBRAGProvenance:
+        stored = self._extract_stored_provenance(value)
+        if stored is not None:
+            return stored.model_copy(
+                update={
+                    "namespace": self._namespace_to_string(namespace),
+                    "record_id": key,
+                    "policy_decision_id": policy_decision_id,
+                    "correlation_id": correlation_id,
+                }
+            )
+
+        now = self._now_iso()
+        created_at = getattr(item, "created_at", None)
+        updated_at = getattr(item, "updated_at", None)
+        return DBRAGProvenance(
+            source_peer_id=source_peer_id,
+            owner_peer_id=owner_peer_id,
+            namespace=self._namespace_to_string(namespace),
+            record_id=key,
+            origin_principal_id=origin_principal_id or "redacted",
+            created_at=created_at.isoformat() if hasattr(created_at, "isoformat") else now,
+            updated_at=updated_at.isoformat() if hasattr(updated_at, "isoformat") else now,
+            policy_decision_id=policy_decision_id,
+            correlation_id=correlation_id,
+            tombstone=bool(value.get("_aurora_tombstone")) if isinstance(value, dict) else False,
+            deleted_at=value.get("_aurora_deleted_at") if isinstance(value, dict) else None,
+            deleted_by=value.get("_aurora_deleted_by") if isinstance(value, dict) else None,
+            delete_reason=value.get("_aurora_delete_reason") if isinstance(value, dict) else None,
+        )
+
+    def _redact_value(self, value: Any) -> tuple[Any, bool, list[str]]:
+        reasons: list[str] = []
+
+        def redact(obj: Any) -> Any:
+            if isinstance(obj, dict):
+                redacted: dict[str, Any] = {}
+                for key, child in obj.items():
+                    lowered = key.lower()
+                    if lowered.startswith("_aurora_"):
+                        reasons.append("internal_metadata")
+                        continue
+                    if any(
+                        marker in lowered
+                        for marker in (
+                            "embedding",
+                            "vector",
+                            "token",
+                            "password",
+                            "secret",
+                            "credential",
+                            "private_key",
+                        )
+                    ):
+                        redacted[key] = "[redacted]"
+                        reasons.append(key)
+                        continue
+                    if lowered in {"path", "file_path", "source_path"} and isinstance(child, str):
+                        redacted[key] = "[redacted]"
+                        reasons.append(key)
+                        continue
+                    redacted[key] = redact(child)
+                return redacted
+            if isinstance(obj, list):
+                return [redact(item) for item in obj]
+            return obj
+
+        safe_value = redact(deepcopy(value))
+        return safe_value, bool(reasons), sorted(set(reasons))
+
+    def _to_provenance_item(
+        self,
+        item: Any,
+        *,
+        policy_decision_id: str,
+        correlation_id: str,
+        origin_principal_id: str | None = None,
+    ) -> DBRAGProvenanceItem:
+        value = item.value
+        search_score = None
+        if isinstance(value, dict) and "_search_score" in value:
+            value = deepcopy(value)
+            search_score = value.pop("_search_score")
+        namespace = self._namespace_to_string(item.namespace)
+        safe_value, redacted, reasons = self._redact_value(value)
+        provenance = self._build_provenance(
+            namespace=namespace,
+            key=item.key,
+            value=value,
+            item=item,
+            origin_principal_id=origin_principal_id,
+            policy_decision_id=policy_decision_id,
+            correlation_id=correlation_id,
+        )
+        return DBRAGProvenanceItem(
+            key=item.key,
+            value=safe_value,
+            namespace=namespace,
+            search_score=search_score,
+            provenance=provenance,
+            redacted=redacted,
+            redaction_reasons=reasons,
+        )
+
+    def _value_for_import(
+        self,
+        record: DBRAGExportRecord,
+        *,
+        target_namespace: str,
+        import_operation_id: str,
+    ) -> Any:
+        value = deepcopy(record.value)
+        if not isinstance(value, dict):
+            value = {"value": value}
+        provenance = record.provenance.model_copy(
+            update={
+                "namespace": target_namespace,
+                "imported_at": self._now_iso(),
+                "import_operation_id": import_operation_id,
+            }
+        )
+        value["_aurora_provenance"] = provenance.model_dump()
+        if provenance.tombstone:
+            value["_aurora_tombstone"] = True
+            value["_aurora_deleted_at"] = provenance.deleted_at
+            value["_aurora_deleted_by"] = provenance.deleted_by
+            value["_aurora_delete_reason"] = provenance.delete_reason
+        return value
 
     @method_contract(
         method_id=DBMethods.SAVE_MESSAGE,
@@ -395,12 +658,7 @@ class DBService(BaseService):
                 log_debug("Skipping RAG store because RAG stores are disabled or unavailable")
                 return EmptyOutput()
 
-            # Convert string namespace to tuple (store expects tuple)
-            # Support both "tools" and "main.memories" formats
-            if isinstance(cmd.namespace, str):
-                namespace_tuple = tuple(cmd.namespace.split("."))
-            else:
-                namespace_tuple = cmd.namespace
+            namespace_tuple = self._namespace_to_tuple(cmd.namespace)
 
             # Get the appropriate store based on namespace
             store = self.rag_service.combined_store
@@ -429,12 +687,7 @@ class DBService(BaseService):
                 log_debug("Skipping RAG delete because RAG stores are disabled or unavailable")
                 return EmptyOutput()
 
-            # Convert string namespace to tuple (store expects tuple)
-            # Support both "tools" and "main.memories" formats
-            if isinstance(cmd.namespace, str):
-                namespace_tuple = tuple(cmd.namespace.split("."))
-            else:
-                namespace_tuple = cmd.namespace
+            namespace_tuple = self._namespace_to_tuple(cmd.namespace)
 
             # Get the appropriate store based on namespace
             store = self.rag_service.combined_store
@@ -467,12 +720,7 @@ class DBService(BaseService):
                 )
                 return DBRAGListResponse(items=[])
 
-            # Convert string namespace to tuple (store expects tuple)
-            # Support both "tools" and "main.memories" formats
-            if isinstance(query.namespace, str):
-                namespace_tuple = tuple(query.namespace.split("."))
-            else:
-                namespace_tuple = query.namespace
+            namespace_tuple = self._namespace_to_tuple(query.namespace)
 
             # Get the appropriate store based on namespace
             store = self.rag_service.combined_store
@@ -523,12 +771,7 @@ class DBService(BaseService):
                 log_debug("Returning no RAG item because RAG stores are disabled or unavailable")
                 return None
 
-            # Convert string namespace to tuple (store expects tuple)
-            # Support both "tools" and "main.memories" formats
-            if isinstance(query.namespace, str):
-                namespace_tuple = tuple(query.namespace.split("."))
-            else:
-                namespace_tuple = query.namespace
+            namespace_tuple = self._namespace_to_tuple(query.namespace)
 
             # Get the appropriate store based on namespace
             store = self.rag_service.combined_store
@@ -568,12 +811,7 @@ class DBService(BaseService):
                 log_debug("Returning empty RAG list because RAG stores are disabled or unavailable")
                 return DBRAGListResponse(items=[])
 
-            # Convert string namespace to tuple (store expects tuple)
-            # Support both "tools" and "main.memories" formats
-            if isinstance(query.namespace, str):
-                namespace_tuple = tuple(query.namespace.split("."))
-            else:
-                namespace_tuple = query.namespace
+            namespace_tuple = self._namespace_to_tuple(query.namespace)
 
             # Get the appropriate store based on namespace
             store = self.rag_service.combined_store
@@ -599,6 +837,357 @@ class DBService(BaseService):
         except Exception as e:
             log_error(f"Error listing RAG items: {e}", exc_info=True)
             return DBRAGListResponse(items=[])
+
+    @method_contract(
+        method_id=DBMethods.RAG_LIST_NAMESPACES,
+        input_model=DBRAGListNamespacesRequest,
+        output_model=DBRAGListNamespacesResponse,
+        summary="List policy-aware RAG namespaces",
+        exposure="both",
+        method_type="use",
+        required_perms=["DB.RAGSearch"],
+    )
+    async def rag_list_namespaces(
+        self, query: DBRAGListNamespacesRequest
+    ) -> DBRAGListNamespacesResponse:
+        """Return local RAG namespace catalog entries with sharing policy metadata."""
+        try:
+            known_namespaces = ["main.memories", "tools"]
+            namespaces: list[DBRAGNamespaceInfo] = []
+            for namespace in known_namespaces:
+                if query.namespace_prefix and not namespace.startswith(query.namespace_prefix):
+                    continue
+                policy = self._namespace_policy(namespace)
+                record_count: int | None = None
+                availability = "available" if self.rag_service.is_initialized else "unavailable"
+                if self.rag_service.is_initialized:
+                    try:
+                        items = self.rag_service.combined_store.retrieve_items(
+                            self._namespace_to_tuple(namespace), limit=1_000, offset=0
+                        )
+                        record_count = len(items)
+                    except Exception:
+                        availability = "unavailable"
+                namespaces.append(
+                    DBRAGNamespaceInfo(
+                        namespace=namespace,
+                        source_peer_id="local",
+                        owner_peer_id="local",
+                        provider_peer_id="local",
+                        availability=availability,
+                        policy=policy,
+                        record_count=record_count,
+                    )
+                )
+            return DBRAGListNamespacesResponse(namespaces=namespaces)
+        except Exception as e:
+            log_error(f"Error listing RAG namespaces: {e}", exc_info=True)
+            return DBRAGListNamespacesResponse(namespaces=[])
+
+    @method_contract(
+        method_id=DBMethods.RAG_SEARCH_REMOTE,
+        input_model=DBRAGSearchRemoteRequest,
+        output_model=DBRAGSearchRemoteResponse,
+        summary="Policy-enforced remote RAG search",
+        exposure="both",
+        method_type="use",
+        required_perms=["DB.RAGSearch"],
+    )
+    async def rag_search_remote(self, query: DBRAGSearchRemoteRequest) -> DBRAGSearchRemoteResponse:
+        """Search RAG with explicit remote namespace policy and provenance."""
+        policy_decision_id = self._new_policy_decision_id(query.policy_decision_id)
+        correlation_id = self._new_correlation_id(query.correlation_id)
+        allowed, denial_reason, _policy = self._validate_rag_access(
+            query.namespace, query.mesh_selector, operation="search"
+        )
+        if not allowed:
+            return DBRAGSearchRemoteResponse(
+                decision="denied",
+                items=[],
+                denial_reason=denial_reason,
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+        if not self.rag_service.is_initialized:
+            return DBRAGSearchRemoteResponse(
+                decision="unavailable",
+                items=[],
+                denial_reason="RAG stores are disabled or unavailable",
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+
+        try:
+            namespace_tuple = self._namespace_to_tuple(query.namespace)
+            store = self.rag_service.combined_store
+            items = store.search(
+                namespace_tuple, query=query.query, limit=query.limit, offset=query.offset
+            )
+            provenance_items = [
+                self._to_provenance_item(
+                    item,
+                    policy_decision_id=policy_decision_id,
+                    correlation_id=correlation_id,
+                    origin_principal_id=query.caller_principal_id,
+                )
+                for item in items
+            ]
+            return DBRAGSearchRemoteResponse(
+                decision="allowed",
+                items=provenance_items,
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+        except Exception as e:
+            log_error(f"Error in remote RAG search: {e}", exc_info=True)
+            return DBRAGSearchRemoteResponse(
+                decision="unavailable",
+                items=[],
+                denial_reason="RAG search failed",
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+
+    @method_contract(
+        method_id=DBMethods.RAG_GET_PROVENANCE,
+        input_model=DBRAGGetProvenanceRequest,
+        output_model=DBRAGGetProvenanceResponse,
+        summary="Get RAG item provenance",
+        exposure="both",
+        method_type="use",
+        required_perms=["DB.RAGSearch"],
+    )
+    async def rag_get_provenance(
+        self, query: DBRAGGetProvenanceRequest
+    ) -> DBRAGGetProvenanceResponse:
+        """Return provenance for one RAG item without exposing raw internal metadata."""
+        allowed, denial_reason, _policy = self._validate_rag_access(
+            query.namespace, query.mesh_selector, operation="provenance"
+        )
+        if not allowed:
+            return DBRAGGetProvenanceResponse(
+                provenance=None, decision="denied", denial_reason=denial_reason
+            )
+        if not self.rag_service.is_initialized:
+            return DBRAGGetProvenanceResponse(
+                provenance=None,
+                decision="unavailable",
+                denial_reason="RAG stores are disabled or unavailable",
+            )
+
+        try:
+            namespace_tuple = self._namespace_to_tuple(query.namespace)
+            item = self.rag_service.combined_store.get(namespace_tuple, query.key)
+            if item is None:
+                return DBRAGGetProvenanceResponse(
+                    provenance=None, decision="unavailable", denial_reason="record not found"
+                )
+            policy_decision_id = self._new_policy_decision_id()
+            correlation_id = self._new_correlation_id(query.correlation_id)
+            provenance = self._build_provenance(
+                namespace=query.namespace,
+                key=query.key,
+                value=item.value,
+                item=item,
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+            return DBRAGGetProvenanceResponse(provenance=provenance)
+        except Exception as e:
+            log_error(f"Error getting RAG provenance: {e}", exc_info=True)
+            return DBRAGGetProvenanceResponse(
+                provenance=None, decision="unavailable", denial_reason="provenance lookup failed"
+            )
+
+    @method_contract(
+        method_id=DBMethods.RAG_EXPORT_NAMESPACE,
+        input_model=DBRAGExportNamespaceRequest,
+        output_model=DBRAGExportNamespaceResponse,
+        summary="Export a RAG namespace snapshot with provenance",
+        exposure="both",
+        method_type="manage",
+        required_perms=["DB.manage"],
+    )
+    async def rag_export_namespace(
+        self, query: DBRAGExportNamespaceRequest
+    ) -> DBRAGExportNamespaceResponse:
+        """Export a bounded, redacted RAG namespace snapshot."""
+        policy_decision_id = self._new_policy_decision_id(query.policy_decision_id)
+        correlation_id = self._new_correlation_id(query.correlation_id)
+        namespace = self._namespace_to_string(query.namespace)
+        allowed, denial_reason, _policy = self._validate_rag_access(
+            namespace, query.mesh_selector, operation="export"
+        )
+        if not allowed:
+            return DBRAGExportNamespaceResponse(
+                decision="denied",
+                namespace=namespace,
+                source_peer_id="local",
+                owner_peer_id="local",
+                records=[],
+                denial_reason=denial_reason,
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+        if not self.rag_service.is_initialized:
+            return DBRAGExportNamespaceResponse(
+                decision="unavailable",
+                namespace=namespace,
+                source_peer_id="local",
+                owner_peer_id="local",
+                records=[],
+                denial_reason="RAG stores are disabled or unavailable",
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+
+        try:
+            items = self.rag_service.combined_store.retrieve_items(
+                self._namespace_to_tuple(namespace), limit=query.limit, offset=query.offset
+            )
+            records: list[DBRAGExportRecord] = []
+            tombstone_count = 0
+            for item in items:
+                provenance_item = self._to_provenance_item(
+                    item,
+                    policy_decision_id=policy_decision_id,
+                    correlation_id=correlation_id,
+                    origin_principal_id=query.caller_principal_id,
+                )
+                if provenance_item.provenance.tombstone:
+                    tombstone_count += 1
+                    if not query.include_tombstones:
+                        continue
+                records.append(
+                    DBRAGExportRecord(
+                        key=provenance_item.key,
+                        value=provenance_item.value,
+                        provenance=provenance_item.provenance,
+                        redacted=provenance_item.redacted,
+                        redaction_reasons=provenance_item.redaction_reasons,
+                    )
+                )
+            return DBRAGExportNamespaceResponse(
+                decision="allowed",
+                namespace=namespace,
+                source_peer_id="local",
+                owner_peer_id="local",
+                records=records,
+                tombstone_count=tombstone_count,
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+        except Exception as e:
+            log_error(f"Error exporting RAG namespace: {e}", exc_info=True)
+            return DBRAGExportNamespaceResponse(
+                decision="unavailable",
+                namespace=namespace,
+                source_peer_id="local",
+                owner_peer_id="local",
+                records=[],
+                denial_reason="RAG namespace export failed",
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+
+    @method_contract(
+        method_id=DBMethods.RAG_IMPORT_NAMESPACE,
+        input_model=DBRAGImportNamespaceRequest,
+        output_model=DBRAGImportNamespaceResponse,
+        summary="Import a RAG namespace snapshot with provenance",
+        exposure="both",
+        method_type="manage",
+        required_perms=["DB.manage"],
+    )
+    async def rag_import_namespace(
+        self, cmd: DBRAGImportNamespaceRequest
+    ) -> DBRAGImportNamespaceResponse:
+        """Import a provenance-preserving RAG namespace snapshot."""
+        policy_decision_id = self._new_policy_decision_id(cmd.policy_decision_id)
+        correlation_id = self._new_correlation_id(cmd.correlation_id)
+        import_operation_id = f"rag-import-{uuid4()}"
+        target_namespace = self._namespace_to_string(cmd.target_namespace)
+        allowed, denial_reason, _policy = self._validate_rag_access(
+            target_namespace, cmd.mesh_selector, operation="import"
+        )
+        if not allowed:
+            return DBRAGImportNamespaceResponse(
+                decision="denied",
+                imported_count=0,
+                skipped_count=len(cmd.records),
+                target_namespace=target_namespace,
+                import_operation_id=import_operation_id,
+                denial_reason=denial_reason,
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+        if not self.rag_service.is_initialized:
+            return DBRAGImportNamespaceResponse(
+                decision="unavailable",
+                imported_count=0,
+                skipped_count=len(cmd.records),
+                target_namespace=target_namespace,
+                import_operation_id=import_operation_id,
+                denial_reason="RAG stores are disabled or unavailable",
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+
+        try:
+            target_tuple = self._namespace_to_tuple(target_namespace)
+            existing = self.rag_service.combined_store.retrieve_items(
+                target_tuple, limit=1, offset=0
+            )
+            if existing and not cmd.allow_owner_overwrite:
+                return DBRAGImportNamespaceResponse(
+                    decision="conflict",
+                    imported_count=0,
+                    skipped_count=len(cmd.records),
+                    target_namespace=target_namespace,
+                    import_operation_id=import_operation_id,
+                    denial_reason=(
+                        "target namespace already has records; set allow_owner_overwrite "
+                        "to import intentionally"
+                    ),
+                    policy_decision_id=policy_decision_id,
+                    correlation_id=correlation_id,
+                )
+
+            imported = 0
+            skipped = 0
+            store = self.rag_service.combined_store
+            for record in cmd.records:
+                if record.provenance.owner_peer_id != cmd.owner_peer_id:
+                    skipped += 1
+                    continue
+                value = self._value_for_import(
+                    record,
+                    target_namespace=target_namespace,
+                    import_operation_id=import_operation_id,
+                )
+                store.put(target_tuple, record.key, value, index=True)
+                imported += 1
+            return DBRAGImportNamespaceResponse(
+                decision="allowed",
+                imported_count=imported,
+                skipped_count=skipped,
+                target_namespace=target_namespace,
+                import_operation_id=import_operation_id,
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
+        except Exception as e:
+            log_error(f"Error importing RAG namespace: {e}", exc_info=True)
+            return DBRAGImportNamespaceResponse(
+                decision="unavailable",
+                imported_count=0,
+                skipped_count=len(cmd.records),
+                target_namespace=target_namespace,
+                import_operation_id=import_operation_id,
+                denial_reason="RAG namespace import failed",
+                policy_decision_id=policy_decision_id,
+                correlation_id=correlation_id,
+            )
 
     # ── User CRUD ────────────────────────────────────────────────────────
 

--- a/app/shared/contracts/models/db.py
+++ b/app/shared/contracts/models/db.py
@@ -1,6 +1,6 @@
 """DB (Database) service contract models."""
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import Field
 
@@ -29,6 +29,11 @@ class DBMethods:
     RAG_DELETE = f"{DBModule.NAME}.RAGDelete"
     RAG_GET = f"{DBModule.NAME}.RAGGet"
     RAG_LIST = f"{DBModule.NAME}.RAGList"
+    RAG_LIST_NAMESPACES = f"{DBModule.NAME}.RAGListNamespaces"
+    RAG_SEARCH_REMOTE = f"{DBModule.NAME}.RAGSearchRemote"
+    RAG_GET_PROVENANCE = f"{DBModule.NAME}.RAGGetProvenance"
+    RAG_EXPORT_NAMESPACE = f"{DBModule.NAME}.RAGExportNamespace"
+    RAG_IMPORT_NAMESPACE = f"{DBModule.NAME}.RAGImportNamespace"
     SAVE_CRON_JOB = f"{DBModule.NAME}.SaveCronJob"
     GET_CRON_JOBS = f"{DBModule.NAME}.GetCronJobs"
     DELETE_CRON_JOB = f"{DBModule.NAME}.DeleteCronJob"
@@ -201,6 +206,194 @@ class DBRAGListResponse(IOModel):
     """Response for RAG list/search."""
 
     items: list[DBRAGItemResponse]
+
+
+RAGPolicyDecision = Literal["allowed", "denied", "unavailable", "conflict"]
+RAGPrivacyClass = Literal["public", "internal", "personal", "sensitive", "secret"]
+
+
+class DBRAGNamespacePolicy(IOModel):
+    """Policy and capability metadata for a RAG namespace."""
+
+    sharing_mode: Literal["remote_query", "export_import", "one_way_sync", "never"] = "remote_query"
+    privacy_class: RAGPrivacyClass = "personal"
+    allowed_operations: list[str] = Field(default_factory=list)
+    explicit_selector_required: bool = True
+    export_supported: bool = False
+    import_supported: bool = False
+    delete_supported: bool = False
+    requires_admin_approval: bool = False
+    denial_reason: str | None = None
+
+
+class DBRAGNamespaceInfo(IOModel):
+    """Namespace catalog entry for local or remote RAG data."""
+
+    namespace: str
+    source_peer_id: str
+    owner_peer_id: str
+    provider_peer_id: str | None = None
+    availability: Literal["available", "unavailable", "stale", "denied"] = "available"
+    policy: DBRAGNamespacePolicy
+    record_count: int | None = None
+    embedding_model: str | None = None
+    schema_version: str = "rag-provenance.v1"
+    freshness: str | None = None
+
+
+class DBRAGListNamespacesRequest(IOModel):
+    """Request a policy-aware catalog of RAG namespaces."""
+
+    include_remote: bool = True
+    include_unavailable: bool = True
+    namespace_prefix: str | None = None
+    mesh_selector: MeshAddressSelector | None = None
+
+
+class DBRAGListNamespacesResponse(IOModel):
+    """Policy-aware RAG namespace catalog."""
+
+    namespaces: list[DBRAGNamespaceInfo] = Field(default_factory=list)
+
+
+class DBRAGProvenance(IOModel):
+    """Provenance attached to an exported/imported or remote-search RAG record."""
+
+    source_peer_id: str
+    owner_peer_id: str
+    namespace: str
+    record_id: str
+    origin_principal_id: str
+    created_at: str
+    updated_at: str
+    schema_version: str = "rag-provenance.v1"
+    policy_decision_id: str
+    correlation_id: str
+    imported_at: str | None = None
+    import_operation_id: str | None = None
+    tombstone: bool = False
+    deleted_at: str | None = None
+    deleted_by: str | None = None
+    delete_reason: str | None = None
+
+
+class DBRAGProvenanceItem(IOModel):
+    """RAG item with provenance and redaction status."""
+
+    key: str
+    value: Any
+    namespace: str
+    search_score: float | None = None
+    provenance: DBRAGProvenance
+    redacted: bool = False
+    redaction_reasons: list[str] = Field(default_factory=list)
+
+
+class DBRAGSearchRemoteRequest(IOModel):
+    """Policy-enforced remote-capable RAG search request."""
+
+    namespace: str
+    query: str
+    limit: int = 10
+    offset: int = 0
+    mesh_selector: MeshAddressSelector | None = None
+    caller_peer_id: str | None = None
+    caller_principal_id: str | None = None
+    policy_decision_id: str | None = None
+    correlation_id: str | None = None
+
+
+class DBRAGSearchRemoteResponse(IOModel):
+    """Remote-capable RAG search response with policy status."""
+
+    decision: RAGPolicyDecision
+    items: list[DBRAGProvenanceItem] = Field(default_factory=list)
+    denial_reason: str | None = None
+    policy_decision_id: str
+    correlation_id: str
+
+
+class DBRAGGetProvenanceRequest(IOModel):
+    """Request provenance for one RAG record."""
+
+    namespace: str
+    key: str
+    mesh_selector: MeshAddressSelector | None = None
+    correlation_id: str | None = None
+
+
+class DBRAGGetProvenanceResponse(IOModel):
+    """Response containing provenance for one RAG record."""
+
+    provenance: DBRAGProvenance | None = None
+    decision: RAGPolicyDecision = "allowed"
+    denial_reason: str | None = None
+
+
+class DBRAGExportRecord(IOModel):
+    """One record in a RAG namespace export snapshot."""
+
+    key: str
+    value: Any
+    provenance: DBRAGProvenance
+    redacted: bool = False
+    redaction_reasons: list[str] = Field(default_factory=list)
+
+
+class DBRAGExportNamespaceRequest(IOModel):
+    """Export a bounded RAG namespace snapshot."""
+
+    namespace: str
+    limit: int = 100
+    offset: int = 0
+    include_tombstones: bool = True
+    caller_principal_id: str | None = None
+    policy_decision_id: str | None = None
+    correlation_id: str | None = None
+    mesh_selector: MeshAddressSelector | None = None
+
+
+class DBRAGExportNamespaceResponse(IOModel):
+    """Exported RAG namespace snapshot."""
+
+    decision: RAGPolicyDecision
+    namespace: str
+    source_peer_id: str
+    owner_peer_id: str
+    schema_version: str = "rag-export.v1"
+    records: list[DBRAGExportRecord] = Field(default_factory=list)
+    tombstone_count: int = 0
+    denial_reason: str | None = None
+    policy_decision_id: str
+    correlation_id: str
+
+
+class DBRAGImportNamespaceRequest(IOModel):
+    """Import a RAG namespace snapshot into a local namespace."""
+
+    source_namespace: str
+    target_namespace: str
+    records: list[DBRAGExportRecord]
+    source_peer_id: str
+    owner_peer_id: str
+    allow_owner_overwrite: bool = False
+    caller_principal_id: str | None = None
+    policy_decision_id: str | None = None
+    correlation_id: str | None = None
+    mesh_selector: MeshAddressSelector | None = None
+
+
+class DBRAGImportNamespaceResponse(IOModel):
+    """Result of importing a RAG namespace snapshot."""
+
+    decision: RAGPolicyDecision
+    imported_count: int = 0
+    skipped_count: int = 0
+    target_namespace: str
+    import_operation_id: str
+    denial_reason: str | None = None
+    policy_decision_id: str
+    correlation_id: str
 
 
 # ── Shared response types ────────────────────────────────────────────────

--- a/docs/DATA_SHARING_POLICY.md
+++ b/docs/DATA_SHARING_POLICY.md
@@ -76,6 +76,19 @@ implementation:
   These are read/query surfaces and are compatible with remote-query-only policy
   when protected by peer permissions and explicit selectors for remote DB/data
   access.
+- `DB.RAGListNamespaces` is `both` and returns a policy-aware namespace catalog:
+  availability, source/owner peer, allowed operations, privacy class, explicit
+  selector requirement, and export/import support.
+- `DB.RAGSearchRemote` is `both` and enforces explicit remote namespace intent.
+  When a request carries a remote mesh selector, the selector must include
+  `resource_namespace` or `data_scope` matching the requested namespace. Denied
+  requests return a typed policy denial instead of falling back to another
+  namespace/provider.
+- `DB.RAGGetProvenance` is `both` and returns record provenance without exposing
+  internal RAG metadata.
+- `DB.RAGExportNamespace` and `DB.RAGImportNamespace` are `both`/`manage` with
+  `DB.manage` permission. They implement bounded export/import snapshots, not
+  continuous replication.
 - `DB.RAGStore`, `DB.RAGDelete`, `DB.RAGGet`, `DB.RAGList`, and DB cron-job
   persistence methods are internal. They are not current replication contracts.
 - RAG request models already include optional `mesh_selector`; this preserves
@@ -87,14 +100,43 @@ implementation:
 - Auth principal/token/device management and mesh peer management are controlled
   through Auth contracts. The underlying DB rows are not DB/data-sharing domains.
 
+## Implemented RAG Namespace Contracts
+
+The implemented RAG namespace contracts use schema version
+`rag-provenance.v1` for records and `rag-export.v1` for namespace snapshots.
+Each exported/imported or remote-search result carries:
+
+- `source_peer_id`
+- `owner_peer_id`
+- `namespace`
+- `record_id`
+- `origin_principal_id`, using `redacted` when no safe principal can be exposed
+- `created_at` and `updated_at`
+- `schema_version`
+- `policy_decision_id`
+- `correlation_id`
+- tombstone fields when a delete marker is present
+
+Search and export responses redact raw embeddings, vector fields, secrets,
+credential material, tokens/passwords, internal Aurora metadata, and private
+filesystem path fields before returning records to a peer or UI.
+
+Import preserves the source and owner provenance while writing into the target
+namespace with an `import_operation_id` and `imported_at` timestamp. It refuses
+to write into a non-empty target namespace unless the caller explicitly sets the
+overwrite flag, preventing silent owner-namespace replacement.
+
+One-way and bidirectional sync remain deferred. Future sync contracts must add
+source authority, subscription, conflict resolution, delete propagation, and
+retention semantics before copying data continuously across peers.
+
 ## Follow-up Gates
 
 Before implementing P4 data sync or replication work, create explicit follow-up
 contracts/specs for:
 
-1. RAG namespace export/import with provenance and namespace ownership.
-2. RAG one-way published namespace replication with tombstones.
-3. Chat history export/import with user-scoped redaction and delete handling.
-4. Scheduler migration/import that creates new local jobs unless ownership
+1. RAG one-way published namespace replication with tombstones.
+2. Chat history export/import with user-scoped redaction and delete handling.
+3. Scheduler migration/import that creates new local jobs unless ownership
    transfer is explicitly approved.
-5. Redacted cross-peer audit query/export for diagnostics.
+4. Redacted cross-peer audit query/export for diagnostics.

--- a/docs/DATA_SHARING_POLICY.md
+++ b/docs/DATA_SHARING_POLICY.md
@@ -39,8 +39,8 @@ future data-sync contracts.
 | Mesh identity and credentials | Auth mesh identity/peer credential contracts; DB mesh credential storage is internal. | Never share by DB/data sync. | Local Auth/Gateway own stable peer ID, outbound/inbound credentials, room material, and trust status. | Local delete/revoke only, with explicit peer-deny/remove flows for trust changes. | Mesh secrets are local-authoritative even when a paired peer knows its own reciprocal credential. |
 | Mesh peer registry and trust state | Auth `MeshListPeers`, `MeshGetPeer`, `MeshApprovePeer`, `MeshDenyPeer`, `MeshUpdatePeerPermissions`, `MeshRemovePeer`. | Remote query only for redacted peer status; never replicate trust tables. | Each node owns its view of remote peers, approvals, permissions, connection state, and inbound grants. | Removal/deny applies to the local trust store; reciprocal cleanup requires peer-side action. | Query responses must redact stored tokens and credential material. |
 | Audit log | Auth `StoreAuditEvent` internal write; `AuditLog` manage read. | Remote query only, or export/import for support bundles. | Event owner is the peer that observed and stored the event. | Audit events are append-only unless a local retention/erasure policy explicitly removes them. | Cross-peer audit views must preserve source peer and correlation ID. |
-| Chat/message history | DB `SaveMessage` internal write; `GetMessages` and `GetMessagesForDate` are currently `both`. | Remote query only by default; export/import for user-approved history moves. Bidirectional sync is deferred. | Owner is the peer/session that captured the conversation. Shared namespace must include source peer and session/user scope. | User forget/delete must create a tombstone or remain local-only. Imported copies must retain origin metadata so deletes can be evaluated. | External read exposure is acceptable only as filtered history retrieval, not replication. |
-| RAG/memory user knowledge | DB `RAGSearch` is `both`; `RAGStore`, `RAGDelete`, `RAGGet`, and `RAGList` are internal. | Remote query only by default; export/import for curated namespaces; one-way replication allowed for explicitly published namespaces; bidirectional sync deferred. | Namespace owner is the peer that created the namespace. Shared namespace format should include `peer_id`, data domain, and user/project scope. | Deletes require tombstones per key/namespace before replication. Export/import snapshots must record source and import time. | Existing `mesh_selector` fields support explicit peer/namespace intent, but no sync contract exists yet. |
+| Chat/message history | DB `SaveMessage` internal write; `GetMessages` and `GetMessagesForDate` remain filtered read contracts when externally enabled by policy. | Remote query only by default; export/import for user-approved history moves. Bidirectional sync is deferred. | Owner is the peer/session that captured the conversation. Shared namespace must include source peer and session/user scope. | User forget/delete must create a tombstone or remain local-only. Imported copies must retain origin metadata so deletes can be evaluated. | External read exposure is acceptable only as filtered history retrieval, not replication. |
+| RAG/memory user knowledge | Legacy/raw DB `RAGSearch`, `RAGStore`, `RAGDelete`, `RAGGet`, and `RAGList` are internal. `DB.RAGSearchRemote` is the remote-safe query path. | Remote query only by default; export/import for curated namespaces; one-way replication allowed for explicitly published namespaces; bidirectional sync deferred. | Namespace owner is the peer that created the namespace. Shared namespace format should include `peer_id`, data domain, and user/project scope. | Deletes require tombstones per key/namespace before replication. Export/import snapshots must record source and import time. | Remote-safe RAG search requires an explicit matching `mesh_selector.resource_namespace` or `mesh_selector.data_scope`; absent or non-matching selectors deny. No sync contract exists yet. |
 | Tool index RAG namespace | Tooling writes `main.tools`-style RAG data via DB internal RAG contracts. | One-way replication from the tool provider, or remote query only. | Tool provider peer owns its advertised tool index. | Provider withdrawal or tool deletion must invalidate subscriber copies. | This is derived metadata; never treat it as a source for executing a tool without Tooling policy. |
 | Scheduler jobs and ownership | Scheduler `Schedule`, `Cancel`, `ListJobs` are `both`; DB cron-job persistence is internal. | Remote query only for listing. Export/import is allowed for user migration. One-way replication is allowed only for passive calendar/reminder mirrors. | Job owner is the peer that will execute the job. Resource namespace must include executing peer and job ID. | Cancel/delete belongs to the executing peer. Imported jobs are new local jobs with new IDs unless a future scheduler sync contract defines ownership transfer. | Remote scheduling must use explicit target peer/resource selection and policy, not transparent routing. |
 | Config values and feature flags | Config has external get/set/validate contracts. | Never share by DB/data sync. Remote query/manage only through Config contracts and permissions. | Local Config service owns local settings. | Local set/delete/reset semantics only. | Config mutation is administrative and outside DB replication scope. |
@@ -72,18 +72,20 @@ implementation:
 
 - `DB.ExecuteSQL` is `internal` and `manage`; it must remain internal-only and
   must not be mesh-shareable.
-- `DB.GetMessages`, `DB.GetMessagesForDate`, and `DB.RAGSearch` are `both`.
-  These are read/query surfaces and are compatible with remote-query-only policy
-  when protected by peer permissions and explicit selectors for remote DB/data
-  access.
+- Legacy/raw `DB.RAGSearch` is `internal`; it is not mesh-advertised and must
+  not be used as the remote-safe RAG path because it returns raw RAG values
+  without provenance/redaction wrapping.
+- `DB.GetMessages` and `DB.GetMessagesForDate` are message-history read
+  surfaces, not RAG namespace-sharing contracts. Treat any external use as
+  filtered history retrieval governed by chat-history policy, not replication.
 - `DB.RAGListNamespaces` is `both` and returns a policy-aware namespace catalog:
   availability, source/owner peer, allowed operations, privacy class, explicit
   selector requirement, and export/import support.
 - `DB.RAGSearchRemote` is `both` and enforces explicit remote namespace intent.
-  When a request carries a remote mesh selector, the selector must include
-  `resource_namespace` or `data_scope` matching the requested namespace. Denied
-  requests return a typed policy denial instead of falling back to another
-  namespace/provider.
+  Sensitive remote-capable RAG search requires
+  `mesh_selector.resource_namespace` or `mesh_selector.data_scope` matching the
+  requested namespace. Absent selectors and non-matching selectors return a
+  typed policy denial instead of falling back to another namespace/provider.
 - `DB.RAGGetProvenance` is `both` and returns record provenance without exposing
   internal RAG metadata.
 - `DB.RAGExportNamespace` and `DB.RAGImportNamespace` are `both`/`manage` with

--- a/tests/integration/test_mesh_rag_namespace_policy.py
+++ b/tests/integration/test_mesh_rag_namespace_policy.py
@@ -1,0 +1,87 @@
+"""Integration coverage for mesh-safe RAG namespace export/import policy."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from langgraph.store.base import Item
+
+from app.services.db.service import DBService
+from app.shared.contracts.models.db import (
+    DBRAGExportNamespaceRequest,
+    DBRAGImportNamespaceRequest,
+)
+
+
+def _db_service_with_store(store: MagicMock) -> DBService:
+    with (
+        patch("app.services.db.service.DatabaseManager") as mock_db_mgr,
+        patch("app.services.db.service.SchedulerDatabaseService") as mock_scheduler_db,
+        patch("app.services.db.service.RAGService") as mock_rag,
+        patch("app.shared.services.base_service.get_bus_singleton"),
+    ):
+        mock_db_mgr.return_value.initialize = AsyncMock()
+        mock_scheduler_db.return_value.initialize = AsyncMock()
+        mock_rag.return_value.async_initialize = AsyncMock()
+        mock_rag.return_value.is_initialized = True
+        mock_rag.return_value.combined_store = store
+
+        service = DBService()
+        service.db_manager = mock_db_mgr.return_value
+        service.scheduler_db = mock_scheduler_db.return_value
+        service.rag_service = mock_rag.return_value
+        return service
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_two_peer_rag_namespace_export_import_preserves_provenance():
+    """One peer can export a namespace snapshot that another imports with provenance."""
+    provider_store = MagicMock()
+    provider_store.retrieve_items = Mock(
+        return_value=[
+            Item(
+                value={"text": "portable memory", "embedding": [0.1, 0.2]},
+                key="memory-1",
+                namespace=("main", "memories"),
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            )
+        ]
+    )
+    consumer_store = MagicMock()
+    consumer_store.retrieve_items = Mock(return_value=[])
+    consumer_store.put = Mock()
+
+    provider = _db_service_with_store(provider_store)
+    consumer = _db_service_with_store(consumer_store)
+
+    exported = await provider.rag_export_namespace(
+        DBRAGExportNamespaceRequest(
+            namespace="main.memories",
+            policy_decision_id="policy-export",
+            correlation_id="corr-export",
+        )
+    )
+    imported = await consumer.rag_import_namespace(
+        DBRAGImportNamespaceRequest(
+            source_namespace=exported.namespace,
+            target_namespace="imported.peer_a.memories",
+            records=exported.records,
+            source_peer_id=exported.source_peer_id,
+            owner_peer_id=exported.owner_peer_id,
+            policy_decision_id="policy-import",
+            correlation_id="corr-import",
+        )
+    )
+
+    assert exported.decision == "allowed"
+    assert exported.records[0].redacted is True
+    assert exported.records[0].value["embedding"] == "[redacted]"
+    assert imported.decision == "allowed"
+    assert imported.imported_count == 1
+    put_args = consumer_store.put.call_args.args
+    assert put_args[0] == ("imported", "peer_a", "memories")
+    assert put_args[2]["_aurora_provenance"]["source_peer_id"] == "local"
+    assert put_args[2]["_aurora_provenance"]["namespace"] == "imported.peer_a.memories"
+    assert put_args[2]["_aurora_provenance"]["import_operation_id"].startswith("rag-import-")

--- a/tests/unit/db/test_service.py
+++ b/tests/unit/db/test_service.py
@@ -296,3 +296,251 @@ class TestDBServiceRAGOperations:
         # Verify response
         assert isinstance(response, DBRAGListResponse)
         assert len(response.items) == 1
+
+    @pytest.mark.asyncio
+    async def test_rag_list_namespaces_includes_policy(self, db_service):
+        """Namespace catalog exposes availability and policy metadata."""
+        from app.shared.contracts.models.db import DBRAGListNamespacesRequest
+
+        mock_store = MagicMock()
+        mock_store.retrieve_items = Mock(return_value=[])
+        db_service.rag_service.combined_store = mock_store
+
+        response = await db_service.rag_list_namespaces(DBRAGListNamespacesRequest())
+
+        namespaces = {entry.namespace: entry for entry in response.namespaces}
+        assert "main.memories" in namespaces
+        assert namespaces["main.memories"].policy.explicit_selector_required is True
+        assert namespaces["main.memories"].policy.export_supported is True
+        assert "tools" in namespaces
+        assert namespaces["tools"].policy.export_supported is False
+
+    @pytest.mark.asyncio
+    async def test_rag_search_remote_denies_remote_selector_without_namespace(self, db_service):
+        """Remote RAG search requires an explicit namespace/data scope selector."""
+        from app.shared.contracts.models.db import DBRAGSearchRemoteRequest
+        from app.shared.contracts.models.mesh import MeshAddressSelector
+
+        response = await db_service.rag_search_remote(
+            DBRAGSearchRemoteRequest(
+                namespace="main.memories",
+                query="privacy",
+                mesh_selector=MeshAddressSelector(peer_id="peer-b"),
+            )
+        )
+
+        assert response.decision == "denied"
+        assert "resource_namespace" in response.denial_reason
+
+    @pytest.mark.asyncio
+    async def test_rag_search_remote_allows_selector_and_redacts(self, db_service):
+        """Allowed remote search returns provenance and redacts sensitive fields."""
+        from datetime import datetime
+
+        from langgraph.store.base import Item
+
+        from app.shared.contracts.models.db import DBRAGSearchRemoteRequest
+        from app.shared.contracts.models.mesh import MeshAddressSelector
+
+        item = Item(
+            value={
+                "text": "safe memory",
+                "embedding": [0.1, 0.2],
+                "source_path": "/home/user/private.txt",
+                "_aurora_provenance": {
+                    "source_peer_id": "peer-owner",
+                    "owner_peer_id": "peer-owner",
+                    "namespace": "main.memories",
+                    "record_id": "memory-1",
+                    "origin_principal_id": "redacted",
+                    "created_at": "2026-06-19T00:00:00+00:00",
+                    "updated_at": "2026-06-19T00:00:00+00:00",
+                    "schema_version": "rag-provenance.v1",
+                    "policy_decision_id": "old",
+                    "correlation_id": "old",
+                    "tombstone": False,
+                },
+            },
+            key="memory-1",
+            namespace=("main", "memories"),
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_store = MagicMock()
+        mock_store.search = Mock(return_value=[item])
+        db_service.rag_service.combined_store = mock_store
+
+        response = await db_service.rag_search_remote(
+            DBRAGSearchRemoteRequest(
+                namespace="main.memories",
+                query="safe",
+                mesh_selector=MeshAddressSelector(
+                    peer_id="peer-b", resource_namespace="main.memories"
+                ),
+                caller_principal_id="principal-a",
+                policy_decision_id="policy-1",
+                correlation_id="corr-1",
+            )
+        )
+
+        assert response.decision == "allowed"
+        assert len(response.items) == 1
+        result = response.items[0]
+        assert result.provenance.source_peer_id == "peer-owner"
+        assert result.provenance.policy_decision_id == "policy-1"
+        assert result.value["embedding"] == "[redacted]"
+        assert result.value["source_path"] == "[redacted]"
+        assert "_aurora_provenance" not in result.value
+        assert result.redacted is True
+
+    @pytest.mark.asyncio
+    async def test_rag_export_namespace_preserves_provenance_and_tombstones(self, db_service):
+        """Export produces a bounded snapshot with provenance and tombstone metadata."""
+        from datetime import datetime
+
+        from langgraph.store.base import Item
+
+        from app.shared.contracts.models.db import DBRAGExportNamespaceRequest
+
+        item = Item(
+            value={
+                "text": "deleted memory",
+                "_aurora_tombstone": True,
+                "_aurora_deleted_at": "2026-06-19T00:00:00+00:00",
+                "_aurora_deleted_by": "principal-a",
+                "_aurora_delete_reason": "user_forget",
+            },
+            key="memory-1",
+            namespace=("main", "memories"),
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_store = MagicMock()
+        mock_store.retrieve_items = Mock(return_value=[item])
+        db_service.rag_service.combined_store = mock_store
+
+        response = await db_service.rag_export_namespace(
+            DBRAGExportNamespaceRequest(
+                namespace="main.memories",
+                policy_decision_id="policy-export",
+                correlation_id="corr-export",
+            )
+        )
+
+        assert response.decision == "allowed"
+        assert response.tombstone_count == 1
+        assert response.records[0].provenance.tombstone is True
+        assert response.records[0].provenance.deleted_by == "principal-a"
+        assert response.records[0].provenance.policy_decision_id == "policy-export"
+
+    @pytest.mark.asyncio
+    async def test_rag_import_namespace_blocks_existing_owner_without_override(self, db_service):
+        """Import cannot silently overwrite an existing target namespace."""
+        from datetime import datetime
+
+        from langgraph.store.base import Item
+
+        from app.shared.contracts.models.db import (
+            DBRAGExportRecord,
+            DBRAGImportNamespaceRequest,
+            DBRAGProvenance,
+        )
+
+        mock_store = MagicMock()
+        mock_store.retrieve_items = Mock(
+            return_value=[
+                Item(
+                    value={"text": "existing"},
+                    key="existing",
+                    namespace=("imported", "memories"),
+                    created_at=datetime.now(),
+                    updated_at=datetime.now(),
+                )
+            ]
+        )
+        db_service.rag_service.combined_store = mock_store
+        record = DBRAGExportRecord(
+            key="memory-1",
+            value={"text": "portable"},
+            provenance=DBRAGProvenance(
+                source_peer_id="peer-a",
+                owner_peer_id="peer-a",
+                namespace="main.memories",
+                record_id="memory-1",
+                origin_principal_id="redacted",
+                created_at="2026-06-19T00:00:00+00:00",
+                updated_at="2026-06-19T00:00:00+00:00",
+                policy_decision_id="policy-export",
+                correlation_id="corr-export",
+            ),
+        )
+
+        response = await db_service.rag_import_namespace(
+            DBRAGImportNamespaceRequest(
+                source_namespace="main.memories",
+                target_namespace="imported.memories",
+                records=[record],
+                source_peer_id="peer-a",
+                owner_peer_id="peer-a",
+            )
+        )
+
+        assert response.decision == "conflict"
+        mock_store.put.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rag_import_namespace_preserves_import_provenance(self, db_service):
+        """Import writes records with preserved source provenance in the target namespace."""
+        from app.shared.contracts.models.db import (
+            DBRAGExportRecord,
+            DBRAGImportNamespaceRequest,
+            DBRAGProvenance,
+        )
+
+        mock_store = MagicMock()
+        mock_store.retrieve_items = Mock(return_value=[])
+        mock_store.put = Mock()
+        db_service.rag_service.combined_store = mock_store
+        record = DBRAGExportRecord(
+            key="memory-1",
+            value={"text": "portable"},
+            provenance=DBRAGProvenance(
+                source_peer_id="peer-a",
+                owner_peer_id="peer-a",
+                namespace="main.memories",
+                record_id="memory-1",
+                origin_principal_id="redacted",
+                created_at="2026-06-19T00:00:00+00:00",
+                updated_at="2026-06-19T00:00:00+00:00",
+                policy_decision_id="policy-export",
+                correlation_id="corr-export",
+            ),
+        )
+
+        response = await db_service.rag_import_namespace(
+            DBRAGImportNamespaceRequest(
+                source_namespace="main.memories",
+                target_namespace="imported.memories",
+                records=[record],
+                source_peer_id="peer-a",
+                owner_peer_id="peer-a",
+            )
+        )
+
+        assert response.decision == "allowed"
+        assert response.imported_count == 1
+        put_args = mock_store.put.call_args.args
+        assert put_args[0] == ("imported", "memories")
+        stored_value = put_args[2]
+        assert stored_value["_aurora_provenance"]["source_peer_id"] == "peer-a"
+        assert stored_value["_aurora_provenance"]["namespace"] == "imported.memories"
+        assert stored_value["_aurora_provenance"]["import_operation_id"].startswith("rag-import-")
+
+    def test_rag_contract_exposure_and_raw_sql_internal(self):
+        """RAG sharing contracts are exposed, while raw SQL remains internal-only."""
+        assert DBService.rag_search_remote._contract_metadata["exposure"] == "both"
+        assert DBService.rag_list_namespaces._contract_metadata["exposure"] == "both"
+        assert DBService.rag_export_namespace._contract_metadata["method_type"] == "manage"
+        assert DBService.rag_import_namespace._contract_metadata["method_type"] == "manage"
+        assert DBService.execute_sql._contract_metadata["exposure"] == "internal"
+        assert DBService.execute_sql._contract_metadata["method_type"] == "manage"

--- a/tests/unit/db/test_service.py
+++ b/tests/unit/db/test_service.py
@@ -333,6 +333,41 @@ class TestDBServiceRAGOperations:
         assert "resource_namespace" in response.denial_reason
 
     @pytest.mark.asyncio
+    async def test_rag_search_remote_denies_missing_selector_for_sensitive_namespace(
+        self, db_service
+    ):
+        """Remote-safe RAG search denies personal namespaces without any explicit selector."""
+        from datetime import datetime
+
+        from langgraph.store.base import Item
+
+        from app.shared.contracts.models.db import DBRAGSearchRemoteRequest
+
+        item = Item(
+            value={
+                "text": "private memory",
+                "embedding": [0.1],
+                "source_path": "/home/user/private.txt",
+            },
+            key="memory-1",
+            namespace=("main", "memories"),
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        mock_store = MagicMock()
+        mock_store.search = Mock(return_value=[item])
+        db_service.rag_service.combined_store = mock_store
+
+        response = await db_service.rag_search_remote(
+            DBRAGSearchRemoteRequest(namespace="main.memories", query="private")
+        )
+
+        assert response.decision == "denied"
+        assert response.items == []
+        assert "explicit mesh_selector" in response.denial_reason
+        mock_store.search.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_rag_search_remote_allows_selector_and_redacts(self, db_service):
         """Allowed remote search returns provenance and redacts sensitive fields."""
         from datetime import datetime
@@ -538,6 +573,7 @@ class TestDBServiceRAGOperations:
 
     def test_rag_contract_exposure_and_raw_sql_internal(self):
         """RAG sharing contracts are exposed, while raw SQL remains internal-only."""
+        assert DBService.rag_search._contract_metadata["exposure"] == "internal"
         assert DBService.rag_search_remote._contract_metadata["exposure"] == "both"
         assert DBService.rag_list_namespaces._contract_metadata["exposure"] == "both"
         assert DBService.rag_export_namespace._contract_metadata["method_type"] == "manage"


### PR DESCRIPTION
## Summary

- Add DB/RAG contracts for namespace catalog, policy-enforced remote search, provenance lookup, and namespace export/import snapshots.
- Implement DB service policy helpers for explicit remote namespace selectors, provenance synthesis, redaction, export tombstones, and import conflict protection.
- Document the implemented RAG namespace contract surface and deferred sync/replication semantics.

## Validation

- `/home/developer/projects/aurora/.venv/bin/ruff check app/shared/contracts/models/db.py app/services/db/service.py tests/unit/db/test_service.py tests/integration/test_mesh_rag_namespace_policy.py`
- `/home/developer/projects/aurora/.venv/bin/ruff format app/shared/contracts/models/db.py app/services/db/service.py tests/unit/db/test_service.py tests/integration/test_mesh_rag_namespace_policy.py --check`
- `/home/developer/projects/aurora/.venv/bin/python -m pytest tests/unit/db/test_service.py tests/integration/test_mesh_rag_namespace_policy.py tests/unit/contracts -q`

## Notes

- Raw SQL remains internal/manage only.
- Export/import is snapshot-only; one-way and bidirectional sync remain deferred pending explicit conflict/delete/retention semantics.
