### PR TITLE
PER-221: Decide UI package layout

### DIFF
--- a/.omx/specs/ui-production-tasks/index.md
+++ b/.omx/specs/ui-production-tasks/index.md
@@ -115,6 +115,11 @@ The critical path is: P0 baseline → SDK core/contract inventory → backend ga
 - [ ] [P0-003 — Establish frontend package lint/type/build/test baseline](tasks/P0-003-establish-frontend-package-lint-type-build-test-baseline.md) _(lane: frontend/readiness; deps: None)_
 - [ ] [P0-004 — Create monorepo/package layout decision for SDK, UI, Tauri, and native plugins](tasks/P0-004-create-monorepo-package-layout-decision-for-sdk-ui-tauri-and-native-plugins.md) _(lane: architecture; deps: P0-001)_
 
+P0-004 accepted decision artifacts:
+
+- [Package layout decision](package-layout-decision.md)
+- [Static workspace graph](package-layout-workspace-graph.json)
+
 ### P1 — Transport-independent SDK and capability catalog foundation
 
 - [ ] [SDK-001 — Scaffold `@aurora/client` TypeScript SDK package and public API](tasks/SDK-001-scaffold-@aurora-client-typescript-sdk-package-and-public-api.md) _(lane: sdk; deps: P0-004)_

--- a/.omx/specs/ui-production-tasks/package-layout-decision.md
+++ b/.omx/specs/ui-production-tasks/package-layout-decision.md
@@ -1,0 +1,105 @@
+# Aurora UI Package Layout Decision
+
+Date: 2026-06-19
+Status: accepted planning baseline for P0-004; no production package scaffold in this task.
+Branch target: `feat/ui-multi-platform-integration`
+
+## Scope
+
+This document fixes the future production workspace layout for Aurora's TypeScript SDK, shared UI, web app, official Tauri 2 app, desktop sidecar bridge, Android native plugin, and iOS native plugin/extensions.
+
+The current repository remains Python-runtime-first. `pyproject.toml` stays the source of truth for Aurora services. `modules/ui-mock-reference/` remains reference-only and is not a production package boundary.
+
+## Decision
+
+Future production UI/native work will use a root JavaScript/Rust workspace with these directories:
+
+| Path | Package or crate name | Owner lane | Purpose |
+| --- | --- | --- | --- |
+| `packages/aurora-sdk` | `@aurora/client` | SDK | Transport-independent TypeScript client, generated backend types, normalized envelopes, auth/session state, capability graph, route/privacy helpers, and test fixtures. |
+| `packages/aurora-ui` | `@aurora/ui` | UI | Shared React components, design tokens, accessibility primitives, state renderers, route/privacy UI, and SDK-bound hooks. |
+| `apps/aurora-web` | `@aurora/web` | UI | Browser/server-web application. It consumes `@aurora/client` and `@aurora/ui`; it must not call Gateway, Tauri IPC, Python services, or WebRTC directly. |
+| `apps/aurora-tauri/src` | `@aurora/tauri-ui` | Tauri desktop | Frontend bundle for the official Tauri 2 desktop app. It consumes `@aurora/client` and `@aurora/ui`. |
+| `apps/aurora-tauri/src-tauri` | `aurora-tauri` | Tauri desktop | Official Tauri 2 Rust shell, typed commands, sidecar supervision, secure IPC, updater, permissions/capabilities, and platform plugin glue. |
+| `apps/aurora-tauri/sidecars` | not independently published | Tauri desktop/backend integration | Packaging manifests and entrypoint wrappers for supervising local Aurora Python service processes. Runtime code stays under the existing Python `app/` tree unless a future task explicitly extracts it. |
+| `native/android` | `aurora-android-plugin` | Android native | Kotlin native plugin source, Android capability manifest provider, assistant-role proof, permissions, foreground-service declarations, emulator/build fixtures, and Android-specific CI. |
+| `native/ios` | `aurora-ios-plugin` | iOS native | Swift native plugin source, App Intents, Shortcuts, widgets/share extensions, file/deep-link associations, Keychain/biometric storage, device fixtures, and iOS-specific CI. |
+
+## Import Direction
+
+Allowed import direction:
+
+```text
+apps/aurora-web -> packages/aurora-ui -> packages/aurora-sdk
+apps/aurora-web -----------------------> packages/aurora-sdk
+apps/aurora-tauri/src -> packages/aurora-ui -> packages/aurora-sdk
+apps/aurora-tauri/src -----------------> packages/aurora-sdk
+apps/aurora-tauri/src-tauri -> packaged Python sidecar process/Gateway contracts only
+native/android -> Tauri mobile plugin bridge and generated native capability manifest
+native/ios -> Tauri mobile plugin bridge and generated native capability manifest
+packages/aurora-sdk -> generated backend contract artifacts only
+```
+
+The SDK is the only production TypeScript package that may know backend transport details. UI packages and apps consume SDK interfaces and view models.
+
+## Forbidden Dependencies
+
+- `packages/aurora-ui`, `apps/aurora-web`, and `apps/aurora-tauri/src` must not use direct `fetch`, raw WebSocket/SSE clients, Tauri `invoke`, Python service objects, or raw WebRTC APIs for Aurora service state. They must use `@aurora/client`.
+- `packages/aurora-sdk` must not import React, Next.js, Tauri frontend APIs, native mobile APIs, or components from `@aurora/ui`.
+- `packages/aurora-ui` must not import app routes, app stores, Tauri Rust command bindings, native plugin code, Python modules, or generated Python files directly.
+- `apps/aurora-tauri/src-tauri` must not become a second source of truth for Aurora services, mesh, auth, tools, DB, scheduler, or audio. It returns backend evidence through typed commands and sidecar/Gateway contracts.
+- `native/android` and `native/ios` must not import production React app code. Native capability state flows through Tauri/mobile plugin bridges and the SDK native capability manifest.
+- Production packages must not import from `modules/ui-mock-reference/`. Components may be copied from the mock only with attribution, review, fixture removal, and migration into `packages/aurora-ui` or an app-owned directory.
+- No package may claim backend, mesh, Tauri, native, audio, Auth/RBAC, process-mode, or transport parity behavior from frontend-only fixtures.
+
+## Build And CI Ownership
+
+| Surface | Build owner | Required future baseline |
+| --- | --- | --- |
+| Root JS workspace | P0-003/frontend readiness | Package manager workspace, lint/typecheck/test/build commands, dependency boundaries. |
+| `@aurora/client` | SDK lane | Type generation, contract conformance tests, transport fixtures, HTTP/Tauri/mesh adapter parity. |
+| `@aurora/ui` | UI lane | Component tests, accessibility checks, visual states for backend-proven/pending/denied/degraded/stale/privacy-blocked/deferred states. |
+| `@aurora/web` | UI lane | Browser build, route tests, SDK transport integration fixtures. |
+| `aurora-tauri` | Tauri lane | Rust checks/tests, Tauri 2 configuration, command permission/capability tests, desktop WebDriver E2E where platform support exists. |
+| Desktop sidecars | Tauri lane with backend review | Sidecar packaging smoke, isolated profile/config/data dirs, process lifecycle evidence. |
+| Android native | Android lane | Gradle/Tauri Android build, emulator smoke, RoleManager/assistant-role capability evidence, permission states. |
+| iOS native | iOS lane | Xcode/Tauri iOS build on macOS, App Intents/extension compile checks, simulator/device smoke where available. |
+
+## Runtime Boundaries
+
+- Server Web and Desktop Thin use HTTP/WebSocket/SSE SDK transports only.
+- Desktop Local uses the official Tauri 2 Rust shell to supervise or connect to a local Aurora node, but UI state still comes through `@aurora/client`.
+- Mesh Shell surfaces require provider identity, route explain/selector evidence, policy result, provenance, and audit/correlation data before enabling remote actions.
+- Android and iOS native capabilities are manifest-driven and permission-gated. iOS must not claim Siri replacement; Android assistant-role support must be proven by native package qualification and runtime role state.
+
+## Static Workspace Graph
+
+The machine-readable graph for this decision is `.omx/specs/ui-production-tasks/package-layout-workspace-graph.json`. It is a planning artifact until P0-003/SDK-001/TAURI-001/AND-001/IOS-001 create the actual workspace manifests.
+
+Validation command:
+
+```bash
+python -m json.tool .omx/specs/ui-production-tasks/package-layout-workspace-graph.json >/tmp/package-layout-workspace-graph.pretty.json
+```
+
+Current repository check:
+
+```bash
+find . -maxdepth 3 \( -name package.json -o -name pnpm-workspace.yaml -o -name Cargo.toml -o -name turbo.json -o -name nx.json \) -print
+```
+
+Expected result before scaffolding: only `modules/ui-mock-reference/package.json` exists. Any future root/package manifests must match this decision or update this document in the same change.
+
+## Downstream Task Mapping
+
+- P0-003 creates the root package manager/workspace baseline and must encode these package paths.
+- SDK-001 owns `packages/aurora-sdk`.
+- UI-001 owns first production use of `packages/aurora-ui` and `apps/aurora-web`.
+- TAURI-001 owns `apps/aurora-tauri/src` and `apps/aurora-tauri/src-tauri`.
+- TAURI-002 owns sidecar supervision under `apps/aurora-tauri/sidecars` plus any Python entrypoint changes.
+- AND-001/AND-002 own `native/android`.
+- IOS-001/IOS-002 own `native/ios`.
+
+## Review Gate
+
+Before any production scaffold task proceeds, the implementing agent must check this document and the graph artifact, then keep package names, import direction, forbidden dependencies, and CI ownership consistent unless that task explicitly updates the decision.

--- a/.omx/specs/ui-production-tasks/package-layout-workspace-graph.json
+++ b/.omx/specs/ui-production-tasks/package-layout-workspace-graph.json
@@ -1,0 +1,178 @@
+{
+  "status": "accepted-planning-baseline",
+  "date": "2026-06-19",
+  "scope": "P0-004 package layout decision; no production scaffold",
+  "workspaceRoot": ".",
+  "pythonRuntimeSource": "pyproject.toml",
+  "referenceOnly": [
+    {
+      "path": "modules/ui-mock-reference",
+      "rule": "visual and component reference only; no production imports"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "aurora-python-runtime",
+      "path": "app",
+      "kind": "python-runtime",
+      "ownerLane": "backend",
+      "publishName": null
+    },
+    {
+      "id": "aurora-client",
+      "path": "packages/aurora-sdk",
+      "kind": "typescript-package",
+      "ownerLane": "sdk",
+      "publishName": "@aurora/client"
+    },
+    {
+      "id": "aurora-ui",
+      "path": "packages/aurora-ui",
+      "kind": "typescript-package",
+      "ownerLane": "ui",
+      "publishName": "@aurora/ui"
+    },
+    {
+      "id": "aurora-web",
+      "path": "apps/aurora-web",
+      "kind": "web-app",
+      "ownerLane": "ui",
+      "publishName": "@aurora/web"
+    },
+    {
+      "id": "aurora-tauri-ui",
+      "path": "apps/aurora-tauri/src",
+      "kind": "tauri-frontend",
+      "ownerLane": "tauri-desktop",
+      "publishName": "@aurora/tauri-ui"
+    },
+    {
+      "id": "aurora-tauri-rust",
+      "path": "apps/aurora-tauri/src-tauri",
+      "kind": "rust-tauri-crate",
+      "ownerLane": "tauri-desktop",
+      "publishName": "aurora-tauri"
+    },
+    {
+      "id": "aurora-tauri-sidecars",
+      "path": "apps/aurora-tauri/sidecars",
+      "kind": "sidecar-packaging",
+      "ownerLane": "tauri-desktop",
+      "publishName": null
+    },
+    {
+      "id": "aurora-android-plugin",
+      "path": "native/android",
+      "kind": "android-native-plugin",
+      "ownerLane": "android-native",
+      "publishName": "aurora-android-plugin"
+    },
+    {
+      "id": "aurora-ios-plugin",
+      "path": "native/ios",
+      "kind": "ios-native-plugin",
+      "ownerLane": "ios-native",
+      "publishName": "aurora-ios-plugin"
+    }
+  ],
+  "allowedEdges": [
+    {
+      "from": "aurora-web",
+      "to": "aurora-ui",
+      "type": "imports"
+    },
+    {
+      "from": "aurora-web",
+      "to": "aurora-client",
+      "type": "imports"
+    },
+    {
+      "from": "aurora-tauri-ui",
+      "to": "aurora-ui",
+      "type": "imports"
+    },
+    {
+      "from": "aurora-tauri-ui",
+      "to": "aurora-client",
+      "type": "imports"
+    },
+    {
+      "from": "aurora-ui",
+      "to": "aurora-client",
+      "type": "imports"
+    },
+    {
+      "from": "aurora-client",
+      "to": "aurora-python-runtime",
+      "type": "generated-contracts-only"
+    },
+    {
+      "from": "aurora-tauri-rust",
+      "to": "aurora-python-runtime",
+      "type": "sidecar-process-or-gateway-contract"
+    },
+    {
+      "from": "aurora-tauri-sidecars",
+      "to": "aurora-python-runtime",
+      "type": "packages-entrypoints"
+    },
+    {
+      "from": "aurora-android-plugin",
+      "to": "aurora-tauri-rust",
+      "type": "mobile-plugin-bridge"
+    },
+    {
+      "from": "aurora-ios-plugin",
+      "to": "aurora-tauri-rust",
+      "type": "mobile-plugin-bridge"
+    }
+  ],
+  "forbiddenEdges": [
+    {
+      "from": "aurora-ui",
+      "to": "aurora-python-runtime",
+      "reason": "UI must consume backend truth through @aurora/client only"
+    },
+    {
+      "from": "aurora-web",
+      "to": "aurora-python-runtime",
+      "reason": "Web app must not call Python services or bus internals directly"
+    },
+    {
+      "from": "aurora-client",
+      "to": "aurora-ui",
+      "reason": "SDK must stay framework-neutral"
+    },
+    {
+      "from": "aurora-client",
+      "to": "aurora-tauri-rust",
+      "reason": "Tauri transport is an adapter boundary, not a hard SDK dependency"
+    },
+    {
+      "from": "aurora-web",
+      "to": "modules/ui-mock-reference",
+      "reason": "Mock is reference-only; copied code requires attribution and review"
+    },
+    {
+      "from": "aurora-ui",
+      "to": "modules/ui-mock-reference",
+      "reason": "Mock is reference-only; production components live under packages/aurora-ui"
+    },
+    {
+      "from": "aurora-tauri-ui",
+      "to": "modules/ui-mock-reference",
+      "reason": "Mock is reference-only; production Tauri UI consumes @aurora/ui"
+    }
+  ],
+  "ciOwners": {
+    "root-js-workspace": "P0-003",
+    "packages/aurora-sdk": "SDK-001",
+    "packages/aurora-ui": "UI-001",
+    "apps/aurora-web": "UI-001",
+    "apps/aurora-tauri/src": "TAURI-001",
+    "apps/aurora-tauri/src-tauri": "TAURI-001",
+    "apps/aurora-tauri/sidecars": "TAURI-002",
+    "native/android": "AND-001",
+    "native/ios": "IOS-001"
+  }
+}

--- a/.omx/specs/ui-production-tasks/tasks/P0-004-create-monorepo-package-layout-decision-for-sdk-ui-tauri-and-native-plugins.md
+++ b/.omx/specs/ui-production-tasks/tasks/P0-004-create-monorepo-package-layout-decision-for-sdk-ui-tauri-and-native-plugins.md
@@ -61,6 +61,7 @@ Task owners can implement in isolation without arguing file layout.
 - Documented package names, build ownership, import direction, and forbidden dependencies.
 - No production UI imports from `modules/ui-mock-reference` after migration except copied components with attribution/review.
 - Tauri/native code has platform-specific directories and CI ownership.
+- Accepted decision artifacts live at `.omx/specs/ui-production-tasks/package-layout-decision.md` and `.omx/specs/ui-production-tasks/package-layout-workspace-graph.json`.
 
 ## Verification commands / evidence
 


### PR DESCRIPTION
## Summary
- Add the accepted P0-004 package layout decision for SDK, shared UI, web, Tauri, sidecars, Android, and iOS native surfaces.
- Add a machine-readable static workspace graph that records package names, allowed edges, forbidden edges, and CI ownership.
- Link the decision artifacts from the UI production task index and P0-004 task file.

## Verification
- python -m json.tool .omx/specs/ui-production-tasks/package-layout-workspace-graph.json
- find . -maxdepth 3 \( -name package.json -o -name pnpm-workspace.yaml -o -name Cargo.toml -o -name turbo.json -o -name nx.json \) -print
- git diff --check

## Scope
Planning/docs only. No production package scaffold, UI wiring, backend contracts, route semantics, permissions, or mock fixtures changed.