### PR TITLE
SDK-005: Add permission catalog helpers

### DIFF
--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -18,6 +18,7 @@ const client = new AuroraClient({
 
 const methods = await client.registry.listMethods()
 const catalog = await client.capabilities.listCatalog({ include_schemas: true })
+const permissions = await client.permissions.listCatalog()
 const result = await client.result(() => client.registry.getRegistry())
 
 client.auth.updateFromLogin({
@@ -31,6 +32,9 @@ client.auth.updateFromLogin({
 if (client.auth.snapshot().state === 'admin') {
   // Enable admin surfaces only from backend-proven permissions.
 }
+
+client.permissions.check(['Auth.DeletePrincipal'], 'manage').allowed
+permissions.find((permission) => permission.id === 'Auth.manage')?.label
 ```
 
 ## Generated Backend Inventory
@@ -50,6 +54,21 @@ gatewayBuiltins.find((route) => route.routePath === '/api/registry')
 
 Generated methods keep backend `bus_topic`, permission casing, `method_type`, schemas, and route paths. Internal-only methods are marked unavailable over HTTP unless a local/native transport explicitly supports bus access.
 
+Permission catalogs can be derived from the same inventory without inventing frontend permission IDs:
+
+```ts
+import { buildPermissionCatalogFromBackendInventory, resolveEffectivePermissions } from '@aurora/client'
+
+const permissions = buildPermissionCatalogFromBackendInventory(inventory)
+permissions.find((permission) => permission.id === 'Tooling.use')?.label // "Use Tooling"
+
+const effective = resolveEffectivePermissions({
+  userPermissions: ['Auth.manage', 'Gateway.use'],
+  tokenScopes: ['Gateway.*'],
+  userIsAdmin: false
+})
+```
+
 ## Tauri Local
 
 ```ts
@@ -68,6 +87,7 @@ const tauriTransport: AuroraTransport = {
 const client = new AuroraClient({ transport: tauriTransport })
 const manifest = await client.native.getManifest()
 const result = await client.result(() => client.native.getManifest())
+const canManageAuth = client.permissions.has('Auth.DeletePrincipal', 'manage')
 
 client.auth.updateFromWhoAmI({
   principal_id: 'local-owner',
@@ -105,6 +125,8 @@ client.auth.updateFromPairingExchange({
   node_name: 'Kitchen node',
   permissions: ['TTS.use']
 })
+
+client.permissions.check(['TTS.Synthesize'], 'use').allowed
 ```
 
 Mesh UI should show selected provider peer, service instance, fallback behavior, blockers, and correlation/audit metadata when available.
@@ -125,6 +147,11 @@ client.auth.updateFromTokenValidation({
   is_admin: false,
   source: 'http_bearer'
 })
+
+const effective = client.permissions.resolveEffective({
+  userPermissions: ['Gateway.use', 'TTS.use'],
+  tokenScopes: ['TTS.*']
+})
 ```
 
 Android/iOS features are enabled only when the native capability manifest and backend route/policy evidence both support them.
@@ -139,6 +166,7 @@ const transport = new MockAuroraTransport()
 
 const client = new AuroraClient({ transport })
 const result = await client.result(() => client.registry.getRegistry())
+const permissionCatalog = await client.permissions.listCatalog()
 
 client.auth.setApiKeySystem()
 client.auth.snapshot().state // "api_key_system"
@@ -179,6 +207,28 @@ if (session.state === 'forbidden') {
 ```
 
 `request()` and `requestResult()` apply normalized `401` and `403` failures to `client.auth`. A `401` becomes `unauthorized`, `expired`, or `revoked` when backend detail text identifies the specific condition. A `403` becomes `forbidden`. Transport loss, timeouts, validation errors, unavailable services, unsupported features, privacy blocks, and native permission errors do not change auth state.
+
+## Permission Catalog And Effective Access
+
+Permission helpers mirror the backend matcher in `app/shared/auth/permissions.py`:
+
+- `*` grants all permissions.
+- `Service.*` grants every permission under that service prefix.
+- `Service.use` and `Service.manage` grant methods with the matching backend `method_type`.
+- Exact method permissions such as `Gateway.GetRegistry` grant that backend method only.
+- Matching is case-sensitive; display helpers preserve raw backend IDs like `Auth.manage`, `Tooling.use`, and `*`.
+
+```ts
+import { checkAccess, hasPermission, permissionLabel } from '@aurora/client'
+
+hasPermission('Auth.DeletePrincipal', ['Auth.manage'], 'manage') // true
+hasPermission('Auth.DeletePrincipal', ['auth.manage'], 'manage') // false
+
+const decision = checkAccess(['Gateway.use'], ['Gateway.GetRegistry'], 'use')
+decision.grants['Gateway.GetRegistry'] // "Gateway.use"
+
+permissionLabel('Auth.manage') // "Manage Auth"
+```
 
 ## Normalized Envelopes
 

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -10,6 +10,7 @@ import {
 } from './transport.js'
 import { describeRegistry, GATEWAY_METHODS, TOOLING_METHODS, routePath } from './descriptors.js'
 import { buildAdminOverviewManifest, summarizeCapabilities } from './capabilities.js'
+import { buildPermissionCatalog, checkAccess, hasPermission, resolveEffectivePermissions } from './permissions.js'
 import type {
   AdminOverviewManifest,
   AdminOverviewManifestInput,
@@ -22,9 +23,16 @@ import type {
   MethodDescriptor,
   NativeCapabilityManifest,
   PeerSummary,
+  ContractMethodType,
   RouteExplainRequest,
   RouteExplainResponse
 } from './types.js'
+import type {
+  EffectivePermissionInput,
+  PermissionAccessDecision,
+  PermissionCatalogInput,
+  PermissionCatalogEntry
+} from './permissions.js'
 
 export interface AuroraClientOptions {
   transport: AuroraTransport
@@ -37,6 +45,7 @@ export class AuroraClient {
   readonly registry: RegistryClient
   readonly capabilities: CapabilityClient
   readonly adminOverview: AdminOverviewClient
+  readonly permissions: PermissionClient
   readonly routes: RouteClient
   readonly tools: ToolClient
   readonly native: NativeClient
@@ -49,6 +58,7 @@ export class AuroraClient {
     this.registry = new RegistryClient(this)
     this.capabilities = new CapabilityClient(this)
     this.adminOverview = new AdminOverviewClient(this)
+    this.permissions = new PermissionClient(this)
     this.routes = new RouteClient(this)
     this.tools = new ToolClient(this)
     this.native = new NativeClient(this)
@@ -150,6 +160,35 @@ export class CapabilityClient {
 
   async listSummaries(request: CapabilityCatalogRequest = {}): Promise<CapabilitySummary[]> {
     return summarizeCapabilities(await this.listCatalog(request))
+  }
+}
+
+export interface PermissionCatalogOptions {
+  gatewayBuiltins?: GatewayBuiltinRouteDescriptor[]
+}
+
+export class PermissionClient {
+  constructor(private readonly client: AuroraClient) {}
+
+  async listCatalog(options: PermissionCatalogOptions = {}): Promise<PermissionCatalogEntry[]> {
+    const input: PermissionCatalogInput = {
+      methods: await this.client.registry.listMethods(),
+      source: 'registry'
+    }
+    if (options.gatewayBuiltins !== undefined) input.gatewayBuiltins = options.gatewayBuiltins
+    return buildPermissionCatalog(input)
+  }
+
+  has(permission: string, methodType: ContractMethodType | null = null): boolean {
+    return hasPermission(permission, this.client.auth.snapshot().effectivePermissions, methodType)
+  }
+
+  check(requiredPermissions: string[], methodType: ContractMethodType | null = null): PermissionAccessDecision {
+    return checkAccess(this.client.auth.snapshot().effectivePermissions, requiredPermissions, methodType)
+  }
+
+  resolveEffective(input: EffectivePermissionInput): string[] {
+    return resolveEffectivePermissions(input)
   }
 }
 

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -22,6 +22,20 @@ export {
   privacyClassForAction,
   summarizeCapabilities
 } from './capabilities.js'
+export {
+  PERMISSION_ALL,
+  buildPermissionCatalog,
+  buildPermissionCatalogFromBackendInventory,
+  buildPermissionCatalogFromRegistry,
+  checkAccess,
+  hasPermission,
+  permissionDescription,
+  permissionGrantFor,
+  permissionLabel,
+  permissionsForMethod,
+  resolveEffectivePermissions,
+  wildcardIntersection
+} from './permissions.js'
 export { auditFromHeaders, captureResult, createAuditReceipt, createAuroraEvent, createRedactionMetadata, normalizeError } from './transport.js'
 export {
   backendInventoryFixture,
@@ -33,6 +47,14 @@ export {
 } from './fixtures.js'
 export type * from './types.js'
 export type * from './transport.js'
+export type {
+  EffectivePermissionInput,
+  PermissionAccessDecision,
+  PermissionCatalogEntry,
+  PermissionCatalogEntryKind,
+  PermissionCatalogInput,
+  PermissionRequirementSource
+} from './permissions.js'
 export type { AuroraErrorCode, AuroraErrorOptions } from './errors.js'
 export type {
   AuthCredentialKind,

--- a/packages/aurora-sdk/src/permissions.ts
+++ b/packages/aurora-sdk/src/permissions.ts
@@ -1,0 +1,355 @@
+import { describeBackendInventory, describeRegistry } from './descriptors.js'
+import type {
+  BackendInventory,
+  ContractExposure,
+  ContractMethodType,
+  GatewayBuiltinRouteDescriptor,
+  GetRegistryResponse,
+  MethodDescriptor
+} from './types.js'
+
+export const PERMISSION_ALL = '*'
+
+export type PermissionCatalogEntryKind =
+  | 'all'
+  | 'service_wildcard'
+  | 'method_type'
+  | 'method'
+  | 'gateway_builtin'
+  | 'unknown'
+
+export interface PermissionCatalogEntry {
+  id: string
+  label: string
+  description: string
+  service: string | null
+  action: string | null
+  kind: PermissionCatalogEntryKind
+  methodType: ContractMethodType | null
+  exposure: ContractExposure | null
+  busTopic: string | null
+  routePath: string | null
+  availableOverHttp: boolean
+  requiredBy: PermissionRequirementSource[]
+}
+
+export interface PermissionRequirementSource {
+  module: string | null
+  method: string
+  busTopic: string | null
+  routePath: string | null
+  methodType: ContractMethodType | null
+  exposure: ContractExposure | null
+  availableOverHttp: boolean
+  source: 'registry' | 'backend_inventory' | 'gateway_builtin' | 'manual'
+}
+
+export interface PermissionCatalogInput {
+  methods?: MethodDescriptor[]
+  gatewayBuiltins?: GatewayBuiltinRouteDescriptor[]
+  source?: PermissionRequirementSource['source']
+}
+
+export interface PermissionAccessDecision {
+  allowed: boolean
+  required: string[]
+  satisfied: string[]
+  missing: string[]
+  grants: Record<string, string | null>
+}
+
+export interface EffectivePermissionInput {
+  userPermissions: string[]
+  userIsAdmin?: boolean
+  tokenScopes: string[]
+}
+
+export function permissionLabel(permission: string): string {
+  if (permission === PERMISSION_ALL) return 'Full access'
+  const parsed = parsePermission(permission)
+  if (!parsed.service) return permission
+  if (parsed.action === '*') return `All ${parsed.service} permissions`
+  if (parsed.action === 'use') return `Use ${parsed.service}`
+  if (parsed.action === 'manage') return `Manage ${parsed.service}`
+  return parsed.action ? `${parsed.service} ${splitWords(parsed.action)}` : parsed.service
+}
+
+export function permissionDescription(permission: string, methodType: ContractMethodType | null = null): string {
+  if (permission === PERMISSION_ALL) return 'Grants every Aurora permission.'
+  const parsed = parsePermission(permission)
+  if (!parsed.service) return `Backend permission ${permission}.`
+  if (parsed.action === '*') return `Grants every ${parsed.service} permission.`
+  if (parsed.action === 'use') return `Grants ${parsed.service} methods whose backend method_type is use.`
+  if (parsed.action === 'manage') return `Grants ${parsed.service} methods whose backend method_type is manage.`
+  const typeSuffix = methodType ? ` This method is classified as ${methodType}.` : ''
+  return `Grants backend permission ${permission}.${typeSuffix}`
+}
+
+export function buildPermissionCatalog(input: PermissionCatalogInput): PermissionCatalogEntry[] {
+  const entries = new Map<string, PermissionCatalogEntry>()
+  ensureEntry(entries, PERMISSION_ALL, null, null)
+
+  for (const method of input.methods ?? []) {
+    const source = requirementSourceFromMethod(method, input.source ?? 'registry')
+    ensureServiceTemplates(entries, method.module)
+    ensureEntry(entries, method.busTopic, method.methodType, source)
+    for (const permission of method.requiredPermissions) {
+      ensureEntry(entries, permission, method.methodType, source).requiredBy.push(source)
+    }
+  }
+
+  for (const route of input.gatewayBuiltins ?? []) {
+    const source = requirementSourceFromGatewayBuiltin(route)
+    for (const permission of route.requiredPermissions) {
+      ensureEntry(entries, permission, route.methodType, source).requiredBy.push(source)
+    }
+  }
+
+  return [...entries.values()]
+    .map((entry) => ({
+      ...entry,
+      requiredBy: uniqueRequirementSources(entry.requiredBy)
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id))
+}
+
+export function buildPermissionCatalogFromRegistry(
+  registry: GetRegistryResponse,
+  gatewayBuiltins: GatewayBuiltinRouteDescriptor[] = []
+): PermissionCatalogEntry[] {
+  return buildPermissionCatalog({
+    methods: describeRegistry(registry),
+    gatewayBuiltins,
+    source: 'registry'
+  })
+}
+
+export function buildPermissionCatalogFromBackendInventory(inventory: BackendInventory): PermissionCatalogEntry[] {
+  const descriptors = describeBackendInventory(inventory)
+  return buildPermissionCatalog({
+    methods: descriptors.methods,
+    gatewayBuiltins: descriptors.gatewayBuiltins,
+    source: 'backend_inventory'
+  })
+}
+
+export function hasPermission(
+  required: string,
+  grantedPermissions: Iterable<string>,
+  methodType: ContractMethodType | null = null
+): boolean {
+  return permissionGrantFor(required, grantedPermissions, methodType) !== null
+}
+
+export function permissionGrantFor(
+  required: string,
+  grantedPermissions: Iterable<string>,
+  methodType: ContractMethodType | null = null
+): string | null {
+  const granted = new Set(grantedPermissions)
+  if (granted.has(PERMISSION_ALL)) return PERMISSION_ALL
+  if (granted.has(required)) return required
+
+  const requiredParts = required.split('.')
+  if (requiredParts.length > 1) {
+    for (const permission of granted) {
+      if (!permission.endsWith('.*')) continue
+      const prefixParts = permission.slice(0, -2).split('.')
+      if (
+        prefixParts.length < requiredParts.length &&
+        requiredParts.slice(0, prefixParts.length).every((part, index) => part === prefixParts[index])
+      ) {
+        return permission
+      }
+    }
+  }
+
+  if (methodType && requiredParts.length > 1) {
+    const typePermission = `${requiredParts[0]}.${methodType}`
+    if (granted.has(typePermission)) return typePermission
+  }
+
+  return null
+}
+
+export function checkAccess(
+  effectivePermissions: Iterable<string>,
+  requiredPermissions: string[],
+  methodType: ContractMethodType | null = null
+): PermissionAccessDecision {
+  const grants: Record<string, string | null> = {}
+  const satisfied: string[] = []
+  const missing: string[] = []
+
+  for (const required of requiredPermissions) {
+    const grant = permissionGrantFor(required, effectivePermissions, methodType)
+    grants[required] = grant
+    if (grant) satisfied.push(required)
+    else missing.push(required)
+  }
+
+  return {
+    allowed: missing.length === 0,
+    required: [...requiredPermissions],
+    satisfied,
+    missing,
+    grants
+  }
+}
+
+export function wildcardIntersection(userPermissions: Iterable<string>, tokenScopes: Iterable<string>): string[] {
+  const user = new Set(userPermissions)
+  const effective = new Set<string>()
+
+  for (const scope of tokenScopes) {
+    if (hasPermission(scope, user)) {
+      effective.add(scope)
+      continue
+    }
+    if (!isWildcardPermission(scope)) continue
+    for (const permission of user) {
+      if (hasPermission(permission, [scope])) effective.add(permission)
+    }
+  }
+
+  return sortedUnique([...effective])
+}
+
+export function resolveEffectivePermissions(input: EffectivePermissionInput): string[] {
+  if (input.userIsAdmin) return [PERMISSION_ALL]
+  if (input.tokenScopes.includes(PERMISSION_ALL) || input.tokenScopes.includes('all')) {
+    return sortedUnique(input.userPermissions)
+  }
+  return wildcardIntersection(input.userPermissions, input.tokenScopes)
+}
+
+export function permissionsForMethod(method: Pick<MethodDescriptor, 'requiredPermissions' | 'methodType'>): string[] {
+  return sortedUnique([
+    ...method.requiredPermissions,
+    ...method.requiredPermissions.flatMap((permission) => {
+      const parsed = parsePermission(permission)
+      if (!parsed.service) return []
+      return [`${parsed.service}.*`, `${parsed.service}.${method.methodType}`]
+    }),
+    PERMISSION_ALL
+  ])
+}
+
+function ensureServiceTemplates(entries: Map<string, PermissionCatalogEntry>, service: string): void {
+  ensureEntry(entries, `${service}.*`, null, null)
+  ensureEntry(entries, `${service}.use`, 'use', null)
+  ensureEntry(entries, `${service}.manage`, 'manage', null)
+}
+
+function ensureEntry(
+  entries: Map<string, PermissionCatalogEntry>,
+  permission: string,
+  methodType: ContractMethodType | null,
+  source: PermissionRequirementSource | null
+): PermissionCatalogEntry {
+  const existing = entries.get(permission)
+  if (existing) return existing
+
+  const parsed = parsePermission(permission)
+  const entry: PermissionCatalogEntry = {
+    id: permission,
+    label: permissionLabel(permission),
+    description: permissionDescription(permission, methodType),
+    service: parsed.service,
+    action: parsed.action,
+    kind: permissionKind(permission, source),
+    methodType: methodTypeForPermission(permission, methodType),
+    exposure: source?.exposure ?? null,
+    busTopic: source?.busTopic ?? (parsed.action && !['*', 'use', 'manage'].includes(parsed.action) ? permission : null),
+    routePath: source?.routePath ?? null,
+    availableOverHttp: source?.availableOverHttp ?? false,
+    requiredBy: []
+  }
+  entries.set(permission, entry)
+  return entry
+}
+
+function permissionKind(permission: string, source: PermissionRequirementSource | null): PermissionCatalogEntryKind {
+  if (permission === PERMISSION_ALL) return 'all'
+  const parsed = parsePermission(permission)
+  if (parsed.action === '*') return 'service_wildcard'
+  if (parsed.action === 'use' || parsed.action === 'manage') return 'method_type'
+  if (source?.source === 'gateway_builtin') return 'gateway_builtin'
+  return parsed.service ? 'method' : 'unknown'
+}
+
+function methodTypeForPermission(permission: string, methodType: ContractMethodType | null): ContractMethodType | null {
+  const action = parsePermission(permission).action
+  if (action === 'use' || action === 'manage') return action
+  return methodType
+}
+
+function parsePermission(permission: string): { service: string | null; action: string | null } {
+  if (permission === PERMISSION_ALL) return { service: null, action: null }
+  const [service, action] = permission.split('.', 2)
+  return {
+    service: service || null,
+    action: action || null
+  }
+}
+
+function requirementSourceFromMethod(
+  method: MethodDescriptor,
+  source: PermissionRequirementSource['source']
+): PermissionRequirementSource {
+  return {
+    module: method.module,
+    method: method.name,
+    busTopic: method.busTopic,
+    routePath: method.routePath,
+    methodType: method.methodType,
+    exposure: method.exposure,
+    availableOverHttp: method.availableOverHttp,
+    source
+  }
+}
+
+function requirementSourceFromGatewayBuiltin(route: GatewayBuiltinRouteDescriptor): PermissionRequirementSource {
+  return {
+    module: 'Gateway',
+    method: route.name,
+    busTopic: null,
+    routePath: route.routePath,
+    methodType: route.methodType,
+    exposure: route.exposure,
+    availableOverHttp: true,
+    source: 'gateway_builtin'
+  }
+}
+
+function uniqueRequirementSources(sources: PermissionRequirementSource[]): PermissionRequirementSource[] {
+  const seen = new Set<string>()
+  const unique: PermissionRequirementSource[] = []
+  for (const source of sources) {
+    const key = [
+      source.source,
+      source.module,
+      source.method,
+      source.busTopic,
+      source.routePath,
+      source.methodType,
+      source.exposure
+    ].join('|')
+    if (seen.has(key)) continue
+    seen.add(key)
+    unique.push(source)
+  }
+  return unique.sort((a, b) => `${a.module ?? ''}.${a.method}`.localeCompare(`${b.module ?? ''}.${b.method}`))
+}
+
+function isWildcardPermission(permission: string): boolean {
+  return permission === PERMISSION_ALL || permission.endsWith('.*')
+}
+
+function splitWords(value: string): string {
+  return value.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+}
+
+function sortedUnique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort()
+}

--- a/packages/aurora-sdk/src/session.ts
+++ b/packages/aurora-sdk/src/session.ts
@@ -1,4 +1,5 @@
 import { AuroraError } from './errors.js'
+import { hasPermission as hasEffectivePermission } from './permissions.js'
 
 export type AuthSessionState =
   | 'anonymous'
@@ -238,7 +239,7 @@ export class AuthSession {
   }
 
   hasPermission(permission: string): boolean {
-    return hasPermission(permission, this.snapshotValue.effectivePermissions)
+    return hasEffectivePermission(permission, this.snapshotValue.effectivePermissions)
   }
 
   updateFromLogin(response: LoginLikeResponse): void {
@@ -357,14 +358,6 @@ function cloneSnapshot(snapshot: AuthSessionSnapshot): AuthSessionSnapshot {
     permissions: [...snapshot.permissions],
     effectivePermissions: [...snapshot.effectivePermissions]
   }
-}
-
-function hasPermission(required: string, granted: string[]): boolean {
-  if (granted.includes('*')) return true
-  if (granted.includes(required)) return true
-  const [prefix] = required.split('.', 1)
-  if (prefix && granted.includes(`${prefix}.*`)) return true
-  return false
 }
 
 function isSystemSource(source: string | null | undefined): boolean {

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -6,6 +6,9 @@ import {
   HttpGatewayTransport,
   MockAuroraTransport,
   backendInventoryFixture,
+  buildPermissionCatalog,
+  buildPermissionCatalogFromBackendInventory,
+  checkAccess,
   buildAdminOverviewManifest,
   capabilityCatalogFixture,
   createAuditReceipt,
@@ -14,7 +17,11 @@ import {
   describeRegistry,
   gatewayBuiltinRoutesFixture,
   gatewayServicesFixture,
-  gatewayRegistryFixture
+  gatewayRegistryFixture,
+  hasPermission,
+  permissionLabel,
+  resolveEffectivePermissions,
+  wildcardIntersection
 } from '../src/index.js'
 
 describe('AuroraClient', () => {
@@ -599,6 +606,159 @@ describe('AuroraClient', () => {
           eventKind: 'tool.executed'
         }),
         redaction: expect.objectContaining({ secretsRedacted: true })
+      })
+    )
+  })
+})
+
+describe('permissions', () => {
+  it('matches backend permission semantics without lowercasing backend IDs', () => {
+    expect(hasPermission('Auth.DeletePrincipal', ['*'])).toBe(true)
+    expect(hasPermission('Auth.DeletePrincipal', ['Auth.DeletePrincipal'])).toBe(true)
+    expect(hasPermission('Auth.DeletePrincipal', ['Auth.*'])).toBe(true)
+    expect(hasPermission('Auth.DeletePrincipal', ['Auth.manage'], 'manage')).toBe(true)
+    expect(hasPermission('Auth.DeletePrincipal', ['Auth.use'], 'manage')).toBe(false)
+    expect(hasPermission('Auth.DeletePrincipal', ['auth.*'])).toBe(false)
+
+    expect(checkAccess(['Gateway.use'], ['Gateway.GetRegistry'], 'use')).toEqual(
+      expect.objectContaining({
+        allowed: true,
+        satisfied: ['Gateway.GetRegistry'],
+        missing: [],
+        grants: { 'Gateway.GetRegistry': 'Gateway.use' }
+      })
+    )
+
+    expect(checkAccess(['Gateway.use'], ['Gateway.InternalOnly'], 'manage')).toEqual(
+      expect.objectContaining({
+        allowed: false,
+        missing: ['Gateway.InternalOnly'],
+        grants: { 'Gateway.InternalOnly': null }
+      })
+    )
+  })
+
+  it('resolves effective permissions with backend wildcard intersection rules', () => {
+    expect(resolveEffectivePermissions({
+      userPermissions: ['Gateway.use', 'Auth.manage'],
+      userIsAdmin: true,
+      tokenScopes: ['Gateway.use']
+    })).toEqual(['*'])
+
+    expect(resolveEffectivePermissions({
+      userPermissions: ['Gateway.use', 'Auth.manage'],
+      tokenScopes: ['all']
+    })).toEqual(['Auth.manage', 'Gateway.use'])
+
+    expect(wildcardIntersection(['TTS.Synthesize', 'DB.RagSearch'], ['TTS.*'])).toEqual(['TTS.Synthesize'])
+    expect(resolveEffectivePermissions({
+      userPermissions: ['TTS.*', 'Gateway.GetRegistry'],
+      tokenScopes: ['TTS.Synthesize', 'Gateway.*']
+    })).toEqual(['Gateway.GetRegistry', 'TTS.Synthesize'])
+  })
+
+  it('builds a permission catalog from generated backend inventory and gateway builtins', () => {
+    const catalog = buildPermissionCatalogFromBackendInventory(backendInventoryFixture)
+    const byId = new Map(catalog.map((entry) => [entry.id, entry]))
+
+    expect(byId.get('*')).toEqual(
+      expect.objectContaining({
+        label: 'Full access',
+        kind: 'all'
+      })
+    )
+    expect(byId.get('Gateway.use')).toEqual(
+      expect.objectContaining({
+        id: 'Gateway.use',
+        label: 'Use Gateway',
+        kind: 'method_type'
+      })
+    )
+    expect(byId.get('Gateway.manage')).toEqual(
+      expect.objectContaining({
+        id: 'Gateway.manage',
+        methodType: 'manage'
+      })
+    )
+    expect(byId.get('Auth.manage')).toEqual(
+      expect.objectContaining({
+        id: 'Auth.manage',
+        label: 'Manage Auth',
+        kind: 'method_type',
+        availableOverHttp: true,
+        requiredBy: [
+          expect.objectContaining({
+            method: 'list_peers',
+            routePath: '/api/admin/peers',
+            source: 'gateway_builtin'
+          })
+        ]
+      })
+    )
+    expect(catalog.map((entry) => entry.id)).toEqual(expect.arrayContaining(['Gateway.GetRegistry', 'Gateway.*']))
+    expect(permissionLabel('Tooling.use')).toBe('Use Tooling')
+  })
+
+  it('builds a registry-backed permission catalog through AuroraClient and preserves transport-loss failures', async () => {
+    const client = new AuroraClient({
+      transport: new MockAuroraTransport().register('Gateway.GetRegistry', gatewayRegistryFixture)
+    })
+    client.auth.updateFromTokenValidation({
+      valid: true,
+      principal_id: 'user-1',
+      permissions: ['Gateway.use'],
+      effective_perms: ['Gateway.use'],
+      is_admin: false
+    })
+
+    const catalog = await client.permissions.listCatalog({ gatewayBuiltins: gatewayBuiltinRoutesFixture })
+    expect(catalog.map((entry) => entry.id)).toEqual(expect.arrayContaining(['Gateway.use', 'Auth.manage']))
+    expect(client.permissions.has('Gateway.GetRegistry', 'use')).toBe(true)
+    expect(client.permissions.check(['Gateway.InternalOnly'], 'manage')).toEqual(
+      expect.objectContaining({
+        allowed: false,
+        missing: ['Gateway.InternalOnly']
+      })
+    )
+
+    const result = await new AuroraClient({
+      transport: {
+        kind: 'mock',
+        request: async () => {
+          throw new TypeError('registry offline')
+        }
+      }
+    }).result(async function loadPermissions() {
+      const failingClient = new AuroraClient({
+        transport: {
+          kind: 'mock',
+          request: async () => {
+            throw new TypeError('registry offline')
+          }
+        }
+      })
+      return failingClient.permissions.listCatalog()
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.code).toBe('transport_loss')
+  })
+
+  it('builds manual catalog entries from registry descriptors and builtins without invented IDs', () => {
+    const methods = describeRegistry(gatewayRegistryFixture)
+    const catalog = buildPermissionCatalog({ methods, gatewayBuiltins: gatewayBuiltinRoutesFixture })
+
+    expect(catalog.find((entry) => entry.id === 'Gateway.GetRegistry')).toEqual(
+      expect.objectContaining({
+        busTopic: 'Gateway.GetRegistry',
+        routePath: '/api/Gateway/GetRegistry',
+        availableOverHttp: true
+      })
+    )
+    expect(catalog.find((entry) => entry.id === 'Gateway.manage')).toEqual(
+      expect.objectContaining({
+        busTopic: null,
+        kind: 'method_type'
       })
     )
   })


### PR DESCRIPTION
## Summary

- Adds a transport-independent SDK permission catalog module for backend permission IDs, labels, descriptions, catalog generation, and effective-access checks.
- Wires `client.permissions` to derive registry-backed permission catalogs and evaluate current auth-session effective permissions.
- Reuses the shared helper in `AuthSession.hasPermission()` and documents HTTP, Tauri local, mesh, native mobile, mock, inventory, and direct helper examples.

## Validation

- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test`
- `pnpm --filter @aurora/client build`
- `git diff --check origin/feat/ui-multi-platform-integration..HEAD`

## Notes

- The branch diff is limited to `packages/aurora-sdk`.
- A pre-existing local `assets/graph.png` working-tree change remains unstaged and is not included in this PR.
