### PR TITLE
SDK-007 Implement HTTP Gateway transport adapter

### DIFF
--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -12,7 +12,8 @@ import { AuroraClient, HttpGatewayTransport } from '@aurora/client'
 const client = new AuroraClient({
   transport: new HttpGatewayTransport({
     baseUrl: 'http://127.0.0.1:8000',
-    bearerToken: sessionToken
+    bearerToken: sessionToken,
+    defaultTimeoutMs: 15_000
   })
 })
 
@@ -35,6 +36,33 @@ if (client.auth.snapshot().state === 'admin') {
 
 client.permissions.check(['Auth.DeletePrincipal'], 'manage').allowed
 permissions.find((permission) => permission.id === 'Auth.manage')?.label
+```
+
+`HttpGatewayTransport` maps Gateway built-ins to their live HTTP routes:
+
+- `Gateway.GetRegistry` -> `GET /api/registry`
+- `Gateway.GetServices` -> `GET /api/services`
+- `Gateway.Health` / `Gateway.HealthCheck` -> `GET /api/health`
+- `Gateway.OpenAPI` -> `GET /api/openapi.json`
+
+Generated external service methods default to `POST /api/{Module}/{Method}` with a JSON payload, matching Gateway's dynamic route generator. Callers can still pass an explicit `path` and `httpMethod` through `client.request()` when a descriptor or gateway built-in requires it.
+
+API-key and bearer auth are transport options; token values are only placed in request headers:
+
+```ts
+const transport = new HttpGatewayTransport({
+  baseUrl: 'https://aurora.example',
+  apiKey: operatorApiKey,
+  bearerToken: sessionToken
+})
+
+const result = await new AuroraClient({ transport }).requestResult('TTS.Synthesize', {
+  text: 'Hello'
+})
+
+if (!result.ok && result.error.code === 'permission') {
+  result.audit.correlationId
+}
 ```
 
 ## Generated Backend Inventory

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -67,13 +67,14 @@ export class AuroraClient {
   async request<TData = unknown, TPayload = unknown>(
     method: string,
     payload?: TPayload,
-    options: { path?: string; busTopic?: string; timeoutMs?: number } = {}
+    options: { path?: string; busTopic?: string; httpMethod?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'; timeoutMs?: number } = {}
   ): Promise<TData> {
     try {
       const response = await this.transport.request<TData, TPayload>({
         method,
         busTopic: options.busTopic ?? method,
         path: options.path,
+        httpMethod: options.httpMethod,
         payload,
         timeoutMs: options.timeoutMs ?? this.defaultTimeoutMs
       })
@@ -87,7 +88,7 @@ export class AuroraClient {
   async requestResult<TData = unknown, TPayload = unknown>(
     method: string,
     payload?: TPayload,
-    options: { path?: string; busTopic?: string; timeoutMs?: number } = {}
+    options: { path?: string; busTopic?: string; httpMethod?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'; timeoutMs?: number } = {}
   ): Promise<AuroraResponse<TData>> {
     const busTopic = options.busTopic ?? method
     try {
@@ -95,6 +96,7 @@ export class AuroraClient {
         method,
         busTopic,
         path: options.path,
+        httpMethod: options.httpMethod,
         payload,
         timeoutMs: options.timeoutMs ?? this.defaultTimeoutMs
       })
@@ -135,7 +137,10 @@ export class RegistryClient {
   constructor(private readonly client: AuroraClient) {}
 
   getRegistry(): Promise<GetRegistryResponse> {
-    return this.client.request<GetRegistryResponse>(GATEWAY_METHODS.getRegistry, {}, { path: '/api/registry' })
+    return this.client.request<GetRegistryResponse>(GATEWAY_METHODS.getRegistry, undefined, {
+      path: '/api/registry',
+      httpMethod: 'GET'
+    })
   }
 
   async listMethods(): Promise<MethodDescriptor[]> {
@@ -143,7 +148,10 @@ export class RegistryClient {
   }
 
   listServices(): Promise<GetServicesResponse> {
-    return this.client.request<GetServicesResponse>(GATEWAY_METHODS.getServices, {}, { path: '/api/services' })
+    return this.client.request<GetServicesResponse>(GATEWAY_METHODS.getServices, undefined, {
+      path: '/api/services',
+      httpMethod: 'GET'
+    })
   }
 }
 

--- a/packages/aurora-sdk/src/errors.ts
+++ b/packages/aurora-sdk/src/errors.ts
@@ -47,24 +47,45 @@ export class AuroraError extends Error {
 export function classifyHttpError(status: number, detail: unknown): AuroraErrorCode {
   const detailCode = readDetailCode(detail)
   const normalizedCode = detailCode?.toLowerCase()
+  const normalizedText = readDetailText(detail).toLowerCase()
   if (status === 401) return 'auth'
   if (status === 403) return 'permission'
   if (status === 408 || status === 504) return 'timeout'
+  if (normalizedCode?.includes('native_permission') || normalizedText.includes('native permission')) {
+    return 'native_permission_missing'
+  }
+  if (normalizedCode?.includes('privacy') || normalizedText.includes('privacy')) return 'privacy_blocked'
+  if (normalizedCode?.includes('unsupported') || normalizedText.includes('unsupported')) return 'unsupported_feature'
+  if (normalizedCode?.includes('unavailable') || normalizedText.includes('unavailable')) return 'unavailable_service'
+  if (normalizedCode?.includes('validation') || normalizedText.includes('validation')) return 'validation'
+  if (normalizedCode?.includes('auth') || normalizedText.includes('authentication')) return 'auth'
   if (status === 400 || status === 422) return 'validation'
   if (status === 503) return 'unavailable_service'
-  if (status === 428 && normalizedCode?.includes('privacy')) return 'privacy_blocked'
   if (status === 428 || normalizedCode?.includes('permission')) return 'permission'
-  if (normalizedCode?.includes('unsupported')) return 'unsupported_feature'
-  if (normalizedCode?.includes('unavailable')) return 'unavailable_service'
-  if (normalizedCode?.includes('native_permission')) return 'native_permission_missing'
-  if (normalizedCode?.includes('privacy')) return 'privacy_blocked'
-  if (normalizedCode?.includes('validation')) return 'validation'
-  if (normalizedCode?.includes('auth')) return 'auth'
   return 'unknown'
 }
 
 export function readDetailCode(detail: unknown): string | null {
   if (typeof detail !== 'object' || detail === null) return null
-  const maybeCode = (detail as { code?: unknown }).code
+  const maybeCode =
+    (detail as { code?: unknown }).code ??
+    (detail as { error_code?: unknown }).error_code ??
+    (detail as { reason_code?: unknown }).reason_code ??
+    (detail as { reason?: unknown }).reason
   return typeof maybeCode === 'string' ? maybeCode : null
+}
+
+function readDetailText(detail: unknown): string {
+  if (typeof detail === 'string') return detail
+  if (Array.isArray(detail)) return detail.map(readDetailText).join(' ')
+  if (typeof detail !== 'object' || detail === null) return ''
+  const values = [
+    (detail as { message?: unknown }).message,
+    (detail as { error?: unknown }).error,
+    (detail as { detail?: unknown }).detail,
+    (detail as { reason?: unknown }).reason,
+    (detail as { reason_code?: unknown }).reason_code,
+    (detail as { code?: unknown }).code
+  ]
+  return values.map(readDetailText).filter(Boolean).join(' ')
 }

--- a/packages/aurora-sdk/src/http.ts
+++ b/packages/aurora-sdk/src/http.ts
@@ -2,6 +2,8 @@ import { AuroraError, classifyHttpError } from './errors.js'
 import { auditFromHeaders } from './transport.js'
 import type { AuroraTransport, AuroraTransportRequest, AuroraTransportResponse } from './transport.js'
 
+type HttpMethod = NonNullable<AuroraTransportRequest['httpMethod']>
+
 export interface HttpTransportOptions {
   baseUrl: string
   apiKey?: string
@@ -29,19 +31,23 @@ export class HttpGatewayTransport implements AuroraTransport {
   async request<TData = unknown, TPayload = unknown>(
     request: AuroraTransportRequest<TPayload>
   ): Promise<AuroraTransportResponse<TData>> {
-    const path = request.path ?? `/api/${request.method.replace('.', '/')}`
+    const path = request.path ?? builtinPath(request.method) ?? `/api/${request.method.replace('.', '/')}`
+    const httpMethod = request.httpMethod ?? builtinHttpMethod(path) ?? 'POST'
     const controller = new AbortController()
     const timeoutMs = request.timeoutMs ?? this.defaultTimeoutMs
     const timeout = setTimeout(() => controller.abort(), timeoutMs)
-    const signal = request.signal ?? controller.signal
+    const signal = combineSignals(controller.signal, request.signal)
 
     try {
-      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
-        method: 'POST',
+      const init: RequestInit = {
+        method: httpMethod,
         headers: this.headers(request.headers),
-        body: JSON.stringify(request.payload ?? {}),
         signal
-      })
+      }
+      const body = requestBody(httpMethod, request.payload)
+      if (body !== undefined) init.body = body
+
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, init)
       const data = await parseJson(response)
       if (!response.ok) {
         throw new AuroraError({
@@ -66,10 +72,19 @@ export class HttpGatewayTransport implements AuroraTransport {
         }
       }
     } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') {
+      if (isAbortError(error)) {
         throw new AuroraError({
           code: 'timeout',
           message: `Aurora Gateway request timed out after ${timeoutMs}ms`,
+          method: request.method,
+          busTopic: request.busTopic,
+          cause: error
+        })
+      }
+      if (error instanceof TypeError) {
+        throw new AuroraError({
+          code: 'transport_loss',
+          message: error.message,
           method: request.method,
           busTopic: request.busTopic,
           cause: error
@@ -90,6 +105,62 @@ export class HttpGatewayTransport implements AuroraTransport {
     if (this.bearerToken) headers.Authorization = `Bearer ${this.bearerToken}`
     return headers
   }
+}
+
+function builtinPath(method: string): string | null {
+  switch (method) {
+    case 'Gateway.GetRegistry':
+      return '/api/registry'
+    case 'Gateway.GetServices':
+      return '/api/services'
+    case 'Gateway.Health':
+    case 'Gateway.HealthCheck':
+      return '/api/health'
+    case 'Gateway.OpenAPI':
+      return '/api/openapi.json'
+    default:
+      return null
+  }
+}
+
+function builtinHttpMethod(path: string): HttpMethod | null {
+  return path === '/api/registry' ||
+    path === '/api/services' ||
+    path === '/api/health' ||
+    path === '/api/openapi.json'
+    ? 'GET'
+    : null
+}
+
+function requestBody(method: HttpMethod, payload: unknown): BodyInit | undefined {
+  if (method === 'GET') return undefined
+  return JSON.stringify(payload ?? {})
+}
+
+function combineSignals(primary: AbortSignal, secondary: AbortSignal | undefined): AbortSignal {
+  if (!secondary) return primary
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any([primary, secondary])
+  }
+  const controller = new AbortController()
+  const abort = () => controller.abort()
+  if (primary.aborted || secondary.aborted) {
+    abort()
+  } else {
+    primary.addEventListener('abort', abort, { once: true })
+    secondary.addEventListener('abort', abort, { once: true })
+  }
+  return controller.signal
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError') ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error as { name?: unknown }).name === 'AbortError')
+  )
 }
 
 async function parseJson(response: Response): Promise<unknown> {

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -56,6 +56,7 @@ export type {
   PermissionRequirementSource
 } from './permissions.js'
 export type { AuroraErrorCode, AuroraErrorOptions } from './errors.js'
+export type { HttpTransportOptions } from './http.js'
 export type {
   AuthCredentialKind,
   AuthSessionIdentity,

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -34,6 +34,7 @@ export interface AuroraRequest<TPayload = unknown> {
   method: string
   busTopic?: string | undefined
   path?: string | undefined
+  httpMethod?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | undefined
   payload?: TPayload | undefined
   timeoutMs?: number | undefined
   headers?: Record<string, string> | undefined

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -323,6 +323,68 @@ describe('AuroraClient', () => {
     }
   })
 
+  it('uses Gateway built-in GET routes with auth headers and no request body', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = []
+    const transport = new HttpGatewayTransport({
+      baseUrl: 'http://aurora.local/',
+      apiKey: 'test-api-key',
+      bearerToken: 'test-bearer-token',
+      fetchImpl: async (input, init) => {
+        calls.push({ url: String(input), init: init ?? {} })
+        return new Response(
+          JSON.stringify({
+            digest: 'fixture',
+            modules: [],
+            service_count: 0,
+            method_count: 0
+          }),
+          {
+            status: 200,
+            headers: { 'x-correlation-id': 'corr-http-registry' }
+          }
+        )
+      }
+    })
+    const client = new AuroraClient({ transport })
+
+    await expect(client.registry.getRegistry()).resolves.toEqual(
+      expect.objectContaining({ digest: 'fixture' })
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toBe('http://aurora.local/api/registry')
+    expect(calls[0]?.init.method).toBe('GET')
+    expect(calls[0]?.init.body).toBeUndefined()
+    expect(calls[0]?.init.headers).toEqual(
+      expect.objectContaining({
+        'X-API-Key': 'test-api-key',
+        Authorization: 'Bearer test-bearer-token',
+        'content-type': 'application/json'
+      })
+    )
+  })
+
+  it('posts dynamic generated route payloads by method identity when no explicit path is supplied', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = []
+    const transport = new HttpGatewayTransport({
+      baseUrl: 'http://aurora.local',
+      fetchImpl: async (input, init) => {
+        calls.push({ url: String(input), init: init ?? {} })
+        return new Response(JSON.stringify({ route_decision: 'local', topic: 'TTS.Synthesize' }), {
+          status: 200
+        })
+      }
+    })
+    const client = new AuroraClient({ transport })
+
+    await expect(client.request('TTS.Synthesize', { text: 'hello' })).resolves.toEqual(
+      expect.objectContaining({ route_decision: 'local' })
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toBe('http://aurora.local/api/TTS/Synthesize')
+    expect(calls[0]?.init.method).toBe('POST')
+    expect(calls[0]?.init.body).toBe(JSON.stringify({ text: 'hello' }))
+  })
+
   it('classifies HTTP auth, validation, timeout, and unavailable service failures', async () => {
     const responses = [401, 422, 504, 503]
     const expected = ['auth', 'validation', 'timeout', 'unavailable_service']
@@ -366,6 +428,53 @@ describe('AuroraClient', () => {
         })
       )
     }
+  })
+
+  it('classifies HTTP detail-code unsupported, privacy, and native permission failures', async () => {
+    const cases = [
+      [{ detail: { code: 'unsupported_feature', message: 'Unsupported method' } }, 'unsupported_feature'],
+      [{ detail: { reason_code: 'privacy_blocked', message: 'Explicit selector required' } }, 'privacy_blocked'],
+      [{ detail: { code: 'native_permission_missing', message: 'Native permission missing' } }, 'native_permission_missing']
+    ] as const
+
+    for (const [body, expected] of cases) {
+      const transport = new HttpGatewayTransport({
+        baseUrl: 'http://aurora.local',
+        fetchImpl: async () => new Response(JSON.stringify(body), { status: 428 })
+      })
+      const client = new AuroraClient({ transport })
+      const result = await client.requestResult('Gateway.ExplainRoute', { topic: 'TTS.Synthesize' })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error.code).toBe(expected)
+    }
+  })
+
+  it('classifies HTTP abort timeout and network send failures', async () => {
+    const timeoutTransport = new HttpGatewayTransport({
+      baseUrl: 'http://aurora.local',
+      defaultTimeoutMs: 5,
+      fetchImpl: async () => {
+        throw new DOMException('Request aborted', 'AbortError')
+      }
+    })
+    const timeoutClient = new AuroraClient({ transport: timeoutTransport })
+    const timeoutResult = await timeoutClient.requestResult('Gateway.GetRegistry')
+
+    expect(timeoutResult.ok).toBe(false)
+    if (!timeoutResult.ok) expect(timeoutResult.error.code).toBe('timeout')
+
+    const lossTransport = new HttpGatewayTransport({
+      baseUrl: 'http://aurora.local',
+      fetchImpl: async () => {
+        throw new TypeError('fetch failed')
+      }
+    })
+    const lossClient = new AuroraClient({ transport: lossTransport })
+    const lossResult = await lossClient.requestResult('Gateway.GetRegistry')
+
+    expect(lossResult.ok).toBe(false)
+    if (!lossResult.ok) expect(lossResult.error.code).toBe('transport_loss')
   })
 
   it('classifies unsupported, privacy blocked, and native permission errors', async () => {


### PR DESCRIPTION
## Summary
- Implement HTTP Gateway transport route/method selection for Gateway built-ins and dynamic generated routes.
- Add auth headers, timeout/abort handling, transport-loss wrapping, and backend detail-code error classification.
- Document HTTP/Tauri/mesh/native/mock usage and add SDK tests for success and failure paths.

## Verification
- pnpm --filter @aurora/client typecheck
- pnpm --filter @aurora/client test