### PR TITLE
SDK-006 Implement capability graph engine

### DIFF
--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -18,6 +18,8 @@ const client = new AuroraClient({
 
 const methods = await client.registry.listMethods()
 const catalog = await client.capabilities.listCatalog({ include_schemas: true })
+const graph = await client.capabilities.getGraph()
+const tts = graph.explain('method:TTS.Synthesize')
 const permissions = await client.permissions.listCatalog()
 const result = await client.result(() => client.registry.getRegistry())
 
@@ -35,6 +37,7 @@ if (client.auth.snapshot().state === 'admin') {
 
 client.permissions.check(['Auth.DeletePrincipal'], 'manage').allowed
 permissions.find((permission) => permission.id === 'Auth.manage')?.label
+tts.providerCandidates.map((candidate) => candidate.providerIdentity)
 ```
 
 ## Generated Backend Inventory
@@ -73,7 +76,7 @@ const effective = resolveEffectivePermissions({
 
 ```ts
 import type { AuroraTransport } from '@aurora/client'
-import { AuroraClient } from '@aurora/client'
+import { AuroraClient, buildCapabilityGraph } from '@aurora/client'
 
 const tauriTransport: AuroraTransport = {
   kind: 'tauri-local',
@@ -86,6 +89,12 @@ const tauriTransport: AuroraTransport = {
 
 const client = new AuroraClient({ transport: tauriTransport })
 const manifest = await client.native.getManifest()
+const catalog = await client.capabilities.listCatalog({ include_unavailable: true })
+const graph = buildCapabilityGraph({
+  catalog,
+  nativeManifest: manifest,
+  transportKind: client.transport.kind
+})
 const result = await client.result(() => client.native.getManifest())
 const canManageAuth = client.permissions.has('Auth.DeletePrincipal', 'manage')
 
@@ -109,8 +118,14 @@ const route = await client.routes.explain({
   selector: { peer_id: 'peer-123', module: 'TTS' }
 })
 
+const capability = await client.capabilities.explain('method:TTS.Synthesize')
+
 if (route.security_privacy_blockers.length > 0) {
   // Show the backend reason and keep execution disabled.
+}
+
+if (capability.selectorRequired && !capability.selectedProvider) {
+  // Ask the user to choose an eligible peer/provider before execution.
 }
 
 const result = await client.result(() => client.routes.explain({
@@ -136,6 +151,11 @@ Mesh UI should show selected provider peer, service instance, fallback behavior,
 ```ts
 const manifest = await client.native.getManifest()
 client.native.requirePermission('microphone', manifest)
+const nativeGraph = buildCapabilityGraph({
+  catalog: await client.capabilities.listCatalog({ include_unavailable: true }),
+  nativeManifest: manifest,
+  transportKind: client.transport.kind
+})
 const result = await client.result(() => client.native.getManifest())
 
 client.auth.updateFromTokenValidation({
@@ -159,18 +179,43 @@ Android/iOS features are enabled only when the native capability manifest and ba
 ## Mock Tests
 
 ```ts
-import { AuroraClient, MockAuroraTransport, gatewayRegistryFixture } from '@aurora/client'
+import {
+  AuroraClient,
+  MockAuroraTransport,
+  capabilityGraphCatalogFixture,
+  gatewayRegistryFixture
+} from '@aurora/client'
 
 const transport = new MockAuroraTransport()
   .register('Gateway.GetRegistry', gatewayRegistryFixture)
+  .register('Gateway.GetCapabilityCatalog', capabilityGraphCatalogFixture)
 
 const client = new AuroraClient({ transport })
 const result = await client.result(() => client.registry.getRegistry())
+const explanation = await client.capabilities.explain('tool:tool:notes')
 const permissionCatalog = await client.permissions.listCatalog()
 
 client.auth.setApiKeySystem()
 client.auth.snapshot().state // "api_key_system"
+explanation.providerCandidates.length // local and remote providers remain separate.
 ```
+
+## Capability Graph
+
+`client.capabilities.getGraph()` merges backend capability catalog actions, registry-only method exposure, native manifests, provider freshness, routeability, policy flags, and privacy/permission requirements into deterministic feature nodes. It preserves provider identity instead of collapsing local and remote providers:
+
+```ts
+const graph = await client.capabilities.getGraph()
+const notes = graph.explain('tool:tool:notes')
+
+notes.providerCandidates.map((candidate) => ({
+  provider: candidate.providerIdentity,
+  selectable: candidate.selectable,
+  reason: candidate.disabledReasons[0] ?? null
+}))
+```
+
+`graph.explain(featureId)` returns the selected provider, alternate providers, disabled reason, next repair action, selector/approval requirements, permission requirements, privacy class, and redaction evidence. Explicit selector and privacy requirements remain blocked until backend or native evidence satisfies them; the SDK does not silently fallback for safety-sensitive features.
 
 ## Auth Session State
 

--- a/packages/aurora-sdk/src/capabilities.ts
+++ b/packages/aurora-sdk/src/capabilities.ts
@@ -6,8 +6,16 @@ import type {
   AvailabilityState,
   CapabilityActionInfo,
   CapabilityCatalogResponse,
+  CapabilityExplanation,
+  CapabilityGraph,
+  CapabilityGraphInput,
+  CapabilityGraphNode,
+  CapabilityProviderCandidate,
+  CapabilityProviderIdentity,
+  CapabilityProviderInfo,
   CapabilitySummary,
   GetServicesResponse,
+  MethodDescriptor,
   NativeCapabilityManifest,
   NativeCapabilityState,
   PrivacyClass,
@@ -32,9 +40,68 @@ export function summarizeCapabilities(catalog: CapabilityCatalogResponse): Capab
   }))
 }
 
+export function buildCapabilityGraph(input: CapabilityGraphInput): CapabilityGraph {
+  const candidatesByFeature = new Map<string, CapabilityProviderCandidate[]>()
+  const rawActionsByFeature = new Map<string, CapabilityActionInfo[]>()
+  const providersById = new Map(input.catalog.providers.map((provider) => [provider.provider_id, provider]))
+  const registryMethods = input.registry ? describeRegistry(input.registry) : []
+  const catalogFeatureIds = new Set<string>()
+
+  for (const action of input.catalog.actions) {
+    const featureId = featureIdForAction(action)
+    catalogFeatureIds.add(featureId)
+    addCandidate(candidatesByFeature, candidateFromAction(action, featureId, providersById.get(action.provider_id)))
+    addRawAction(rawActionsByFeature, featureId, action)
+  }
+
+  for (const method of registryMethods) {
+    const featureId = featureIdForMethod(method)
+    if (catalogFeatureIds.has(featureId)) continue
+    if (method.exposure === 'internal' && !transportSupportsInternalBus(input.transportKind ?? null)) {
+      addCandidate(candidatesByFeature, candidateFromMethod(method, featureId, 'internal-only over this transport'))
+    }
+  }
+
+  for (const candidate of candidatesFromNativeManifest(input.nativeManifest)) {
+    addCandidate(candidatesByFeature, candidate)
+  }
+
+  const nodes = [...candidatesByFeature.entries()]
+    .map(([featureId, candidates]) =>
+      nodeFromCandidates(featureId, candidates, rawActionsByFeature.get(featureId) ?? [])
+    )
+    .sort((a, b) => a.featureId.localeCompare(b.featureId))
+  const byFeatureId = Object.fromEntries(nodes.map((node) => [node.featureId, node]))
+  const providerIndex = normalizeIndex(input.catalog.provider_index)
+  const candidateProviderIndex = {
+    ...providerIndex,
+    ...Object.fromEntries(
+      nodes.map((node) => [node.featureId, node.providers.map((provider) => provider.id)])
+    )
+  }
+
+  return {
+    generatedAt: input.catalog.generated_at,
+    localPeerId: input.catalog.local_peer_id,
+    localNodeName: input.catalog.local_node_name,
+    secretsRedacted: input.catalog.secrets_redacted,
+    nodes,
+    byFeatureId,
+    providerIndex,
+    candidateProviderIndex,
+    explain(featureId: string): CapabilityExplanation {
+      const node = byFeatureId[featureId]
+      if (!node) {
+        return explainMissingFeature(featureId, input.catalog.generated_at, input.catalog.secrets_redacted)
+      }
+      return explainNode(node, input.catalog.generated_at, input.catalog.secrets_redacted)
+    }
+  }
+}
+
 export function availabilityForAction(action: CapabilityActionInfo): AvailabilityState {
   if (action.freshness.stale) return 'stale'
-  if (action.policy.denial_reasons.length > 0 || action.bindability === 'denied') return 'denied'
+  if (action.bindability === 'pending') return 'pending'
   if (
     action.policy.consent_required ||
     action.policy.privacy_indicator_required ||
@@ -43,6 +110,7 @@ export function availabilityForAction(action: CapabilityActionInfo): Availabilit
   ) {
     return 'privacy-blocked'
   }
+  if (action.policy.denial_reasons.length > 0 || action.bindability === 'denied') return 'denied'
   if (action.route_blockers.length > 0 || action.bindability === 'unavailable') return 'unsupported'
   if (action.bindability === 'degraded') return 'degraded'
   if (action.provider_kind === 'local') return 'available-local'
@@ -148,6 +216,435 @@ function nativeCapabilityState(manifest: NativeCapabilityManifest | null | undef
     capabilityKeys: Object.keys(manifest.capabilities).sort(),
     evidenceSource: 'native-manifest'
   }
+}
+
+function featureIdForAction(action: CapabilityActionInfo): string {
+  if (action.tool_id) return `tool:${action.tool_id}`
+  if (action.resource_id) return `resource:${action.resource_id}`
+  return methodFeatureId(action.module, action.method, action.topic)
+}
+
+function featureIdForMethod(method: MethodDescriptor): string {
+  return methodFeatureId(method.module, method.name, method.busTopic)
+}
+
+function methodFeatureId(module: string, method: string, busTopic: string | null): string {
+  return `method:${busTopic ?? `${module}.${method}`}`
+}
+
+function candidateFromAction(
+  action: CapabilityActionInfo,
+  featureId: string,
+  provider: CapabilityProviderInfo | undefined
+): CapabilityProviderCandidate {
+  const availability = availabilityForAction(action)
+  const disabledReasons = sortedUnique([
+    ...action.route_blockers,
+    ...action.policy.denial_reasons,
+    ...(provider && !provider.eligible ? [provider.reason_code || provider.reason].filter(Boolean) : [])
+  ])
+  const selectorRequired = action.policy.explicit_selector_required || action.policy.selector_required
+  const privacyBlocked =
+    selectorRequired || action.policy.consent_required || action.policy.privacy_indicator_required
+  return {
+    id: `${featureId}@${action.provider_id}`,
+    featureId,
+    providerIdentity: providerIdentityFor(action.provider_kind, action.peer_id, action.provider_id),
+    providerId: action.provider_id,
+    providerKind: action.provider_kind,
+    peerId: action.peer_id,
+    serviceInstanceId: action.service_instance_id,
+    module: action.module,
+    method: action.method,
+    busTopic: action.topic,
+    toolId: action.tool_id,
+    resourceId: action.resource_id,
+    availability,
+    selectable: isSelectable(availability) && !privacyBlocked,
+    selected: false,
+    trustTier: action.policy.trust_tier,
+    routeability: routeabilityForAction(action, provider),
+    freshness: action.freshness,
+    requiredPermissions: [...action.policy.required_permissions],
+    privacyClass: privacyClassForAction(action),
+    disabledReasons,
+    requiredAction: requiredActionForAction(action, provider, disabledReasons),
+    selector: action.selector,
+    source: 'catalog',
+    raw: action
+  }
+}
+
+function candidateFromMethod(
+  method: MethodDescriptor,
+  featureId: string,
+  reason: string
+): CapabilityProviderCandidate {
+  return {
+    id: `${featureId}@unavailable:http`,
+    featureId,
+    providerIdentity: 'unavailable',
+    providerId: 'unavailable:http',
+    providerKind: 'unavailable',
+    peerId: null,
+    serviceInstanceId: null,
+    module: method.module,
+    method: method.name,
+    busTopic: method.busTopic,
+    toolId: null,
+    resourceId: null,
+    availability: 'unsupported',
+    selectable: false,
+    selected: false,
+    trustTier: 'none',
+    routeability: 'unavailable',
+    freshness: emptyFreshness('registry'),
+    requiredPermissions: [...method.requiredPermissions],
+    privacyClass: privacyClassForMethod(method),
+    disabledReasons: [reason],
+    requiredAction: 'use a local/Tauri transport with bus access or expose a backend contract',
+    selector: null,
+    source: 'registry',
+    raw: method
+  }
+}
+
+function candidatesFromNativeManifest(
+  manifest: NativeCapabilityManifest | null | undefined
+): CapabilityProviderCandidate[] {
+  if (!manifest) return []
+  return Object.entries(manifest.capabilities)
+    .map(([capability, enabled]) => {
+      const featureId = `native:${manifest.platform}:${capability}`
+      const missingPermissions = Object.entries(manifest.permissions)
+        .filter(([, granted]) => !granted)
+        .map(([permission]) => permission)
+      const availability: AvailabilityState = enabled
+        ? missingPermissions.length > 0
+          ? 'privacy-blocked'
+          : 'available-local'
+        : 'unsupported'
+      return {
+        id: `${featureId}@native:${manifest.platform}`,
+        featureId,
+        providerIdentity: `native:${manifest.platform}`,
+        providerId: `native:${manifest.platform}`,
+        providerKind: 'native',
+        peerId: null,
+        serviceInstanceId: null,
+        module: 'Native',
+        method: capability,
+        busTopic: null,
+        toolId: null,
+        resourceId: null,
+        availability,
+        selectable: availability === 'available-local',
+        selected: false,
+        trustTier: 'device',
+        routeability: enabled ? 'native-manifest' : 'disabled',
+        freshness: emptyFreshness('native-manifest'),
+        requiredPermissions: missingPermissions,
+        privacyClass: capability.toLowerCase().includes('microphone') ? 'raw-audio' : 'personal',
+        disabledReasons: enabled ? missingPermissions.map((permission) => `native permission missing: ${permission}`) : ['native capability disabled'],
+        requiredAction:
+          availability === 'privacy-blocked'
+            ? 'grant required native permission'
+            : availability === 'unsupported'
+              ? 'enable native capability in manifest'
+              : null,
+        selector: { platform: manifest.platform, capability },
+        source: 'native-manifest',
+        raw: null
+      } satisfies CapabilityProviderCandidate
+    })
+    .sort((a, b) => a.featureId.localeCompare(b.featureId))
+}
+
+function nodeFromCandidates(
+  featureId: string,
+  candidates: CapabilityProviderCandidate[],
+  rawActions: CapabilityActionInfo[]
+): CapabilityGraphNode {
+  const sortedCandidates = candidates
+    .map((candidate) => ({ ...candidate, selected: false }))
+    .sort(compareCandidates)
+  const selectedIndex = sortedCandidates.findIndex((candidate) => candidate.selectable)
+  const fallbackIndex = selectedIndex >= 0 ? selectedIndex : 0
+  const providers = sortedCandidates.map((candidate, index) => ({
+    ...candidate,
+    selected: index === fallbackIndex && candidate.selectable
+  }))
+  const selectedProvider = providers.find((candidate) => candidate.selected) ?? null
+  const primary = selectedProvider ?? providers[0] ?? null
+  const availability = availabilityForNode(providers, primary)
+  const requiredPermissions = sortedUnique(providers.flatMap((provider) => provider.requiredPermissions))
+  const disabledReason =
+    primary && !isSelectable(availability)
+      ? primary.disabledReasons[0] ?? primary.requiredAction ?? availability
+      : null
+  const selectorRequired = providers.some((provider) =>
+    provider.raw && 'policy' in provider.raw
+      ? provider.raw.policy.explicit_selector_required || provider.raw.policy.selector_required
+      : false
+  )
+  const approvalRequired = providers.some((provider) =>
+    provider.raw && 'policy' in provider.raw ? provider.raw.policy.approval_required : false
+  )
+  return {
+    featureId,
+    module: primary?.module ?? '',
+    method: primary?.method ?? '',
+    busTopic: primary?.busTopic ?? null,
+    kind: kindForFeature(featureId),
+    availability,
+    privacyClass: highestPrivacyClass(providers.map((provider) => provider.privacyClass)),
+    providerIdentity: selectedProvider?.providerIdentity ?? primary?.providerIdentity ?? 'unavailable',
+    selectedProvider,
+    providers,
+    alternateProviders: providers.filter((provider) => provider.id !== selectedProvider?.id),
+    requiredPermissions,
+    disabledReason,
+    requiredAction: primary?.requiredAction ?? null,
+    freshness: primary?.freshness ?? null,
+    selectorRequired,
+    approvalRequired,
+    routeable: providers.some((provider) => provider.selectable),
+    trustTier: primary?.trustTier ?? null,
+    rawActions
+  }
+}
+
+function explainNode(
+  node: CapabilityGraphNode,
+  generatedAt: string,
+  secretsRedacted: boolean
+): CapabilityExplanation {
+  const nextRepairAction = node.requiredAction ?? repairActionForState(node.availability)
+  return {
+    featureId: node.featureId,
+    state: node.availability,
+    summary: `${node.featureId} is ${node.availability}`,
+    selectedProvider: node.selectedProvider,
+    providerCandidates: node.providers,
+    alternateProviders: node.alternateProviders,
+    disabledReason: node.disabledReason,
+    nextRepairAction,
+    selectorRequired: node.selectorRequired,
+    approvalRequired: node.approvalRequired,
+    routeable: node.routeable,
+    requiredPermissions: node.requiredPermissions,
+    privacyClass: node.privacyClass,
+    evidence: {
+      generatedAt,
+      secretsRedacted,
+      sources: sortedUnique(node.providers.map((provider) => provider.source))
+    }
+  }
+}
+
+function explainMissingFeature(
+  featureId: string,
+  generatedAt: string,
+  secretsRedacted: boolean
+): CapabilityExplanation {
+  return {
+    featureId,
+    state: 'unsupported',
+    summary: `${featureId} is unsupported`,
+    selectedProvider: null,
+    providerCandidates: [],
+    alternateProviders: [],
+    disabledReason: 'No backend, native, or registry evidence exists for this feature',
+    nextRepairAction: 'refresh the capability catalog or install/enable a provider',
+    selectorRequired: false,
+    approvalRequired: false,
+    routeable: false,
+    requiredPermissions: [],
+    privacyClass: 'public',
+    evidence: {
+      generatedAt,
+      secretsRedacted,
+      sources: []
+    }
+  }
+}
+
+function providerIdentityFor(
+  providerKind: string,
+  peerId: string | null,
+  providerId: string
+): CapabilityProviderIdentity {
+  if (providerKind === 'local') return 'local'
+  if (providerKind === 'remote' && peerId) return `remote:${peerId}`
+  if (providerKind === 'native') return `native:${providerId.replace(/^native:/, '')}`
+  if (providerKind === 'cloud') return 'cloud'
+  return providerKind || 'unavailable'
+}
+
+function routeabilityForAction(
+  action: CapabilityActionInfo,
+  provider: CapabilityProviderInfo | undefined
+): string {
+  if (action.route_blockers.length > 0) return 'blocked'
+  if (action.freshness.stale) return 'stale'
+  if (provider && !provider.eligible) return provider.reason_code || 'ineligible'
+  return action.bindability
+}
+
+function requiredActionForAction(
+  action: CapabilityActionInfo,
+  provider: CapabilityProviderInfo | undefined,
+  disabledReasons: string[]
+): string | null {
+  if (action.freshness.stale) return 'refresh peer manifest or reconnect provider'
+  if (action.policy.explicit_selector_required || action.policy.selector_required) return 'choose a peer/provider'
+  if (action.policy.approval_required) return 'request approval before execution'
+  if (action.policy.consent_required) return 'collect user consent'
+  if (action.policy.privacy_indicator_required) return 'show required privacy indicator'
+  if (action.policy.denial_reasons.length > 0) return 'change policy, permission, or selected provider'
+  if (provider && !provider.eligible) return 'select an eligible provider'
+  if (disabledReasons.length > 0) return 'inspect capability blockers'
+  return null
+}
+
+function availabilityForNode(
+  providers: CapabilityProviderCandidate[],
+  primary: CapabilityProviderCandidate | null
+): AvailabilityState {
+  if (providers.some((provider) => provider.availability === 'available-local')) return 'available-local'
+  if (providers.some((provider) => provider.availability === 'available-remote')) return 'available-remote'
+  if (providers.some((provider) => provider.availability === 'privacy-blocked')) return 'privacy-blocked'
+  if (providers.some((provider) => provider.availability === 'pending')) return 'pending'
+  if (providers.some((provider) => provider.availability === 'degraded')) return 'degraded'
+  if (providers.some((provider) => provider.availability === 'stale')) return 'stale'
+  if (providers.some((provider) => provider.availability === 'denied')) return 'denied'
+  return primary?.availability ?? 'unsupported'
+}
+
+function isSelectable(availability: AvailabilityState): boolean {
+  return availability === 'available-local' || availability === 'available-remote' || availability === 'degraded'
+}
+
+function compareCandidates(a: CapabilityProviderCandidate, b: CapabilityProviderCandidate): number {
+  return (
+    availabilityRank(a.availability) - availabilityRank(b.availability) ||
+    providerRank(a.providerIdentity) - providerRank(b.providerIdentity) ||
+    a.providerId.localeCompare(b.providerId)
+  )
+}
+
+function availabilityRank(availability: AvailabilityState): number {
+  switch (availability) {
+    case 'available-local':
+      return 0
+    case 'available-remote':
+      return 1
+    case 'degraded':
+      return 2
+    case 'privacy-blocked':
+      return 3
+    case 'pending':
+      return 4
+    case 'stale':
+      return 5
+    case 'denied':
+      return 6
+    case 'unsupported':
+      return 7
+  }
+}
+
+function providerRank(identity: CapabilityProviderIdentity): number {
+  if (identity === 'local') return 0
+  if (identity.startsWith('remote:')) return 1
+  if (identity.startsWith('native:')) return 2
+  if (identity === 'cloud') return 3
+  if (identity === 'blocked') return 4
+  return 5
+}
+
+function kindForFeature(featureId: string): CapabilityGraphNode['kind'] {
+  if (featureId.startsWith('tool:')) return 'tool'
+  if (featureId.startsWith('resource:')) return 'resource'
+  if (featureId.startsWith('native:')) return 'native'
+  return 'method'
+}
+
+function highestPrivacyClass(classes: PrivacyClass[]): PrivacyClass {
+  const rank: Record<PrivacyClass, number> = {
+    public: 0,
+    personal: 1,
+    sensitive: 2,
+    secret: 3,
+    'raw-audio': 4,
+    credential: 5,
+    'admin-critical': 6
+  }
+  return classes.reduce<PrivacyClass>(
+    (highest, privacyClass) => (rank[privacyClass] > rank[highest] ? privacyClass : highest),
+    'public'
+  )
+}
+
+function privacyClassForMethod(method: MethodDescriptor): PrivacyClass {
+  return method.methodType === 'manage' ? 'admin-critical' : 'public'
+}
+
+function transportSupportsInternalBus(transportKind: string | null): boolean {
+  return transportKind === 'tauri-local' || transportKind === 'mock'
+}
+
+function repairActionForState(availability: AvailabilityState): string | null {
+  switch (availability) {
+    case 'privacy-blocked':
+      return 'complete selector, consent, approval, or privacy requirements'
+    case 'denied':
+      return 'adjust permissions or policy'
+    case 'stale':
+      return 'refresh provider state'
+    case 'pending':
+      return 'wait for backend approval or completion'
+    case 'degraded':
+      return 'inspect fallback and capacity warnings'
+    case 'unsupported':
+      return 'install, enable, or expose a provider'
+    default:
+      return null
+  }
+}
+
+function emptyFreshness(source: string) {
+  return {
+    source,
+    manifest_time: null,
+    last_probe_age_s: null,
+    ttl_s: null,
+    stale: false,
+    registry_digest: ''
+  }
+}
+
+function normalizeIndex(index: Record<string, string[]>): Record<string, string[]> {
+  return Object.fromEntries(Object.entries(index).map(([key, value]) => [key, [...value].sort()]))
+}
+
+function addCandidate(
+  map: Map<string, CapabilityProviderCandidate[]>,
+  candidate: CapabilityProviderCandidate
+): void {
+  const existing = map.get(candidate.featureId) ?? []
+  existing.push(candidate)
+  map.set(candidate.featureId, existing)
+}
+
+function addRawAction(
+  map: Map<string, CapabilityActionInfo[]>,
+  featureId: string,
+  action: CapabilityActionInfo
+): void {
+  const existing = map.get(featureId) ?? []
+  existing.push(action)
+  map.set(featureId, existing)
 }
 
 function sortedUnique(values: string[]): string[] {

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -9,13 +9,15 @@ import {
   type AuroraTransport
 } from './transport.js'
 import { describeRegistry, GATEWAY_METHODS, TOOLING_METHODS, routePath } from './descriptors.js'
-import { buildAdminOverviewManifest, summarizeCapabilities } from './capabilities.js'
+import { buildAdminOverviewManifest, buildCapabilityGraph, summarizeCapabilities } from './capabilities.js'
 import { buildPermissionCatalog, checkAccess, hasPermission, resolveEffectivePermissions } from './permissions.js'
 import type {
   AdminOverviewManifest,
   AdminOverviewManifestInput,
   CapabilityCatalogRequest,
   CapabilityCatalogResponse,
+  CapabilityExplanation,
+  CapabilityGraph,
   CapabilitySummary,
   GetRegistryResponse,
   GetServicesResponse,
@@ -160,6 +162,24 @@ export class CapabilityClient {
 
   async listSummaries(request: CapabilityCatalogRequest = {}): Promise<CapabilitySummary[]> {
     return summarizeCapabilities(await this.listCatalog(request))
+  }
+
+  async getGraph(
+    request: CapabilityCatalogRequest = { include_unavailable: true, include_internal: true }
+  ): Promise<CapabilityGraph> {
+    const [catalog, registry] = await Promise.all([
+      this.listCatalog(request),
+      this.client.registry.getRegistry()
+    ])
+    return buildCapabilityGraph({
+      catalog,
+      registry,
+      transportKind: this.client.transport.kind
+    })
+  }
+
+  async explain(featureId: string): Promise<CapabilityExplanation> {
+    return (await this.getGraph()).explain(featureId)
   }
 }
 

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -1,6 +1,10 @@
 import type {
   BackendInventory,
+  CapabilityActionInfo,
   CapabilityCatalogResponse,
+  CapabilityFreshnessInfo,
+  CapabilityPolicyDecisionInfo,
+  CapabilityProviderInfo,
   GatewayBuiltinRouteDescriptor,
   GetRegistryResponse,
   GetServicesResponse
@@ -62,6 +66,270 @@ export const capabilityCatalogFixture: CapabilityCatalogResponse = {
   resources: [],
   provider_index: {},
   action_index: {},
+  secrets_redacted: true
+}
+
+const basePolicy: CapabilityPolicyDecisionInfo = {
+  required_permissions: [],
+  trust_tier: 'local',
+  safety_class: 'standard',
+  explicit_selector_required: false,
+  consent_required: false,
+  privacy_indicator_required: false,
+  bandwidth_check_required: false,
+  approval_required: false,
+  selector_required: false,
+  mesh_visible: false,
+  local_only: false,
+  allowed_peers: null,
+  operation_class: null,
+  resource_scope: null,
+  denial_reasons: []
+}
+
+const baseFreshness: CapabilityFreshnessInfo = {
+  source: 'catalog',
+  manifest_time: '2026-06-19T00:00:00Z',
+  last_probe_age_s: 1,
+  ttl_s: 30,
+  stale: false,
+  registry_digest: 'fixture'
+}
+
+function provider(overrides: Partial<CapabilityProviderInfo>): CapabilityProviderInfo {
+  return {
+    provider_id: 'local:Gateway',
+    peer_id: 'local-peer',
+    provider_kind: 'local',
+    node_name: 'local',
+    status: 'healthy',
+    service_instance_id: 'gateway-local',
+    module: 'Gateway',
+    version: '0.1.0',
+    latency_ms: 1,
+    max_concurrent: 4,
+    active_calls: 0,
+    available_capacity: 4,
+    eligible: true,
+    reason_code: 'eligible',
+    reason: 'Eligible',
+    policy: basePolicy,
+    freshness: baseFreshness,
+    ...overrides
+  }
+}
+
+function action(overrides: Partial<CapabilityActionInfo>): CapabilityActionInfo {
+  const module = overrides.module ?? 'Gateway'
+  const method = overrides.method ?? 'GetRegistry'
+  return {
+    action_id: `${module}.${method}`,
+    module,
+    method,
+    topic: `${module}.${method}`,
+    tool_id: null,
+    resource_id: null,
+    provider_id: `local:${module}`,
+    peer_id: 'local-peer',
+    provider_kind: 'local',
+    service_instance_id: `${module.toLowerCase()}-local`,
+    selector: { peer_id: 'local-peer', module },
+    bindability: 'available',
+    sdk_operation_kind: 'bus_method',
+    route_hints: [],
+    route_blockers: [],
+    summary: `${module} ${method}`,
+    input_schema: null,
+    output_schema: null,
+    policy: basePolicy,
+    freshness: baseFreshness,
+    ...overrides
+  }
+}
+
+export const capabilityGraphCatalogFixture: CapabilityCatalogResponse = {
+  generated_at: '2026-06-19T00:00:00Z',
+  local_peer_id: 'local-peer',
+  local_node_name: 'local',
+  providers: [
+    provider({
+      provider_id: 'local:TTS',
+      module: 'TTS',
+      service_instance_id: 'tts-local'
+    }),
+    provider({
+      provider_id: 'remote:kitchen:TTS',
+      peer_id: 'kitchen-peer',
+      provider_kind: 'remote',
+      node_name: 'Kitchen node',
+      module: 'TTS',
+      service_instance_id: 'tts-kitchen',
+      latency_ms: 18,
+      policy: { ...basePolicy, trust_tier: 'paired', mesh_visible: true }
+    }),
+    provider({
+      provider_id: 'remote:den:TTS',
+      peer_id: 'den-peer',
+      provider_kind: 'remote',
+      node_name: 'Den node',
+      module: 'TTS',
+      service_instance_id: 'tts-den',
+      eligible: false,
+      reason_code: 'policy_denied',
+      reason: 'Remote playback disabled by policy',
+      policy: {
+        ...basePolicy,
+        trust_tier: 'paired',
+        mesh_visible: true,
+        denial_reasons: ['policy_denied']
+      }
+    }),
+    provider({
+      provider_id: 'remote:garage:Tooling',
+      peer_id: 'garage-peer',
+      provider_kind: 'remote',
+      node_name: 'Garage node',
+      module: 'Tooling',
+      service_instance_id: 'tooling-garage',
+      status: 'stale',
+      eligible: false,
+      reason_code: 'stale',
+      reason: 'Manifest is stale',
+      policy: { ...basePolicy, trust_tier: 'paired', mesh_visible: true },
+      freshness: { ...baseFreshness, last_probe_age_s: 900, stale: true }
+    })
+  ],
+  actions: [
+    action({
+      action_id: 'tts-local-synthesize',
+      module: 'TTS',
+      method: 'Synthesize',
+      topic: 'TTS.Synthesize',
+      provider_id: 'local:TTS',
+      service_instance_id: 'tts-local',
+      policy: { ...basePolicy, required_permissions: ['TTS.use'] }
+    }),
+    action({
+      action_id: 'tts-remote-synthesize',
+      module: 'TTS',
+      method: 'Synthesize',
+      topic: 'TTS.Synthesize',
+      provider_id: 'remote:kitchen:TTS',
+      peer_id: 'kitchen-peer',
+      provider_kind: 'remote',
+      service_instance_id: 'tts-kitchen',
+      selector: { peer_id: 'kitchen-peer', module: 'TTS' },
+      policy: {
+        ...basePolicy,
+        required_permissions: ['TTS.use'],
+        trust_tier: 'paired',
+        mesh_visible: true
+      }
+    }),
+    action({
+      action_id: 'tool-remote-file-search',
+      module: 'Tooling',
+      method: 'ExecuteTool',
+      topic: 'Tooling.ExecuteTool',
+      tool_id: 'tool:file-search',
+      provider_id: 'remote:kitchen:TTS',
+      peer_id: 'kitchen-peer',
+      provider_kind: 'remote',
+      service_instance_id: 'tts-kitchen',
+      selector: { peer_id: 'kitchen-peer', tool_id: 'tool:file-search' },
+      policy: {
+        ...basePolicy,
+        required_permissions: ['Tooling.use'],
+        trust_tier: 'paired',
+        mesh_visible: true
+      }
+    }),
+    action({
+      action_id: 'tool-local-notes',
+      module: 'Tooling',
+      method: 'ExecuteTool',
+      topic: 'Tooling.ExecuteTool',
+      tool_id: 'tool:notes',
+      provider_id: 'local:TTS',
+      service_instance_id: 'tooling-local',
+      policy: { ...basePolicy, required_permissions: ['Tooling.use'] }
+    }),
+    action({
+      action_id: 'tool-remote-notes',
+      module: 'Tooling',
+      method: 'ExecuteTool',
+      topic: 'Tooling.ExecuteTool',
+      tool_id: 'tool:notes',
+      provider_id: 'remote:kitchen:TTS',
+      peer_id: 'kitchen-peer',
+      provider_kind: 'remote',
+      service_instance_id: 'tooling-kitchen',
+      selector: { peer_id: 'kitchen-peer', tool_id: 'tool:notes' },
+      policy: {
+        ...basePolicy,
+        required_permissions: ['Tooling.use'],
+        trust_tier: 'paired',
+        mesh_visible: true
+      }
+    }),
+    action({
+      action_id: 'tool-remote-door',
+      module: 'Tooling',
+      method: 'ExecuteTool',
+      topic: 'Tooling.ExecuteTool',
+      tool_id: 'tool:garage-door',
+      provider_id: 'remote:den:TTS',
+      peer_id: 'den-peer',
+      provider_kind: 'remote',
+      service_instance_id: 'tooling-den',
+      selector: { peer_id: 'den-peer', tool_id: 'tool:garage-door' },
+      bindability: 'denied',
+      policy: {
+        ...basePolicy,
+        required_permissions: ['Tooling.use'],
+        trust_tier: 'paired',
+        mesh_visible: true,
+        explicit_selector_required: true,
+        approval_required: true,
+        operation_class: 'admin',
+        denial_reasons: ['policy_denied']
+      }
+    }),
+    action({
+      action_id: 'tool-stale-camera',
+      module: 'Tooling',
+      method: 'ExecuteTool',
+      topic: 'Tooling.ExecuteTool',
+      tool_id: 'tool:camera-snapshot',
+      provider_id: 'remote:garage:Tooling',
+      peer_id: 'garage-peer',
+      provider_kind: 'remote',
+      service_instance_id: 'tooling-garage',
+      selector: { peer_id: 'garage-peer', tool_id: 'tool:camera-snapshot' },
+      policy: {
+        ...basePolicy,
+        required_permissions: ['Tooling.use'],
+        trust_tier: 'paired',
+        mesh_visible: true
+      },
+      freshness: { ...baseFreshness, last_probe_age_s: 900, stale: true }
+    })
+  ],
+  resources: [],
+  provider_index: {
+    TTS: ['local:TTS', 'remote:kitchen:TTS'],
+    Tooling: ['local:TTS', 'remote:kitchen:TTS']
+  },
+  action_index: {
+    'TTS.Synthesize': ['tts-local-synthesize', 'tts-remote-synthesize'],
+    'Tooling.ExecuteTool': [
+      'tool-remote-file-search',
+      'tool-local-notes',
+      'tool-remote-notes',
+      'tool-remote-door',
+      'tool-stale-camera'
+    ]
+  },
   secrets_redacted: true
 }
 

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -19,6 +19,7 @@ export {
 export {
   availabilityForAction,
   buildAdminOverviewManifest,
+  buildCapabilityGraph,
   privacyClassForAction,
   summarizeCapabilities
 } from './capabilities.js'
@@ -39,6 +40,7 @@ export {
 export { auditFromHeaders, captureResult, createAuditReceipt, createAuroraEvent, createRedactionMetadata, normalizeError } from './transport.js'
 export {
   backendInventoryFixture,
+  capabilityGraphCatalogFixture,
   capabilityCatalogFixture,
   emptyRegistryFixture,
   gatewayBuiltinRoutesFixture,

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -362,6 +362,106 @@ export interface CapabilitySummary {
   raw: CapabilityActionInfo
 }
 
+export type CapabilityProviderIdentity =
+  | 'local'
+  | `remote:${string}`
+  | `native:${string}`
+  | 'cloud'
+  | 'unavailable'
+  | 'blocked'
+  | string
+
+export interface CapabilityProviderCandidate {
+  id: string
+  featureId: string
+  providerIdentity: CapabilityProviderIdentity
+  providerId: string
+  providerKind: string
+  peerId: string | null
+  serviceInstanceId: string | null
+  module: string
+  method: string
+  busTopic: string | null
+  toolId: string | null
+  resourceId: string | null
+  availability: AvailabilityState
+  selectable: boolean
+  selected: boolean
+  trustTier: string
+  routeability: string
+  freshness: CapabilityFreshnessInfo
+  requiredPermissions: string[]
+  privacyClass: PrivacyClass
+  disabledReasons: string[]
+  requiredAction: string | null
+  selector: unknown
+  source: 'catalog' | 'registry' | 'native-manifest'
+  raw: CapabilityActionInfo | MethodDescriptor | null
+}
+
+export interface CapabilityGraphNode {
+  featureId: string
+  module: string
+  method: string
+  busTopic: string | null
+  kind: 'method' | 'tool' | 'resource' | 'native' | string
+  availability: AvailabilityState
+  privacyClass: PrivacyClass
+  providerIdentity: CapabilityProviderIdentity
+  selectedProvider: CapabilityProviderCandidate | null
+  providers: CapabilityProviderCandidate[]
+  alternateProviders: CapabilityProviderCandidate[]
+  requiredPermissions: string[]
+  disabledReason: string | null
+  requiredAction: string | null
+  freshness: CapabilityFreshnessInfo | null
+  selectorRequired: boolean
+  approvalRequired: boolean
+  routeable: boolean
+  trustTier: string | null
+  rawActions: CapabilityActionInfo[]
+}
+
+export interface CapabilityExplanation {
+  featureId: string
+  state: AvailabilityState
+  summary: string
+  selectedProvider: CapabilityProviderCandidate | null
+  providerCandidates: CapabilityProviderCandidate[]
+  alternateProviders: CapabilityProviderCandidate[]
+  disabledReason: string | null
+  nextRepairAction: string | null
+  selectorRequired: boolean
+  approvalRequired: boolean
+  routeable: boolean
+  requiredPermissions: string[]
+  privacyClass: PrivacyClass
+  evidence: {
+    generatedAt: string
+    secretsRedacted: boolean
+    sources: string[]
+  }
+}
+
+export interface CapabilityGraph {
+  generatedAt: string
+  localPeerId: string | null
+  localNodeName: string
+  secretsRedacted: boolean
+  nodes: CapabilityGraphNode[]
+  byFeatureId: Record<string, CapabilityGraphNode>
+  providerIndex: Record<string, string[]>
+  candidateProviderIndex: Record<string, string[]>
+  explain(featureId: string): CapabilityExplanation
+}
+
+export interface CapabilityGraphInput {
+  catalog: CapabilityCatalogResponse
+  registry?: GetRegistryResponse | null
+  nativeManifest?: NativeCapabilityManifest | null
+  transportKind?: AuroraTransportKind | null
+}
+
 export interface PeerSummary {
   peerId: string
   nodeName: string

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -10,6 +10,8 @@ import {
   buildPermissionCatalogFromBackendInventory,
   checkAccess,
   buildAdminOverviewManifest,
+  buildCapabilityGraph,
+  capabilityGraphCatalogFixture,
   capabilityCatalogFixture,
   createAuditReceipt,
   createAuroraEvent,
@@ -109,6 +111,125 @@ describe('AuroraClient', () => {
         peerId: 'local-peer'
       })
     ])
+  })
+
+  it('builds a deterministic capability graph with separate local and remote providers', () => {
+    const graph = buildCapabilityGraph({
+      catalog: capabilityGraphCatalogFixture,
+      registry: gatewayRegistryFixture,
+      nativeManifest: {
+        platform: 'android',
+        permissions: { microphone: true },
+        capabilities: { microphoneCapture: true }
+      },
+      transportKind: 'http'
+    })
+
+    const tts = graph.byFeatureId['method:TTS.Synthesize']
+    expect(tts).toEqual(
+      expect.objectContaining({
+        availability: 'available-local',
+        providerIdentity: 'local',
+        routeable: true
+      })
+    )
+    expect(tts?.providers.map((provider) => provider.providerIdentity)).toEqual([
+      'local',
+      'remote:kitchen-peer'
+    ])
+
+    const duplicatedTool = graph.byFeatureId['tool:tool:notes']
+    expect(duplicatedTool?.providers).toHaveLength(2)
+    expect(duplicatedTool?.providers.map((provider) => provider.providerIdentity)).toEqual([
+      'local',
+      'remote:kitchen-peer'
+    ])
+    expect(duplicatedTool?.selectedProvider?.providerIdentity).toBe('local')
+
+    const native = graph.byFeatureId['native:android:microphoneCapture']
+    expect(native).toEqual(
+      expect.objectContaining({
+        availability: 'available-local',
+        providerIdentity: 'native:android',
+        privacyClass: 'raw-audio'
+      })
+    )
+  })
+
+  it('explains policy, selector, stale, and unsupported capability states', () => {
+    const graph = buildCapabilityGraph({
+      catalog: capabilityGraphCatalogFixture,
+      registry: gatewayRegistryFixture,
+      nativeManifest: {
+        platform: 'android',
+        permissions: { microphone: false },
+        capabilities: { microphoneCapture: true }
+      },
+      transportKind: 'http'
+    })
+
+    const denied = graph.explain('tool:tool:garage-door')
+    expect(denied).toEqual(
+      expect.objectContaining({
+        state: 'privacy-blocked',
+        selectorRequired: true,
+        approvalRequired: true,
+        nextRepairAction: 'choose a peer/provider'
+      })
+    )
+    expect(denied.providerCandidates[0]).toEqual(
+      expect.objectContaining({
+        providerIdentity: 'remote:den-peer',
+        selectable: false,
+        disabledReasons: expect.arrayContaining(['policy_denied'])
+      })
+    )
+
+    const stale = graph.explain('tool:tool:camera-snapshot')
+    expect(stale).toEqual(
+      expect.objectContaining({
+        state: 'stale',
+        routeable: false,
+        nextRepairAction: 'refresh peer manifest or reconnect provider'
+      })
+    )
+
+    const internalOnly = graph.explain('method:Gateway.InternalOnly')
+    expect(internalOnly).toEqual(
+      expect.objectContaining({
+        state: 'unsupported',
+        routeable: false,
+        nextRepairAction: 'use a local/Tauri transport with bus access or expose a backend contract'
+      })
+    )
+
+    const nativePermission = graph.explain('native:android:microphoneCapture')
+    expect(nativePermission).toEqual(
+      expect.objectContaining({
+        state: 'privacy-blocked',
+        nextRepairAction: 'grant required native permission',
+        requiredPermissions: ['microphone']
+      })
+    )
+  })
+
+  it('loads capability graph explanations through the client namespace', async () => {
+    const transport = new MockAuroraTransport()
+      .register('Gateway.GetRegistry', gatewayRegistryFixture)
+      .register('Gateway.GetCapabilityCatalog', capabilityGraphCatalogFixture)
+    const client = new AuroraClient({ transport })
+
+    const explanation = await client.capabilities.explain('tool:tool:file-search')
+
+    expect(explanation).toEqual(
+      expect.objectContaining({
+        state: 'available-remote',
+        routeable: true,
+        selectedProvider: expect.objectContaining({
+          providerIdentity: 'remote:kitchen-peer'
+        })
+      })
+    )
   })
 
   it('builds an admin overview manifest from backend evidence only', async () => {


### PR DESCRIPTION
## Summary

Implements SDK-006 capability graph support for `@aurora/client`.

- Adds typed capability graph nodes, provider candidates, and `graph.explain(featureId)` explanations.
- Exposes `client.capabilities.getGraph()` and `client.capabilities.explain(featureId)`.
- Preserves local, remote peer, native, unavailable, and blocked provider identity without collapsing duplicate tool providers.
- Adds fixtures for local-only, remote-only, local+remote duplicate, policy-disabled remote, stale peer, and native-mobile-only capability states.
- Documents HTTP, Tauri local, mesh, native mobile, mock, and graph usage examples.

## Validation

- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test`
- `pnpm --filter @aurora/client build`

## Notes

The graph is SDK-only and does not implement production UI wiring. It keeps Gateway/catalog/native evidence as the source of truth and blocks explicit selector/privacy requirements instead of silently falling back.
