### PR TITLE
SDK-008: Implement mock transport and contract fixtures

### DIFF
--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -210,23 +210,40 @@ Android/iOS features are enabled only when the native capability manifest and ba
 import {
   AuroraClient,
   MockAuroraTransport,
-  capabilityGraphCatalogFixture,
-  gatewayRegistryFixture
+  compareRegistryFixtureToBackendInventory,
+  gatewayRegistryFixture,
+  backendInventoryFixture
 } from '@aurora/client'
 
 const transport = new MockAuroraTransport()
-  .register('Gateway.GetRegistry', gatewayRegistryFixture)
-  .register('Gateway.GetCapabilityCatalog', capabilityGraphCatalogFixture)
 
 const client = new AuroraClient({ transport })
 const result = await client.result(() => client.registry.getRegistry())
+const catalog = await client.capabilities.listCatalog({ include_unavailable: true })
+const route = await client.routes.explain({ topic: 'TTS.Synthesize' })
+const native = await client.native.getManifest()
 const explanation = await client.capabilities.explain('tool:tool:notes')
 const permissionCatalog = await client.permissions.listCatalog()
 
 client.auth.setApiKeySystem()
 client.auth.snapshot().state // "api_key_system"
 explanation.providerCandidates.length // local and remote providers remain separate.
+compareRegistryFixtureToBackendInventory(gatewayRegistryFixture, backendInventoryFixture).ok // true
 ```
+
+`MockAuroraTransport` preloads deterministic backend-shaped fixtures for registry, services, capability catalog, route explain, native manifest, and tool catalog. The fixtures are based on `modules/ui-mock-reference/lib/aurora/data.ts` labels plus backend inventory shapes; they preserve backend method identity as `bus_topic` + method name and keep internal-only methods unavailable over HTTP.
+
+Use `MockAuroraTransport.empty()` when a test needs no handlers, or override/script individual methods:
+
+```ts
+const transport = new MockAuroraTransport()
+  .register('Gateway.GetRegistry', gatewayRegistryFixture)
+  .fail('Gateway.ExplainRoute', 'privacy_blocked', 'Explicit selector required')
+  .timeout('Tooling.GetToolCatalog')
+  .lose('Gateway.GetCapabilityCatalog')
+```
+
+The mock fixtures are test/development data only. Production UI code should call `AuroraClient` namespaces and treat Gateway/native responses as the truth source.
 
 ## Capability Graph
 

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -7,8 +7,11 @@ import type {
   CapabilityProviderInfo,
   GatewayBuiltinRouteDescriptor,
   GetRegistryResponse,
-  GetServicesResponse
+  GetServicesResponse,
+  NativeCapabilityManifest,
+  RouteExplainResponse
 } from './types.js'
+import { describeBackendInventory, describeRegistry } from './descriptors.js'
 
 export const emptyRegistryFixture: GetRegistryResponse = {
   modules: [],
@@ -57,15 +60,187 @@ export const gatewayRegistryFixture: GetRegistryResponse = {
   method_count: 2
 }
 
+const localFreshness: CapabilityFreshnessInfo = {
+  source: 'ui-mock-reference+backend-inventory',
+  manifest_time: '2026-06-19T00:00:00Z',
+  last_probe_age_s: 2,
+  ttl_s: 30,
+  stale: false,
+  registry_digest: 'fixture'
+}
+
+const staleFreshness: CapabilityFreshnessInfo = {
+  ...localFreshness,
+  last_probe_age_s: 240,
+  stale: true
+}
+
+const standardPolicy: CapabilityPolicyDecisionInfo = {
+  required_permissions: ['Gateway.use'],
+  trust_tier: 'local',
+  safety_class: 'standard',
+  explicit_selector_required: false,
+  consent_required: false,
+  privacy_indicator_required: false,
+  bandwidth_check_required: false,
+  approval_required: false,
+  selector_required: false,
+  mesh_visible: false,
+  local_only: false,
+  allowed_peers: null,
+  operation_class: null,
+  resource_scope: null,
+  denial_reasons: []
+}
+
+const privacyBlockedPolicy: CapabilityPolicyDecisionInfo = {
+  ...standardPolicy,
+  required_permissions: ['TTS.use'],
+  trust_tier: 'mesh',
+  safety_class: 'sensitive',
+  explicit_selector_required: true,
+  consent_required: true,
+  privacy_indicator_required: true,
+  selector_required: true,
+  mesh_visible: true,
+  operation_class: 'audio',
+  resource_scope: 'raw-audio',
+  denial_reasons: []
+}
+
+const localGatewayProvider: CapabilityProviderInfo = {
+  provider_id: 'local:Gateway',
+  peer_id: 'local-peer',
+  provider_kind: 'local',
+  node_name: 'aurora-prod-01',
+  status: 'healthy',
+  service_instance_id: 'gw-7f3a',
+  module: 'Gateway',
+  version: '0.1.0',
+  latency_ms: 1,
+  max_concurrent: 16,
+  active_calls: 0,
+  available_capacity: 16,
+  eligible: true,
+  reason_code: 'eligible',
+  reason: 'Local Gateway fixture provider is available.',
+  policy: standardPolicy,
+  freshness: localFreshness
+}
+
+const remoteTtsProvider: CapabilityProviderInfo = {
+  provider_id: 'mesh:studio-gpu:TTS',
+  peer_id: 'peer-studio-gpu',
+  provider_kind: 'mesh',
+  node_name: 'studio-gpu',
+  status: 'available',
+  service_instance_id: 'tts-remote-01',
+  module: 'TTS',
+  version: '0.1.0',
+  latency_ms: 34,
+  max_concurrent: 2,
+  active_calls: 0,
+  available_capacity: 2,
+  eligible: false,
+  reason_code: 'explicit_selector_required',
+  reason: 'Remote raw-audio capable provider requires explicit selector and consent.',
+  policy: privacyBlockedPolicy,
+  freshness: localFreshness
+}
+
+const staleDbProvider: CapabilityProviderInfo = {
+  provider_id: 'mesh:cabin-node:DB',
+  peer_id: 'peer-cabin-node',
+  provider_kind: 'mesh',
+  node_name: 'cabin-node',
+  status: 'stale',
+  service_instance_id: 'db-stale-01',
+  module: 'DB',
+  version: '0.1.0',
+  latency_ms: 180,
+  max_concurrent: 1,
+  active_calls: 1,
+  available_capacity: 0,
+  eligible: false,
+  reason_code: 'stale_provider',
+  reason: 'Provider heartbeat is older than the fixture TTL.',
+  policy: {
+    ...standardPolicy,
+    required_permissions: ['DB.use'],
+    trust_tier: 'mesh',
+    mesh_visible: true
+  },
+  freshness: staleFreshness
+}
+
+function actionFixture(
+  provider: CapabilityProviderInfo,
+  overrides: Partial<CapabilityActionInfo>
+): CapabilityActionInfo {
+  return {
+    action_id: `${provider.provider_id}:${overrides.method ?? 'Unknown'}`,
+    module: provider.module,
+    method: overrides.method ?? 'Unknown',
+    topic: overrides.topic ?? `${provider.module}.${overrides.method ?? 'Unknown'}`,
+    tool_id: null,
+    resource_id: null,
+    provider_id: provider.provider_id,
+    peer_id: provider.peer_id,
+    provider_kind: provider.provider_kind,
+    service_instance_id: provider.service_instance_id,
+    selector: { peer_id: provider.peer_id, module: provider.module },
+    bindability: provider.eligible ? 'available' : 'unavailable',
+    sdk_operation_kind: 'bus_method',
+    route_hints: [],
+    route_blockers: provider.eligible ? [] : [provider.reason_code],
+    summary: provider.reason,
+    input_schema: null,
+    output_schema: null,
+    policy: provider.policy,
+    freshness: provider.freshness,
+    ...overrides
+  }
+}
+
 export const capabilityCatalogFixture: CapabilityCatalogResponse = {
   generated_at: '2026-06-19T00:00:00Z',
   local_peer_id: 'local-peer',
-  local_node_name: 'local',
-  providers: [],
-  actions: [],
+  local_node_name: 'aurora-prod-01',
+  providers: [localGatewayProvider, remoteTtsProvider, staleDbProvider],
+  actions: [
+    actionFixture(localGatewayProvider, {
+      action_id: 'gateway-registry-local',
+      method: 'GetRegistry',
+      topic: 'Gateway.GetRegistry',
+      summary: 'Return the aggregated service registry fixture.',
+      bindability: 'available'
+    }),
+    actionFixture(remoteTtsProvider, {
+      action_id: 'tts-remote-privacy-blocked',
+      method: 'Synthesize',
+      topic: 'TTS.Synthesize',
+      summary: 'Remote speech synthesis fixture requires explicit selector and consent.',
+      bindability: 'unavailable'
+    }),
+    actionFixture(staleDbProvider, {
+      action_id: 'db-stale-rag-search',
+      method: 'RAGSearch',
+      topic: 'DB.RAGSearch',
+      summary: 'Stale remote DB/RAG provider fixture.',
+      bindability: 'unavailable'
+    })
+  ],
   resources: [],
-  provider_index: {},
-  action_index: {},
+  provider_index: {
+    Gateway: ['local:Gateway'],
+    TTS: ['mesh:studio-gpu:TTS'],
+    DB: ['mesh:cabin-node:DB']
+  },
+  action_index: {
+    Gateway: ['gateway-registry-local'],
+    TTS: ['tts-remote-privacy-blocked'],
+    DB: ['db-stale-rag-search']
+  },
   secrets_redacted: true
 }
 
@@ -443,4 +618,214 @@ export const backendInventoryFixture: BackendInventory = {
     errors: [],
     ok: true
   }
+}
+
+export const routeExplainFixture: RouteExplainResponse = {
+  topic: 'TTS.Synthesize',
+  module: 'TTS',
+  selected_target: 'none',
+  selected_peer_id: null,
+  selected_service_instance_id: null,
+  selected_provider_id: null,
+  selector_valid: false,
+  selector_validation_code: 'explicit_selector_required',
+  selector_validation_message: 'Remote TTS synthesis requires an explicit peer selector and consent.',
+  fallback_behavior: 'blocked',
+  candidates: [
+    {
+      provider_id: remoteTtsProvider.provider_id,
+      peer_id: remoteTtsProvider.peer_id,
+      provider_kind: remoteTtsProvider.provider_kind,
+      service_instance_id: remoteTtsProvider.service_instance_id,
+      module: remoteTtsProvider.module,
+      version: remoteTtsProvider.version,
+      included: true,
+      selected: false,
+      reason_code: remoteTtsProvider.reason_code,
+      reason: remoteTtsProvider.reason,
+      latency_ms: remoteTtsProvider.latency_ms,
+      active_calls: remoteTtsProvider.active_calls,
+      max_concurrent: remoteTtsProvider.max_concurrent,
+      available_capacity: remoteTtsProvider.available_capacity,
+      blockers: [
+        {
+          code: 'explicit_selector_required',
+          message: 'Select the target peer before remote raw-audio capable synthesis.',
+          severity: 'error',
+          provider_id: remoteTtsProvider.provider_id,
+          peer_id: remoteTtsProvider.peer_id,
+          security_privacy: true
+        }
+      ]
+    }
+  ],
+  blockers: [
+    {
+      code: 'explicit_selector_required',
+      message: 'Select the target peer before remote raw-audio capable synthesis.',
+      severity: 'error',
+      provider_id: remoteTtsProvider.provider_id,
+      peer_id: remoteTtsProvider.peer_id,
+      security_privacy: true
+    }
+  ],
+  security_privacy_blockers: [
+    {
+      code: 'privacy_indicator_required',
+      message: 'Show privacy/consent state before sending audio work to a peer.',
+      severity: 'error',
+      provider_id: remoteTtsProvider.provider_id,
+      peer_id: remoteTtsProvider.peer_id,
+      security_privacy: true
+    }
+  ],
+  secrets_redacted: true
+}
+
+export const nativeCapabilityManifestFixture: NativeCapabilityManifest = {
+  platform: 'tauri-desktop',
+  permissions: {
+    microphone: false,
+    notifications: true,
+    secureStorage: true
+  },
+  capabilities: {
+    localGateway: true,
+    sidecarSupervisor: false,
+    voiceCapture: false
+  }
+}
+
+export const toolCatalogFixture = {
+  generated_at: '2026-06-19T00:00:00Z',
+  tools: [
+    {
+      global_tool_id: 'tool:local:diagnostics.serviceHealth',
+      provider_peer_id: 'local-peer',
+      service_instance_id: 'tool-1a9e',
+      display_name: 'diagnostics.serviceHealth',
+      safety_class: 'standard',
+      approval_required: false,
+      required_permissions: ['Tooling.use'],
+      correlation_id: 'corr-tool-catalog-fixture',
+      secrets_redacted: true
+    }
+  ],
+  secrets_redacted: true
+} as const
+
+export const uiMockReferenceFixtureSummary = {
+  source: 'modules/ui-mock-reference/lib/aurora/data.ts',
+  deploymentMode: 'Server',
+  nodeName: 'aurora-prod-01',
+  serviceModules: ['Gateway', 'Auth', 'Orchestrator', 'TTS', 'STT', 'Tooling', 'Scheduler', 'Config', 'DB', 'Supervisor'],
+  availabilityStates: [
+    'available-local',
+    'available-remote',
+    'pending',
+    'denied',
+    'degraded',
+    'stale',
+    'privacy-blocked',
+    'unsupported'
+  ],
+  privacyClasses: ['public', 'personal', 'sensitive', 'secret', 'raw-audio', 'credential', 'admin-critical'],
+  backendTruthRule: 'Fixture labels are deterministic UI/mock references; execution truth stays with Gateway registry, capability catalog, route explain, and native manifest responses.'
+} as const
+
+export interface MockAuroraFixtureSet {
+  registry: GetRegistryResponse
+  services: GetServicesResponse
+  capabilityCatalog: CapabilityCatalogResponse
+  routeExplain: RouteExplainResponse
+  nativeManifest: NativeCapabilityManifest
+  toolCatalog: typeof toolCatalogFixture
+  backendInventory: BackendInventory
+  gatewayBuiltins: GatewayBuiltinRouteDescriptor[]
+}
+
+export const defaultMockAuroraFixtures: MockAuroraFixtureSet = {
+  registry: gatewayRegistryFixture,
+  services: gatewayServicesFixture,
+  capabilityCatalog: capabilityGraphCatalogFixture,
+  routeExplain: routeExplainFixture,
+  nativeManifest: nativeCapabilityManifestFixture,
+  toolCatalog: toolCatalogFixture,
+  backendInventory: backendInventoryFixture,
+  gatewayBuiltins: gatewayBuiltinRoutesFixture
+}
+
+export interface ContractFixtureComparisonIssue {
+  busTopic: string
+  field: 'missing' | 'routePath' | 'requiredPermissions' | 'exposure' | 'methodType' | 'availableOverHttp'
+  fixture: unknown
+  inventory: unknown
+}
+
+export interface ContractFixtureComparison {
+  ok: boolean
+  checked: number
+  issues: ContractFixtureComparisonIssue[]
+}
+
+export function compareRegistryFixtureToBackendInventory(
+  registry: GetRegistryResponse,
+  inventory: BackendInventory
+): ContractFixtureComparison {
+  const inventoryMethods = new Map(
+    describeBackendInventory(inventory).methods.map((method) => [method.busTopic, method])
+  )
+  const issues: ContractFixtureComparisonIssue[] = []
+  const registryMethods = describeRegistry(registry)
+
+  for (const fixtureMethod of registryMethods) {
+    const inventoryMethod = inventoryMethods.get(fixtureMethod.busTopic)
+    if (!inventoryMethod) {
+      issues.push({
+        busTopic: fixtureMethod.busTopic,
+        field: 'missing',
+        fixture: fixtureMethod.name,
+        inventory: null
+      })
+      continue
+    }
+    pushMismatch(issues, fixtureMethod.busTopic, 'routePath', fixtureMethod.routePath, inventoryMethod.routePath)
+    pushMismatch(
+      issues,
+      fixtureMethod.busTopic,
+      'requiredPermissions',
+      fixtureMethod.requiredPermissions,
+      inventoryMethod.requiredPermissions
+    )
+    pushMismatch(issues, fixtureMethod.busTopic, 'exposure', fixtureMethod.exposure, inventoryMethod.exposure)
+    pushMismatch(issues, fixtureMethod.busTopic, 'methodType', fixtureMethod.methodType, inventoryMethod.methodType)
+    pushMismatch(
+      issues,
+      fixtureMethod.busTopic,
+      'availableOverHttp',
+      fixtureMethod.availableOverHttp,
+      inventoryMethod.availableOverHttp
+    )
+  }
+
+  return {
+    ok: issues.length === 0,
+    checked: registryMethods.length,
+    issues
+  }
+}
+
+export function cloneFixture<TFixture>(fixture: TFixture): TFixture {
+  return JSON.parse(JSON.stringify(fixture)) as TFixture
+}
+
+function pushMismatch(
+  issues: ContractFixtureComparisonIssue[],
+  busTopic: string,
+  field: ContractFixtureComparisonIssue['field'],
+  fixture: unknown,
+  inventory: unknown
+): void {
+  if (JSON.stringify(fixture) === JSON.stringify(inventory)) return
+  issues.push({ busTopic, field, fixture, inventory })
 }

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -42,10 +42,17 @@ export {
   backendInventoryFixture,
   capabilityGraphCatalogFixture,
   capabilityCatalogFixture,
+  cloneFixture,
+  compareRegistryFixtureToBackendInventory,
+  defaultMockAuroraFixtures,
   emptyRegistryFixture,
   gatewayBuiltinRoutesFixture,
   gatewayRegistryFixture,
-  gatewayServicesFixture
+  gatewayServicesFixture,
+  nativeCapabilityManifestFixture,
+  routeExplainFixture,
+  toolCatalogFixture,
+  uiMockReferenceFixtureSummary
 } from './fixtures.js'
 export type * from './types.js'
 export type * from './transport.js'
@@ -59,6 +66,11 @@ export type {
 } from './permissions.js'
 export type { AuroraErrorCode, AuroraErrorOptions } from './errors.js'
 export type { HttpTransportOptions } from './http.js'
+export type {
+  ContractFixtureComparison,
+  ContractFixtureComparisonIssue,
+  MockAuroraFixtureSet
+} from './fixtures.js'
 export type {
   AuthCredentialKind,
   AuthSessionIdentity,

--- a/packages/aurora-sdk/src/mock.ts
+++ b/packages/aurora-sdk/src/mock.ts
@@ -1,4 +1,5 @@
 import { AuroraError, type AuroraErrorCode } from './errors.js'
+import { cloneFixture, defaultMockAuroraFixtures, type MockAuroraFixtureSet } from './fixtures.js'
 import type { AuroraTransportEnvelope } from './types.js'
 import type { AuroraTransport, AuroraTransportRequest, AuroraTransportResponse } from './transport.js'
 
@@ -10,9 +11,32 @@ export type MockRegistration<TPayload = unknown, TData = unknown> =
   | TData
   | AuroraTransportEnvelope<TData>
 
+export interface MockAuroraTransportOptions {
+  fixtures?: MockAuroraFixtureSet | false
+}
+
 export class MockAuroraTransport implements AuroraTransport {
   readonly kind = 'mock'
   private readonly handlers = new Map<string, MockHandler>()
+
+  constructor(options: MockAuroraTransportOptions = {}) {
+    const fixtures = options.fixtures === false ? null : options.fixtures ?? defaultMockAuroraFixtures
+    if (fixtures) this.registerFixtures(fixtures)
+  }
+
+  static empty(): MockAuroraTransport {
+    return new MockAuroraTransport({ fixtures: false })
+  }
+
+  registerFixtures(fixtures: MockAuroraFixtureSet): this {
+    return this
+      .register('Gateway.GetRegistry', () => cloneFixture(fixtures.registry))
+      .register('Gateway.GetServices', () => cloneFixture(fixtures.services))
+      .register('Gateway.GetCapabilityCatalog', () => cloneFixture(fixtures.capabilityCatalog))
+      .register('Gateway.ExplainRoute', () => cloneFixture(fixtures.routeExplain))
+      .register('Native.GetCapabilityManifest', () => cloneFixture(fixtures.nativeManifest))
+      .register('Tooling.GetToolCatalog', () => cloneFixture(fixtures.toolCatalog))
+  }
 
   register<TPayload = unknown, TData = unknown>(
     method: string,
@@ -29,6 +53,18 @@ export class MockAuroraTransport implements AuroraTransport {
   fail(method: string, code: AuroraErrorCode, message: string): this {
     return this.register(method, () => {
       throw new AuroraError({ code, message, method })
+    })
+  }
+
+  lose(method: string, message = 'mock transport unavailable'): this {
+    return this.register(method, () => {
+      throw new TypeError(message)
+    })
+  }
+
+  timeout(method: string, message = 'mock request timed out'): this {
+    return this.register(method, () => {
+      throw new DOMException(message, 'AbortError')
     })
   }
 

--- a/packages/aurora-sdk/src/test-utils.ts
+++ b/packages/aurora-sdk/src/test-utils.ts
@@ -1,2 +1,21 @@
 export { MockAuroraTransport } from './mock.js'
-export { capabilityCatalogFixture, emptyRegistryFixture, gatewayRegistryFixture } from './fixtures.js'
+export {
+  backendInventoryFixture,
+  capabilityCatalogFixture,
+  cloneFixture,
+  compareRegistryFixtureToBackendInventory,
+  defaultMockAuroraFixtures,
+  emptyRegistryFixture,
+  gatewayBuiltinRoutesFixture,
+  gatewayRegistryFixture,
+  gatewayServicesFixture,
+  nativeCapabilityManifestFixture,
+  routeExplainFixture,
+  toolCatalogFixture,
+  uiMockReferenceFixtureSummary
+} from './fixtures.js'
+export type {
+  ContractFixtureComparison,
+  ContractFixtureComparisonIssue,
+  MockAuroraFixtureSet
+} from './fixtures.js'

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -13,8 +13,10 @@ import {
   buildCapabilityGraph,
   capabilityGraphCatalogFixture,
   capabilityCatalogFixture,
+  compareRegistryFixtureToBackendInventory,
   createAuditReceipt,
   createAuroraEvent,
+  defaultMockAuroraFixtures,
   describeBackendInventory,
   describeRegistry,
   gatewayBuiltinRoutesFixture,
@@ -22,7 +24,9 @@ import {
   gatewayRegistryFixture,
   hasPermission,
   permissionLabel,
+  routeExplainFixture,
   resolveEffectivePermissions,
+  uiMockReferenceFixtureSummary,
   wildcardIntersection
 } from '../src/index.js'
 
@@ -349,6 +353,55 @@ describe('AuroraClient', () => {
     expect(manifest.native.availability).toBe('unsupported')
   })
 
+  it('preloads deterministic mock fixtures for offline SDK development', async () => {
+    const client = new AuroraClient({ transport: new MockAuroraTransport() })
+
+    const [registry, services, summaries, route, nativeManifest, toolCatalog] = await Promise.all([
+      client.registry.getRegistry(),
+      client.registry.listServices(),
+      client.capabilities.listSummaries({ include_unavailable: true }),
+      client.routes.explain({ topic: 'TTS.Synthesize' }),
+      client.native.getManifest(),
+      client.tools.listCatalog<typeof defaultMockAuroraFixtures.toolCatalog>()
+    ])
+
+    expect(registry.digest).toBe('fixture')
+    expect(services.services[0]?.module).toBe('Gateway')
+    expect(summaries.map((summary) => summary.availability)).toEqual(
+      expect.arrayContaining(['available-local', 'privacy-blocked', 'stale'])
+    )
+    expect(route).toEqual(routeExplainFixture)
+    expect(nativeManifest).toEqual(
+      expect.objectContaining({
+        platform: 'tauri-desktop',
+        permissions: expect.objectContaining({ microphone: false })
+      })
+    )
+    expect(toolCatalog.tools[0]?.global_tool_id).toBe('tool:local:diagnostics.serviceHealth')
+    expect(uiMockReferenceFixtureSummary.privacyClasses).toContain('admin-critical')
+  })
+
+  it('returns cloned fixture data so tests cannot mutate shared backend truth', async () => {
+    const client = new AuroraClient({ transport: new MockAuroraTransport() })
+    const registry = await client.registry.getRegistry()
+    registry.modules[0]!.methods[0]!.required_perms.push('mutated.permission')
+
+    await expect(client.registry.getRegistry()).resolves.toEqual(
+      expect.objectContaining({
+        modules: [
+          expect.objectContaining({
+            methods: [
+              expect.objectContaining({
+                required_perms: ['Gateway.use']
+              }),
+              expect.any(Object)
+            ]
+          })
+        ]
+      })
+    )
+  })
+
   it('returns classified result errors for permissions and transport loss', async () => {
     const permissionTransport = new MockAuroraTransport().fail('Gateway.GetRegistry', 'permission', 'Forbidden')
     const permissionClient = new AuroraClient({ transport: permissionTransport })
@@ -368,6 +421,25 @@ describe('AuroraClient', () => {
 
     expect(lossResult.ok).toBe(false)
     if (!lossResult.ok) expect(lossResult.error.code).toBe('transport_loss')
+  })
+
+  it('scripts mock permission, timeout, and transport-loss failures by method', async () => {
+    const transport = new MockAuroraTransport()
+      .fail('Gateway.GetRegistry', 'permission', 'Forbidden')
+      .timeout('Gateway.GetServices')
+      .lose('Gateway.GetCapabilityCatalog', 'mock socket closed')
+    const client = new AuroraClient({ transport })
+
+    const permission = await client.requestResult('Gateway.GetRegistry')
+    const timeout = await client.requestResult('Gateway.GetServices')
+    const loss = await client.requestResult('Gateway.GetCapabilityCatalog')
+
+    expect(permission.ok).toBe(false)
+    if (!permission.ok) expect(permission.error.code).toBe('permission')
+    expect(timeout.ok).toBe(false)
+    if (!timeout.ok) expect(timeout.error.code).toBe('timeout')
+    expect(loss.ok).toBe(false)
+    if (!loss.ok) expect(loss.error.code).toBe('transport_loss')
   })
 
   it('normalizes successful results with audit and redaction metadata', async () => {
@@ -599,7 +671,7 @@ describe('AuroraClient', () => {
   })
 
   it('classifies unsupported, privacy blocked, and native permission errors', async () => {
-    const unsupportedClient = new AuroraClient({ transport: new MockAuroraTransport() })
+    const unsupportedClient = new AuroraClient({ transport: MockAuroraTransport.empty() })
     const unsupported = await unsupportedClient.result(() => unsupportedClient.registry.getRegistry())
     expect(unsupported.ok).toBe(false)
     if (!unsupported.ok) expect(unsupported.error.code).toBe('unsupported_feature')
@@ -1040,6 +1112,45 @@ describe('descriptors', () => {
         routePath: '/api/admin/peers',
         methodType: 'manage',
         requiredPermissions: ['Auth.manage']
+      })
+    ])
+  })
+
+  it('compares registry fixtures against backend inventory snapshots', () => {
+    const comparison = compareRegistryFixtureToBackendInventory(gatewayRegistryFixture, backendInventoryFixture)
+
+    expect(comparison).toEqual({
+      ok: true,
+      checked: 2,
+      issues: []
+    })
+
+    const mismatched = compareRegistryFixtureToBackendInventory(
+      {
+        ...gatewayRegistryFixture,
+        modules: [
+          {
+            ...gatewayRegistryFixture.modules[0]!,
+            methods: [
+              {
+                ...gatewayRegistryFixture.modules[0]!.methods[0]!,
+                required_perms: ['gateway.use']
+              }
+            ]
+          }
+        ],
+        method_count: 1
+      },
+      backendInventoryFixture
+    )
+
+    expect(mismatched.ok).toBe(false)
+    expect(mismatched.issues).toEqual([
+      expect.objectContaining({
+        busTopic: 'Gateway.GetRegistry',
+        field: 'requiredPermissions',
+        fixture: ['gateway.use'],
+        inventory: ['Gateway.use']
       })
     ])
   })


### PR DESCRIPTION
Summary
- Preloads MockAuroraTransport with deterministic registry, service, capability graph, route explain, native manifest, and tool catalog fixtures.
- Adds fixture clone isolation, scripted mock permission/timeout/transport-loss helpers, and registry-to-backend-inventory comparison helpers.
- Exports fixtures and test utilities, and documents HTTP, Tauri/native, mesh, native mobile, and mock usage without adding React or production UI wiring.

Validation
- pnpm --filter @aurora/client typecheck
- pnpm --filter @aurora/client test
- pnpm --filter @aurora/client build

Known gap
- python backend inventory pytest was not run locally because uv and the repo venv are absent in this worktree, and system Python lacks pytest.