### PR TITLE
SDK-002 generated backend inventory ingestion

### DIFF
--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -21,6 +21,23 @@ const catalog = await client.capabilities.listCatalog({ include_schemas: true })
 const result = await client.result(() => client.registry.getRegistry())
 ```
 
+## Generated Backend Inventory
+
+`scripts/generate_backend_inventory.py` emits the backend contract, route, permission, exposure, and gateway built-in inventory used by UI planning. The SDK can ingest that generated shape directly:
+
+```ts
+import { describeBackendInventory } from '@aurora/client'
+
+const inventory = await fetch('/backend-inventory.json').then((response) => response.json())
+const { methods, gatewayBuiltins, methodTypes } = describeBackendInventory(inventory)
+
+methodTypes['Gateway.GetRegistry'].responseSchema
+methods.find((method) => method.busTopic === 'Gateway.GetRegistry')?.routePath
+gatewayBuiltins.find((route) => route.routePath === '/api/registry')
+```
+
+Generated methods keep backend `bus_topic`, permission casing, `method_type`, schemas, and route paths. Internal-only methods are marked unavailable over HTTP unless a local/native transport explicitly supports bus access.
+
 ## Tauri Local
 
 ```ts

--- a/packages/aurora-sdk/src/descriptors.ts
+++ b/packages/aurora-sdk/src/descriptors.ts
@@ -1,4 +1,15 @@
-import type { GetRegistryResponse, MethodDescriptor, MethodInfo } from './types.js'
+import type {
+  BackendInventory,
+  BackendInventoryDescriptors,
+  BackendInventoryMethod,
+  BackendMethodTypeDescriptor,
+  GatewayBuiltinRouteDescriptor,
+  GeneratedMethodDescriptor,
+  GetRegistryResponse,
+  JsonObject,
+  MethodDescriptor,
+  MethodInfo
+} from './types.js'
 
 export const GATEWAY_METHODS = {
   getRegistry: 'Gateway.GetRegistry',
@@ -52,4 +63,87 @@ export function describeMethod(module: string, method: MethodInfo): MethodDescri
     outputSchema: method.output_schema ?? null,
     availableOverHttp
   }
+}
+
+export function describeBackendInventory(inventory: BackendInventory): BackendInventoryDescriptors {
+  const methods = describeBackendInventoryMethods(inventory)
+  return {
+    methods,
+    gatewayBuiltins: describeGatewayBuiltins(inventory),
+    methodTypes: buildBackendMethodTypes(methods)
+  }
+}
+
+export function describeBackendInventoryMethods(inventory: BackendInventory): GeneratedMethodDescriptor[] {
+  return inventory.methods.map((method) => describeBackendInventoryMethod(method))
+}
+
+export function describeBackendInventoryMethod(method: BackendInventoryMethod): GeneratedMethodDescriptor {
+  if (!method.bus_topic) {
+    throw new TypeError(`Generated backend inventory method ${method.module}.${method.name} is missing bus_topic`)
+  }
+
+  const availableOverHttp = method.exposure === 'external' || method.exposure === 'both'
+  const inventoryRoutePath = method.routePath ?? method.route_path ?? null
+  const descriptorRoutePath = availableOverHttp ? inventoryRoutePath ?? routePath(method.module, method.name) : null
+
+  return {
+    module: method.module,
+    name: method.name,
+    busTopic: method.bus_topic,
+    routePath: descriptorRoutePath,
+    exposure: method.exposure,
+    methodType: method.method_type,
+    summary: method.summary ?? '',
+    inputModel: method.input_model ?? null,
+    outputModel: method.output_model ?? null,
+    requiredPermissions: [...method.required_perms],
+    inputSchema: cloneSchema(method.input_schema),
+    outputSchema: cloneSchema(method.output_schema),
+    availableOverHttp,
+    routeKind: method.route_kind ?? (availableOverHttp ? 'dynamic' : 'internal_bus'),
+    source: method.source ?? null,
+    sourceFile: method.source_file ?? null
+  }
+}
+
+export function describeGatewayBuiltins(inventory: BackendInventory): GatewayBuiltinRouteDescriptor[] {
+  return (inventory.gateway_builtins ?? []).flatMap((route) => {
+    const path = route.routePath ?? route.route_path
+    if (!path) return []
+    return [
+      {
+        name: route.name,
+        routePath: path,
+        httpMethods: [...route.http_methods],
+        exposure: 'gateway_builtin',
+        methodType: route.method_type,
+        summary: route.summary ?? '',
+        requiredPermissions: [...route.required_perms],
+        routeKind: 'gateway_builtin'
+      }
+    ]
+  })
+}
+
+export function buildBackendMethodTypes(
+  methods: GeneratedMethodDescriptor[]
+): Record<string, BackendMethodTypeDescriptor> {
+  return Object.fromEntries(
+    methods.map((descriptor) => [
+      descriptor.busTopic,
+      {
+        busTopic: descriptor.busTopic,
+        requestModel: descriptor.inputModel,
+        responseModel: descriptor.outputModel,
+        requestSchema: descriptor.inputSchema,
+        responseSchema: descriptor.outputSchema,
+        descriptor
+      }
+    ])
+  )
+}
+
+function cloneSchema(schema: JsonObject | null | undefined): JsonObject | null {
+  return schema ? { ...schema } : null
 }

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -1,4 +1,5 @@
 import type {
+  BackendInventory,
   CapabilityCatalogResponse,
   GatewayBuiltinRouteDescriptor,
   GetRegistryResponse,
@@ -102,3 +103,76 @@ export const gatewayBuiltinRoutesFixture: GatewayBuiltinRouteDescriptor[] = [
     requiredPermissions: ['Auth.manage']
   }
 ]
+
+export const backendInventoryFixture: BackendInventory = {
+  generated_by: 'scripts/generate_backend_inventory.py',
+  method_count: 2,
+  gateway_builtin_count: 2,
+  methods: [
+    {
+      module: 'Gateway',
+      name: 'GetRegistry',
+      summary: 'Return the aggregated service registry',
+      bus_topic: 'Gateway.GetRegistry',
+      routePath: '/api/Gateway/GetRegistry',
+      route_kind: 'dynamic',
+      exposure: 'external',
+      method_type: 'use',
+      required_perms: ['Gateway.use'],
+      input_model: null,
+      output_model: 'GetRegistryResponse',
+      input_schema: null,
+      output_schema: {
+        title: 'GetRegistryResponse',
+        type: 'object'
+      },
+      source: 'live_registry',
+      source_file: 'app/services/gateway/service.py:100'
+    },
+    {
+      module: 'Gateway',
+      name: 'InternalOnly',
+      summary: 'Internal-only method',
+      bus_topic: 'Gateway.InternalOnly',
+      routePath: null,
+      route_kind: 'internal_bus',
+      exposure: 'internal',
+      method_type: 'manage',
+      required_perms: ['Gateway.manage'],
+      input_model: null,
+      output_model: null,
+      input_schema: null,
+      output_schema: null,
+      source: 'static_contract',
+      source_file: 'tests/fixtures/gateway.py:1'
+    }
+  ],
+  gateway_builtins: [
+    {
+      name: 'get_registry',
+      summary: 'Get aggregated service registry',
+      routePath: '/api/registry',
+      http_methods: ['GET'],
+      route_kind: 'gateway_builtin',
+      exposure: 'gateway_builtin',
+      method_type: 'gateway',
+      required_perms: []
+    },
+    {
+      name: 'list_peers',
+      summary: 'List connected WebRTC peers',
+      routePath: '/api/admin/peers',
+      http_methods: ['GET'],
+      route_kind: 'gateway_builtin',
+      exposure: 'gateway_builtin',
+      method_type: 'manage',
+      required_perms: ['Auth.manage']
+    }
+  ],
+  import_errors: [],
+  ui_fixture_validation: {
+    checked: 0,
+    errors: [],
+    ok: true
+  }
+}

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -6,6 +6,11 @@ export { AuroraError, classifyHttpError } from './errors.js'
 export {
   GATEWAY_METHODS,
   TOOLING_METHODS,
+  buildBackendMethodTypes,
+  describeBackendInventory,
+  describeBackendInventoryMethod,
+  describeBackendInventoryMethods,
+  describeGatewayBuiltins,
   describeMethod,
   describeRegistry,
   methodIdentity,
@@ -19,6 +24,7 @@ export {
 } from './capabilities.js'
 export { auditFromHeaders, captureResult, createAuditReceipt, createAuroraEvent, createRedactionMetadata, normalizeError } from './transport.js'
 export {
+  backendInventoryFixture,
   capabilityCatalogFixture,
   emptyRegistryFixture,
   gatewayBuiltinRoutesFixture,

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -158,6 +158,73 @@ export interface GatewayBuiltinRouteDescriptor {
   requiredPermissions: string[]
 }
 
+export type BackendInventoryRouteKind = 'dynamic' | 'internal_bus' | 'gateway_builtin' | string
+
+export interface BackendInventoryMethod {
+  module: string
+  name: string
+  summary?: string | null
+  bus_topic: string | null
+  routePath?: string | null
+  route_path?: string | null
+  route_kind?: BackendInventoryRouteKind
+  exposure: ContractExposure
+  method_type: ContractMethodType
+  required_perms: string[]
+  input_model?: string | null
+  output_model?: string | null
+  input_schema?: JsonObject | null
+  output_schema?: JsonObject | null
+  source?: string | null
+  source_file?: string | null
+}
+
+export interface GatewayBuiltinInventoryRoute {
+  name: string
+  summary?: string | null
+  routePath?: string | null
+  route_path?: string | null
+  http_methods: string[]
+  route_kind: 'gateway_builtin' | string
+  exposure: 'gateway_builtin' | string
+  method_type: ContractMethodType
+  required_perms: string[]
+}
+
+export interface BackendInventory {
+  generated_by?: string
+  method_count?: number
+  gateway_builtin_count?: number
+  methods: BackendInventoryMethod[]
+  gateway_builtins?: GatewayBuiltinInventoryRoute[]
+  import_errors?: Array<Record<string, JsonValue>>
+  ui_fixture_validation?: Record<string, JsonValue>
+}
+
+export interface GeneratedMethodDescriptor extends MethodDescriptor {
+  routeKind: BackendInventoryRouteKind
+  source: string | null
+  sourceFile: string | null
+}
+
+export interface BackendMethodTypeDescriptor<
+  TRequest = JsonObject,
+  TResponse = JsonObject
+> {
+  busTopic: string
+  requestModel: string | null
+  responseModel: string | null
+  requestSchema: JsonObject | null
+  responseSchema: JsonObject | null
+  descriptor: GeneratedMethodDescriptor
+}
+
+export interface BackendInventoryDescriptors {
+  methods: GeneratedMethodDescriptor[]
+  gatewayBuiltins: GatewayBuiltinRouteDescriptor[]
+  methodTypes: Record<string, BackendMethodTypeDescriptor>
+}
+
 export type AvailabilityState =
   | 'available-local'
   | 'available-remote'

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -5,10 +5,12 @@ import {
   AuroraError,
   HttpGatewayTransport,
   MockAuroraTransport,
+  backendInventoryFixture,
   buildAdminOverviewManifest,
   capabilityCatalogFixture,
   createAuditReceipt,
   createAuroraEvent,
+  describeBackendInventory,
   describeRegistry,
   gatewayBuiltinRoutesFixture,
   gatewayServicesFixture,
@@ -452,6 +454,63 @@ describe('descriptors', () => {
         busTopic: 'Gateway.GetRegistry'
       })
     )
+  })
+
+  it('ingests generated backend inventory without changing route or permission truth', () => {
+    const generated = describeBackendInventory(backendInventoryFixture)
+    const registryMethods = describeRegistry(gatewayRegistryFixture)
+    const generatedByTopic = new Map(generated.methods.map((method) => [method.busTopic, method]))
+
+    for (const registryMethod of registryMethods) {
+      const generatedMethod = generatedByTopic.get(registryMethod.busTopic)
+      expect(generatedMethod).toBeDefined()
+      expect(generatedMethod).toEqual(
+        expect.objectContaining({
+          busTopic: registryMethod.busTopic,
+          routePath: registryMethod.routePath,
+          requiredPermissions: registryMethod.requiredPermissions,
+          availableOverHttp: registryMethod.availableOverHttp
+        })
+      )
+    }
+
+    expect(generated.methodTypes['Gateway.GetRegistry']).toEqual(
+      expect.objectContaining({
+        busTopic: 'Gateway.GetRegistry',
+        requestModel: null,
+        responseModel: 'GetRegistryResponse',
+        responseSchema: expect.objectContaining({ title: 'GetRegistryResponse' })
+      })
+    )
+    expect(generated.gatewayBuiltins).toEqual([
+      expect.objectContaining({
+        routePath: '/api/registry',
+        httpMethods: ['GET'],
+        requiredPermissions: []
+      }),
+      expect.objectContaining({
+        routePath: '/api/admin/peers',
+        methodType: 'manage',
+        requiredPermissions: ['Auth.manage']
+      })
+    ])
+  })
+
+  it('rejects generated backend inventory methods without backend bus identity', () => {
+    expect(() =>
+      describeBackendInventory({
+        methods: [
+          {
+            module: 'Gateway',
+            name: 'Broken',
+            bus_topic: null,
+            exposure: 'external',
+            method_type: 'use',
+            required_perms: []
+          }
+        ]
+      })
+    ).toThrow('missing bus_topic')
   })
 
   it('can carry explicit AuroraError metadata', () => {


### PR DESCRIPTION
## Summary

Implements SDK-002 generated backend inventory ingestion in `@aurora/client`.

- Adds typed SDK shapes for the P0-002 backend inventory, generated method descriptors, gateway built-ins, and schema-backed request/response descriptor metadata.
- Adds descriptor helpers to ingest generated inventory without inventing method IDs or changing backend permission casing.
- Exports the new ingestion helpers and documents HTTP/generated-inventory usage in the SDK README.
- Adds fixture comparison tests that compare generated backend inventory descriptors against the registry fixture for route, permission, and HTTP availability truth.

## Scope

SDK package only. No production UI wiring, Tauri/native work, backend route behavior, or service contract changes.

## Validation

- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test` (1 file, 15 tests)
- `/home/developer/projects/aurora/.venv/bin/python scripts/generate_backend_inventory.py --fail-on-ui-fixture-errors`

Inventory generator note: it completed successfully with `ui_fixture_validation.ok=true`. The existing local environment still reports optional dependency import warnings/errors for DB/Scheduler/Transcription/TTS/Orchestrator optional modules, but the script falls back to static contract extraction and exits 0.

## Risks

The new `methodTypes` map exposes schema/model metadata from generated inventory, not full compile-time payload model generation. That keeps this change SDK-only and transport-independent while preserving generated backend truth for downstream UI tasks.
