### PR TITLE
PER-188 Normalize auth gateway public bypass

### DIFF
--- a/.omx/plans/PER-188-auth-gateway-route-casing.md
+++ b/.omx/plans/PER-188-auth-gateway-route-casing.md
@@ -1,0 +1,42 @@
+# PER-188 Plan: Auth/Gateway Route Casing and Public Bypass
+
+## Requirements Summary
+
+- Source issue: PER-188 / BE-001, `auth.session.state_machine`.
+- Scope: normalize Auth/Gateway public route bypass behavior for generated PascalCase routes and lowercase legacy paths, without production UI wiring.
+- Source docs read: root/service/gateway/auth/shared/contracts/tests `AGENTS.md`, `.omx/specs/ui-refinement/*`, `.omx/specs/ui-production-tasks/index.md`, `.omx/specs/ui-production-tasks/backend-gap-crosswalk.md`, `.omx/specs/mesh-ui-roadmap-integration-review.md`, and `docs/GATEWAY.md`.
+- Code paths: `app/services/gateway/auth.py`, `app/services/gateway/route_generator.py`, `app/services/auth/service.py`, `app/shared/contracts/models/auth.py`, `docs/GATEWAY.md`, focused gateway tests.
+- Invariant: `SYSTEM` is only for auth-disabled mode or validated API keys; auth-enabled public bypass paths resolve as `ANONYMOUS`.
+
+## Acceptance Criteria
+
+- Canonical generated public Auth endpoints `/api/Auth/Login`, `/api/Auth/PairingStart`, `/api/Auth/PairingConnect`, and `/api/Auth/PairingExchange` bypass authentication when auth is enabled.
+- Lowercase legacy public Auth paths continue to bypass authentication where already supported.
+- Bypassed auth-enabled requests resolve as `ANONYMOUS`, not `SYSTEM`, in both middleware and FastAPI security dependency paths.
+- Protected generated Auth routes keep normal permission checks and do not become public through prefix matching.
+- Auth contract decorators use typed `AuthMethods` constants for touched public methods.
+- Gateway docs name canonical public Auth endpoints for SDK consumers.
+
+## Implementation Steps
+
+1. Add a canonical public Auth route list in `GatewayAuth` that includes generated PascalCase and lowercase legacy forms.
+2. Change `_resolve_identity_and_check()` so bypass paths return the middleware identity or `ANONYMOUS`, never `SYSTEM`, while auth-disabled mode still returns `SYSTEM`.
+3. Update touched Auth method contracts to use `AuthMethods.*` constants.
+4. Add focused unit tests for bypass casing, anonymous identity, prefix safety, and generated public route forwarding.
+5. Update `docs/GATEWAY.md` and the Gateway OpenAPI description to document canonical public Auth routes and the anonymous bypass semantics.
+
+## Verification Strategy
+
+- `uv run pytest tests/unit/gateway/test_auth_public_bypass.py tests/unit/gateway/test_route_generator_adminaction.py tests/unit/app/test_gateway.py -q`
+- `uv run ruff check app/services/gateway/auth.py app/services/gateway/fastapi_app.py app/services/auth/service.py tests/unit/gateway/test_auth_public_bypass.py`
+- `git diff --check`
+
+## Risks and Mitigations
+
+- Risk: adding broad prefix bypass could expose protected Auth routes. Mitigation: exact or delimiter-prefix matching only, with a negative test for `/api/Auth/LoginDebug`.
+- Risk: public routes with required permissions would fail under `ANONYMOUS`. Mitigation: only login/pairing start/connect/exchange are public; protected Auth routes retain normal checks.
+- Risk: stale docs imply lowercase dynamic routes are canonical. Mitigation: docs now identify PascalCase generated routes as canonical and lowercase paths as legacy compatibility where present.
+
+## Stop Condition
+
+PER-188 is ready for QA when the focused tests and lint pass, docs are updated, changes are committed and pushed, a PR exists, and the issue is handed to QA with branch/PR/verification evidence.

--- a/.omx/ultragoal/PER-188-checkpoints.md
+++ b/.omx/ultragoal/PER-188-checkpoints.md
@@ -1,0 +1,17 @@
+# PER-188 Ultragoal Checkpoints
+
+## Context
+
+- Issue: PER-188 / BE-001, normalize Auth/Gateway route casing and public bypass behavior.
+- Branch: `multica/PER-188-auth-gateway-route-casing`.
+- Plan: `.omx/plans/PER-188-auth-gateway-route-casing.md`.
+- `omx ultragoal status` showed an unrelated existing in-progress aggregate goal (`G015`), so this task records repo-local PER-188 checkpoints without mutating that active goal.
+
+## Checkpoints
+
+- Planning complete: source docs, code paths, invariants, acceptance criteria, and verification strategy captured before source edits.
+- Implementation complete: canonical PascalCase public Auth paths and lowercase legacy paths are bypass-aware, auth-enabled bypass resolves to `ANONYMOUS`, touched Auth contracts use `AuthMethods` constants, Gateway docs name SDK-facing public endpoints, and focused regression tests cover casing, prefix safety, dependency identity, generated route forwarding, and scope enforcement.
+- Verification passed:
+  - `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy /home/developer/.local/bin/uv run --extra dev --extra test-all --extra gateway pytest tests/unit/gateway/test_auth_public_bypass.py tests/unit/gateway/test_route_generator_adminaction.py tests/unit/app/test_gateway.py -q` -> 41 passed, 19 warnings.
+  - `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy /home/developer/.local/bin/uv run --extra dev --extra gateway ruff check app/services/gateway/auth.py app/services/gateway/fastapi_app.py app/services/auth/service.py tests/unit/gateway/test_auth_public_bypass.py` -> passed.
+  - `git diff --check` -> passed.

--- a/app/services/auth/service.py
+++ b/app/services/auth/service.py
@@ -186,7 +186,7 @@ class AuthService(BaseService):
     # ── Login / Logout ───────────────────────────────────────────────────
 
     @method_contract(
-        method_id="Auth.Login",
+        method_id=AuthMethods.LOGIN,
         summary="Authenticate with username/password and receive a session token",
         input_model=LoginRequest,
         output_model=LoginResponse,
@@ -307,7 +307,7 @@ class AuthService(BaseService):
     # ── Pairing ──────────────────────────────────────────────────────────
 
     @method_contract(
-        method_id="Auth.PairingStart",
+        method_id=AuthMethods.PAIRING_START,
         summary="Start a device pairing request (returns 6-digit code)",
         input_model=PairingStartRequest,
         output_model=PairingStartResponse,
@@ -328,7 +328,7 @@ class AuthService(BaseService):
         return PairingStartResponse(code=code, expires_in_seconds=300)
 
     @method_contract(
-        method_id="Auth.PairingConnect",
+        method_id=AuthMethods.PAIRING_CONNECT,
         summary="Check the status of a pairing request",
         input_model=PairingConnectRequest,
         output_model=PairingConnectResponse,
@@ -368,7 +368,7 @@ class AuthService(BaseService):
         return PairingApproveResponse(success=success)
 
     @method_contract(
-        method_id="Auth.PairingExchange",
+        method_id=AuthMethods.PAIRING_EXCHANGE,
         summary="Exchange an approved pairing code for a token",
         input_model=PairingExchangeRequest,
         output_model=PairingExchangeResponse,

--- a/app/services/gateway/auth.py
+++ b/app/services/gateway/auth.py
@@ -17,6 +17,21 @@ from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBea
 from app.helpers.aurora_logger import log_debug, log_info, log_warning
 from app.services.gateway.acl.identity import ANONYMOUS, SYSTEM, Identity
 from app.services.gateway.dependencies import get_gateway_auth
+from app.shared.contracts.models.auth import AuthMethods
+
+_PUBLIC_AUTH_CONTRACT_PATHS = {
+    AuthMethods.LOGIN: "/api/Auth/Login",
+    AuthMethods.PAIRING_START: "/api/Auth/PairingStart",
+    AuthMethods.PAIRING_CONNECT: "/api/Auth/PairingConnect",
+    AuthMethods.PAIRING_EXCHANGE: "/api/Auth/PairingExchange",
+}
+
+_LEGACY_PUBLIC_AUTH_PATHS = {
+    "/api/auth/login",
+    "/api/auth/pairing/start",
+    "/api/auth/pairing/connect",
+    "/api/auth/pairing/exchange",
+}
 
 
 class GatewayAuth:
@@ -54,10 +69,8 @@ class GatewayAuth:
                 "/api/docs",
                 "/api/redoc",
                 "/api/openapi.json",
-                "/api/auth/login",
-                "/api/auth/pairing/start",
-                "/api/auth/pairing/connect",
-                "/api/auth/pairing/exchange",
+                *_PUBLIC_AUTH_CONTRACT_PATHS.values(),
+                *_LEGACY_PUBLIC_AUTH_PATHS,
             ]
         )
 
@@ -334,11 +347,11 @@ async def _resolve_identity_and_check(
     if not auth.is_enabled():
         return SYSTEM
 
-    if auth.should_bypass(request.url.path):
-        return SYSTEM
-
     # Retrieve identity set by middleware
     identity: Identity | None = getattr(request.state, "identity", None)
+
+    if auth.should_bypass(request.url.path):
+        identity = identity or ANONYMOUS
 
     if identity is None:
         # Fallback: re-authenticate (shouldn't happen if middleware is wired)

--- a/app/services/gateway/fastapi_app.py
+++ b/app/services/gateway/fastapi_app.py
@@ -90,8 +90,10 @@ def create_gateway_app(
             "| Bearer Token | `Authorization: Bearer <token>` "
             "| `Authorization: Bearer eyJ…` |\n\n"
             'Use the **Authorize** button above to set credentials for "Try it out".\n\n'
-            "Endpoints under *Auth → Pairing* (`/start`, `/connect`, `/exchange`) "
-            "and `/login` do **not** require authentication."
+            "Canonical public auth routes are `POST /api/Auth/Login`, "
+            "`POST /api/Auth/PairingStart`, `POST /api/Auth/PairingConnect`, "
+            "and `POST /api/Auth/PairingExchange`. When auth is enabled, these "
+            "routes run as an anonymous caller, not as the system principal."
         ),
         docs_url="/api/docs",
         redoc_url="/api/redoc",

--- a/docs/GATEWAY.md
+++ b/docs/GATEWAY.md
@@ -227,6 +227,28 @@ All service methods with `exposure="external"` or `exposure="both"` are automati
 POST /api/{ServiceName}/{MethodName}
 ```
 
+Service and method path segments use the canonical PascalCase contract names
+from the service registry. SDKs should prefer these generated paths and should
+not infer lowercase route names from bus topics.
+
+### Public Auth Endpoints
+
+The canonical public Auth endpoints are generated from `Auth` service
+contracts:
+
+| Method ID | HTTP route | Public behavior |
+|-----------|------------|-----------------|
+| `Auth.Login` | `POST /api/Auth/Login` | Bypasses credential requirement and runs as `ANONYMOUS`. |
+| `Auth.PairingStart` | `POST /api/Auth/PairingStart` | Bypasses credential requirement and runs as `ANONYMOUS`. |
+| `Auth.PairingConnect` | `POST /api/Auth/PairingConnect` | Bypasses credential requirement and runs as `ANONYMOUS`. |
+| `Auth.PairingExchange` | `POST /api/Auth/PairingExchange` | Bypasses credential requirement and runs as `ANONYMOUS`. |
+
+When gateway auth is enabled, these routes are public but do not receive
+`SYSTEM` privileges. `SYSTEM` is reserved for auth-disabled mode and validated
+API-key calls. Lowercase legacy paths such as `/api/auth/login` may exist for
+compatibility in older deployments, but SDK descriptors should advertise the
+canonical generated PascalCase routes.
+
 #### Example: Orchestrator.ExternalUserInput
 
 ```bash
@@ -421,7 +443,7 @@ Schemas are extracted from service method contracts:
 
 ### API Key Authentication
 
-When enabled, all requests (except `/api/health`) require an API key:
+When enabled, protected requests require an API key or bearer token:
 
 ```bash
 curl -X POST http://localhost:8000/api/Orchestrator/ExternalUserInput \
@@ -437,6 +459,10 @@ The following endpoints bypass authentication:
 - `/api/docs`
 - `/api/redoc`
 - `/api/openapi.json`
+- `POST /api/Auth/Login`
+- `POST /api/Auth/PairingStart`
+- `POST /api/Auth/PairingConnect`
+- `POST /api/Auth/PairingExchange`
 
 ## WebRTC Authentication & Pairing
 

--- a/tests/unit/gateway/test_auth_public_bypass.py
+++ b/tests/unit/gateway/test_auth_public_bypass.py
@@ -1,0 +1,241 @@
+"""Gateway public Auth route bypass regression tests."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.security import SecurityScopes
+from httpx import ASGITransport, AsyncClient
+
+import app.services.gateway.dependencies as deps
+from app.messaging.bus import QueryResult
+from app.services.gateway.acl.identity import ANONYMOUS, SYSTEM
+from app.services.gateway.auth import (
+    GatewayAuth,
+    _resolve_identity_and_check,
+    create_auth_middleware,
+)
+from app.services.gateway.route_generator import RouteGenerator
+from app.shared.contracts.models.auth import AuthMethods, LoginRequest, LoginResponse
+from app.shared.contracts.models.gateway import MethodInfo
+
+
+class _SingleMethodRegistry:
+    def __init__(self, module_name: str, method_info: MethodInfo):
+        self.module_name = module_name
+        self.method_info = method_info
+
+    def on_registry_change(self, _callback):
+        pass
+
+    async def get_external_methods(self):
+        return [(self.module_name, self.method_info)]
+
+    def is_service_available(self, module_name: str) -> bool:
+        return module_name == self.module_name
+
+
+def _login_method(required_perms: list[str] | None = None) -> MethodInfo:
+    return MethodInfo(
+        name="Login",
+        summary="Login",
+        bus_topic=AuthMethods.LOGIN,
+        exposure="both",
+        method_type="use",
+        required_perms=required_perms or [],
+        input_model="LoginRequest",
+        output_model="LoginResponse",
+        input_schema=LoginRequest.model_json_schema(),
+        output_schema=LoginResponse.model_json_schema(),
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/Auth/Login",
+        "/api/Auth/PairingStart",
+        "/api/Auth/PairingConnect",
+        "/api/Auth/PairingExchange",
+        "/api/auth/login",
+        "/api/auth/pairing/start",
+        "/api/auth/pairing/connect",
+        "/api/auth/pairing/exchange",
+    ],
+)
+def test_gateway_auth_bypasses_canonical_and_legacy_public_auth_paths(path):
+    auth = GatewayAuth(enabled=True)
+
+    assert auth.should_bypass(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/Auth/LoginDebug",
+        "/api/Auth/Login-debug",
+        "/api/auth/login-debug",
+        "/api/Auth/PairingApprove",
+        "/api/auth/pairing/approve",
+    ],
+)
+def test_gateway_auth_bypass_does_not_match_protected_prefixes(path):
+    auth = GatewayAuth(enabled=True)
+
+    assert not auth.should_bypass(path)
+
+
+@pytest.mark.asyncio
+async def test_bypass_middleware_sets_anonymous_identity():
+    auth = GatewayAuth(enabled=True)
+    app = FastAPI()
+    app.middleware("http")(create_auth_middleware(auth))
+
+    @app.post("/api/Auth/Login")
+    async def login(request: Request):
+        identity = request.state.identity
+        return {
+            "principal_id": identity.principal_id,
+            "is_admin": identity.is_admin,
+            "effective_perms": list(identity.effective_perms),
+        }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/api/Auth/Login", json={})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "principal_id": ANONYMOUS.principal_id,
+        "is_admin": False,
+        "effective_perms": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_bypass_security_dependency_returns_anonymous_not_system():
+    auth = GatewayAuth(enabled=True)
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/Auth/Login",
+            "headers": [],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "scheme": "http",
+        }
+    )
+
+    identity = await _resolve_identity_and_check(
+        request,
+        SecurityScopes(scopes=[]),
+        bearer=None,
+        api_key_header=None,
+        auth=auth,
+    )
+
+    assert identity == ANONYMOUS
+    assert identity != SYSTEM
+
+
+@pytest.mark.asyncio
+async def test_auth_disabled_security_dependency_returns_system():
+    auth = GatewayAuth(enabled=False)
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/Auth/Login",
+            "headers": [],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "scheme": "http",
+        }
+    )
+
+    identity = await _resolve_identity_and_check(
+        request,
+        SecurityScopes(scopes=[]),
+        bearer=None,
+        api_key_header=None,
+        auth=auth,
+    )
+
+    assert identity == SYSTEM
+
+
+@pytest.mark.asyncio
+async def test_generated_canonical_login_route_bypasses_auth_as_anonymous():
+    old_gateway_auth = deps._gateway_auth
+    deps._gateway_auth = GatewayAuth(enabled=True)
+    try:
+        bus = AsyncMock()
+        bus.request = AsyncMock(
+            return_value=QueryResult(
+                ok=True,
+                data={
+                    "token": "token-1",
+                    "user_id": "user-1",
+                    "username": "alice",
+                    "permissions": [],
+                    "is_admin": False,
+                    "expires_at": None,
+                },
+            )
+        )
+        app = FastAPI()
+        router = APIRouter()
+        generator = RouteGenerator(
+            bus=bus,
+            registry=_SingleMethodRegistry("Auth", _login_method()),
+        )
+        generator.set_router(router)
+        await generator.start()
+        app.include_router(router)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/Auth/Login",
+                json={"username": "alice", "password": "secret"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["token"] == "token-1"
+        bus.request.assert_awaited_once()
+        assert bus.request.await_args.kwargs["origin"] == "external"
+        assert bus.request.await_args.kwargs["principal_id"] == ANONYMOUS.principal_id
+    finally:
+        deps._gateway_auth = old_gateway_auth
+
+
+@pytest.mark.asyncio
+async def test_generated_public_auth_route_with_permissions_still_checks_anonymous_scope():
+    old_gateway_auth = deps._gateway_auth
+    deps._gateway_auth = GatewayAuth(enabled=True)
+    try:
+        bus = AsyncMock()
+        bus.request = AsyncMock(return_value=QueryResult(ok=True, data={"success": True}))
+        app = FastAPI()
+        router = APIRouter()
+        generator = RouteGenerator(
+            bus=bus,
+            registry=_SingleMethodRegistry("Auth", _login_method([AuthMethods.LOGIN])),
+        )
+        generator.set_router(router)
+        await generator.start()
+        app.include_router(router)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/Auth/Login",
+                json={"username": "alice", "password": "secret"},
+            )
+
+        assert response.status_code == 403
+        bus.request.assert_not_awaited()
+    finally:
+        deps._gateway_auth = old_gateway_auth


### PR DESCRIPTION
## Summary

- Adds canonical PascalCase public Auth bypass paths for generated Gateway routes.
- Keeps lowercase legacy public Auth paths in the bypass list for compatibility.
- Fixes FastAPI security dependency behavior so auth-enabled bypass routes resolve as `ANONYMOUS`, not `SYSTEM`, while still enforcing any declared scopes.
- Documents canonical SDK-facing public Auth endpoints in `docs/GATEWAY.md`.

## Root Cause

Gateway dynamic routes are generated as `/api/{ServiceName}/{MethodName}`, for example `/api/Auth/Login`, but the default bypass list only included lowercase legacy paths like `/api/auth/login`. The middleware already used `ANONYMOUS` for bypass paths, but the security dependency returned `SYSTEM` for bypassed requests.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy /home/developer/.local/bin/uv run --extra dev --extra test-all --extra gateway pytest tests/unit/gateway/test_auth_public_bypass.py tests/unit/gateway/test_route_generator_adminaction.py tests/unit/app/test_gateway.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy /home/developer/.local/bin/uv run --extra dev --extra gateway ruff check app/services/gateway/auth.py app/services/gateway/fastapi_app.py app/services/auth/service.py tests/unit/gateway/test_auth_public_bypass.py`
- `git diff --check`

## Notes

- Production UI wiring remains out of scope for PER-188.
- `.omx` plan/checkpoint artifacts are included for the required Multica/OMX planning trail.
