### PR TITLE
SDK-010: Add mesh P2P transport interface

### DIFF
--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -153,6 +153,50 @@ Internal bus access is explicit to the Tauri command implementation. The SDK pre
 ## Mesh
 
 ```ts
+import { AuroraClient, MeshP2PTransport } from '@aurora/client'
+
+const transport = new MeshP2PTransport({
+  defaultPeerId: 'peer-123',
+  fallbackPeerIds: ['peer-456'],
+  routeResolver: async (request) => {
+    const selector = request.payload && typeof request.payload === 'object'
+      ? (request.payload as { selector?: { peer_id?: string } }).selector
+      : undefined
+    return {
+      peerId: selector?.peer_id ?? 'peer-123',
+      selector,
+      candidates: [
+        { peerId: 'peer-123', providerId: 'remote:TTS:peer-123', module: 'TTS', eligible: true },
+        { peerId: 'peer-456', providerId: 'remote:TTS:peer-456', module: 'TTS', eligible: true, fallback: true }
+      ],
+      fallbackAllowed: true
+    }
+  },
+  bridge: {
+    async call(request) {
+      // A WebRTC DataChannel, Tauri command, native mobile bridge, or test harness
+      // supplies this implementation. It must return backend/peer evidence.
+      return meshRpc.call(request.peerId, {
+        method: request.busTopic,
+        params: request.payload,
+        correlation_id: request.correlationId
+      })
+    }
+  }
+})
+
+const client = new AuroraClient({ transport })
+
+const synth = await client.requestResult('TTS.Synthesize', {
+  text: 'Hello',
+  selector: { peer_id: 'peer-123', module: 'TTS' }
+})
+
+if (synth.ok) {
+  synth.audit.targetPeerId
+  synth.audit.correlationId
+}
+
 const route = await client.routes.explain({
   topic: 'TTS.Synthesize',
   selector: { peer_id: 'peer-123', module: 'TTS' }
@@ -184,7 +228,9 @@ client.auth.updateFromPairingExchange({
 client.permissions.check(['TTS.Synthesize'], 'use').allowed
 ```
 
-Mesh UI should show selected provider peer, service instance, fallback behavior, blockers, and correlation/audit metadata when available.
+`MeshP2PTransport` is an interface over peer RPC rather than a WebRTC implementation. The bridge owns DataChannel/native details; the SDK preserves `method`, `busTopic`, selector, route candidates, fallback hints, timeout, peer IDs, correlation ID, and redaction metadata. Route resolution can come from `Gateway.ExplainRoute`, `Gateway.GetCapabilityCatalog`, a Tauri local command, or a deterministic test resolver, but UI code should still use the same `AuroraClient` calls.
+
+Mesh errors are classified into the shared SDK codes: `auth`, `permission`, `validation`, `timeout`, `unavailable_service`, `unsupported_feature`, `privacy_blocked`, `native_permission_missing`, and `transport_loss`. Mesh UI should show selected provider peer, service instance, fallback behavior, blockers, and correlation/audit metadata when available.
 
 ## Native Mobile
 

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export { AuroraClient } from './client.js'
 export { HttpGatewayTransport } from './http.js'
+export { MeshP2PTransport } from './mesh.js'
 export { MockAuroraTransport } from './mock.js'
 export { TauriLocalTransport } from './tauri.js'
 export { AuthSession } from './session.js'
@@ -67,6 +68,18 @@ export type {
 } from './permissions.js'
 export type { AuroraErrorCode, AuroraErrorOptions } from './errors.js'
 export type { HttpTransportOptions } from './http.js'
+export type {
+  MeshAddressSelector,
+  MeshP2PTransportOptions,
+  MeshPeerBridge,
+  MeshPeerId,
+  MeshPeerManifest,
+  MeshRouteCandidate,
+  MeshRouteResolution,
+  MeshRouteResolver,
+  MeshRpcRequest,
+  MeshRpcResponse
+} from './mesh.js'
 export type {
   LocalFilePickOptions,
   LocalFilePickResult,

--- a/packages/aurora-sdk/src/mesh.ts
+++ b/packages/aurora-sdk/src/mesh.ts
@@ -1,0 +1,357 @@
+import { AuroraError, readDetailCode, type AuroraErrorCode } from './errors.js'
+import type { AuroraTransport, AuroraTransportRequest, AuroraTransportResponse } from './transport.js'
+import type { AuditReceipt, AuroraTransportEnvelope, JsonObject } from './types.js'
+
+export type MeshPeerId = string
+
+export interface MeshAddressSelector {
+  peer_id?: string | null
+  peerId?: string | null
+  provider_id?: string | null
+  providerId?: string | null
+  service_instance_id?: string | null
+  serviceInstanceId?: string | null
+  module?: string | null
+  resource_id?: string | null
+  resourceId?: string | null
+  tool_id?: string | null
+  toolId?: string | null
+  [key: string]: unknown
+}
+
+export interface MeshRouteCandidate {
+  peerId: string
+  providerId?: string | null
+  serviceInstanceId?: string | null
+  module?: string | null
+  latencyMs?: number | null
+  eligible?: boolean | undefined
+  reasonCode?: string | null
+  fallback?: boolean | undefined
+}
+
+export interface MeshPeerManifest {
+  peerId: string
+  nodeName?: string | null
+  version?: string | null
+  trusted?: boolean | undefined
+  authenticated?: boolean | undefined
+  services?: Array<{
+    module: string
+    version?: string | null
+    methods?: string[]
+    capabilities?: string[]
+    providerId?: string | null
+    serviceInstanceId?: string | null
+  }>
+  raw?: unknown
+}
+
+export interface MeshRpcRequest<TPayload = unknown> {
+  peerId: string
+  method: string
+  busTopic: string
+  payload?: TPayload | undefined
+  timeoutMs: number
+  selector?: MeshAddressSelector | undefined
+  candidates: MeshRouteCandidate[]
+  correlationId?: string | undefined
+  audit?: Partial<AuditReceipt> | undefined
+}
+
+export interface MeshRpcResponse<TData = unknown> {
+  data?: TData | undefined
+  error?: unknown
+  status?: string | number | undefined
+  correlationId?: string | null | undefined
+  fallbackUsed?: boolean | undefined
+  peerId?: string | null | undefined
+  targetPeerId?: string | null | undefined
+  providerId?: string | null | undefined
+  serviceInstanceId?: string | null | undefined
+  headers?: Headers | Record<string, string> | undefined
+  audit?: Partial<AuditReceipt> | undefined
+  redactedFields?: string[] | undefined
+  secretsRedacted?: boolean | undefined
+}
+
+export interface MeshPeerBridge {
+  call<TPayload = unknown>(
+    request: MeshRpcRequest<TPayload>
+  ): Promise<MeshRpcResponse<unknown> | AuroraTransportEnvelope<unknown> | unknown>
+  getManifest?(peerId: string): Promise<MeshPeerManifest | null>
+}
+
+export interface MeshRouteResolver {
+  resolve(request: AuroraTransportRequest): Promise<MeshRouteResolution> | MeshRouteResolution
+}
+
+export interface MeshRouteResolution {
+  peerId?: string | null
+  selector?: MeshAddressSelector | null
+  candidates?: MeshRouteCandidate[]
+  fallbackAllowed?: boolean | undefined
+  unavailableReason?: string | null
+  privacyBlockedReason?: string | null
+}
+
+export interface MeshP2PTransportOptions {
+  bridge: MeshPeerBridge
+  routeResolver?: MeshRouteResolver | ((request: AuroraTransportRequest) => Promise<MeshRouteResolution> | MeshRouteResolution)
+  defaultPeerId?: string
+  defaultTimeoutMs?: number
+  fallbackPeerIds?: string[]
+}
+
+export class MeshP2PTransport implements AuroraTransport {
+  readonly kind = 'mesh'
+  private readonly bridge: MeshPeerBridge
+  private readonly routeResolver: MeshRouteResolver | undefined
+  private readonly defaultPeerId: string | undefined
+  private readonly defaultTimeoutMs: number
+  private readonly fallbackPeerIds: string[]
+
+  constructor(options: MeshP2PTransportOptions) {
+    this.bridge = options.bridge
+    this.routeResolver =
+      typeof options.routeResolver === 'function' ? { resolve: options.routeResolver } : options.routeResolver
+    this.defaultPeerId = options.defaultPeerId
+    this.defaultTimeoutMs = options.defaultTimeoutMs ?? 30_000
+    this.fallbackPeerIds = options.fallbackPeerIds ?? []
+  }
+
+  async request<TData = unknown, TPayload = unknown>(
+    request: AuroraTransportRequest<TPayload>
+  ): Promise<AuroraTransportResponse<TData>> {
+    const topic = request.busTopic ?? request.method
+    const resolution = await this.resolveRoute(request)
+    if (resolution.privacyBlockedReason) {
+      throw meshError('privacy_blocked', resolution.privacyBlockedReason, request, {
+        reason_code: 'privacy_blocked',
+        selector: resolution.selector ?? null
+      })
+    }
+    if (!resolution.peerId) {
+      throw meshError('unavailable_service', resolution.unavailableReason ?? `No mesh provider for ${topic}`, request, {
+        reason_code: resolution.unavailableReason ?? 'no_route',
+        candidates: resolution.candidates ?? []
+      })
+    }
+
+    const candidates = normalizeCandidates(resolution, this.fallbackPeerIds)
+    const callRequest: MeshRpcRequest<TPayload> = {
+      peerId: resolution.peerId,
+      method: request.method,
+      busTopic: topic,
+      payload: request.payload,
+      timeoutMs: request.timeoutMs ?? this.defaultTimeoutMs,
+      candidates
+    }
+    if (resolution.selector) callRequest.selector = resolution.selector
+    if (request.audit?.correlationId) callRequest.correlationId = request.audit.correlationId
+    if (request.audit) callRequest.audit = request.audit
+
+    try {
+      const response = await this.bridge.call<TPayload>(callRequest)
+      const envelope = toMeshEnvelope<TData>(response, request, resolution.peerId, candidates)
+      if (envelope.error !== undefined) throw meshError(classifyMeshError(envelope.error), readMeshErrorMessage(envelope.error), request, envelope.error)
+      return {
+        data: envelope.data as TData,
+        status: envelope.status,
+        headers: envelope.headers,
+        audit: {
+          ...envelope.audit,
+          method: envelope.audit?.method ?? request.method,
+          busTopic: envelope.audit?.busTopic ?? topic,
+          targetPeerId: envelope.audit?.targetPeerId ?? envelope.targetPeerId ?? resolution.peerId,
+          peerId: envelope.audit?.peerId ?? envelope.peerId ?? null,
+          transport: this.kind,
+          status: envelope.audit?.status ?? readStatus(envelope.status)
+        }
+      }
+    } catch (error) {
+      if (error instanceof AuroraError) throw error
+      throw normalizeMeshTransportError(error, request)
+    }
+  }
+
+  getManifest(peerId: string): Promise<MeshPeerManifest | null> {
+    if (!this.bridge.getManifest) {
+      throw new AuroraError({
+        code: 'unsupported_feature',
+        message: 'Mesh peer manifest lookup is not supported by this bridge.'
+      })
+    }
+    return this.bridge.getManifest(peerId)
+  }
+
+  private async resolveRoute(request: AuroraTransportRequest): Promise<MeshRouteResolution> {
+    const resolved = this.routeResolver ? await this.routeResolver.resolve(request) : {}
+    const selector = resolved.selector ?? selectorFromPayload(request.payload)
+    const peerId = resolved.peerId ?? selectorPeerId(selector) ?? this.defaultPeerId ?? null
+    const candidates = resolved.candidates ?? []
+    return {
+      ...resolved,
+      peerId,
+      selector,
+      candidates
+    }
+  }
+}
+
+interface MeshEnvelope<TData> extends AuroraTransportEnvelope<TData> {
+  error?: unknown
+  fallbackUsed?: boolean
+  peerId?: string | null
+  targetPeerId?: string | null
+}
+
+function toMeshEnvelope<TData>(
+  value: MeshRpcResponse<unknown> | AuroraTransportEnvelope<unknown> | unknown,
+  request: AuroraTransportRequest,
+  targetPeerId: string,
+  candidates: MeshRouteCandidate[]
+): MeshEnvelope<TData> {
+  if (isObject(value) && ('data' in value || 'error' in value || 'audit' in value || 'status' in value)) {
+    const response = value as unknown as MeshRpcResponse<TData> & AuroraTransportEnvelope<TData>
+    const audit: Partial<AuditReceipt> = {
+      ...response.audit,
+      correlationId: response.audit?.correlationId ?? response.correlationId ?? null,
+      method: response.audit?.method ?? request.method,
+      busTopic: response.audit?.busTopic ?? request.busTopic ?? request.method,
+      targetPeerId: response.audit?.targetPeerId ?? response.targetPeerId ?? targetPeerId,
+      peerId: response.audit?.peerId ?? response.peerId ?? null,
+      status: response.audit?.status ?? readStatus(response.status),
+      redaction: {
+        secretsRedacted: response.secretsRedacted ?? response.audit?.redaction?.secretsRedacted ?? true,
+        redactedFields: response.redactedFields ?? response.audit?.redaction?.redactedFields ?? [],
+        source: response.secretsRedacted === undefined ? response.audit?.redaction?.source ?? 'sdk' : 'backend',
+        warnings: response.audit?.redaction?.warnings ?? []
+      }
+    }
+    return {
+      data: response.data as TData,
+      error: response.error,
+      status: typeof response.status === 'number' ? response.status : undefined,
+      headers: response.headers,
+      audit,
+      fallbackUsed: response.fallbackUsed ?? candidates.some((candidate) => candidate.fallback),
+      peerId: response.peerId ?? null,
+      targetPeerId: response.targetPeerId ?? targetPeerId
+    }
+  }
+  return {
+    data: value as TData,
+    audit: {
+      method: request.method,
+      busTopic: request.busTopic ?? request.method,
+      targetPeerId,
+      transport: 'mesh'
+    }
+  }
+}
+
+function normalizeCandidates(resolution: MeshRouteResolution, fallbackPeerIds: string[]): MeshRouteCandidate[] {
+  const candidates = [...(resolution.candidates ?? [])]
+  const seen = new Set(candidates.map((candidate) => candidate.peerId))
+  if (resolution.peerId && !seen.has(resolution.peerId)) {
+    candidates.unshift({ peerId: resolution.peerId, eligible: true })
+    seen.add(resolution.peerId)
+  }
+  if (resolution.fallbackAllowed) {
+    for (const peerId of fallbackPeerIds) {
+      if (!seen.has(peerId)) candidates.push({ peerId, eligible: true, fallback: true })
+    }
+  }
+  return candidates
+}
+
+function selectorFromPayload(payload: unknown): MeshAddressSelector | null {
+  if (!isObject(payload)) return null
+  const direct = payload.selector ?? payload.mesh_selector ?? payload.meshSelector ?? payload.target_selector ?? payload.targetSelector
+  return isObject(direct) ? (direct as MeshAddressSelector) : null
+}
+
+function selectorPeerId(selector: MeshAddressSelector | null): string | null {
+  if (!selector) return null
+  const value = selector.peer_id ?? selector.peerId
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function normalizeMeshTransportError(error: unknown, request: AuroraTransportRequest): AuroraError {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return meshError('timeout', 'Mesh RPC request timed out', request, error)
+  }
+  if (error instanceof TypeError) {
+    return meshError('transport_loss', error.message, request, error)
+  }
+  if (error instanceof Error && error.name === 'TimeoutError') {
+    return meshError('timeout', error.message, request, error)
+  }
+  if (error instanceof Error) {
+    return meshError('transport_loss', error.message, request, error)
+  }
+  return meshError(classifyMeshError(error), readMeshErrorMessage(error), request, error)
+}
+
+function meshError(
+  code: AuroraErrorCode,
+  message: string,
+  request: AuroraTransportRequest,
+  detail?: unknown
+): AuroraError {
+  return new AuroraError({
+    code,
+    message,
+    method: request.method,
+    busTopic: request.busTopic ?? request.method,
+    correlationId: readString(detail, 'correlation_id', 'correlationId') ?? undefined,
+    detail
+  })
+}
+
+function classifyMeshError(error: unknown): AuroraErrorCode {
+  const code = readDetailCode(error)?.toLowerCase()
+  const text = readMeshErrorMessage(error).toLowerCase()
+  if (code?.includes('privacy') || text.includes('privacy')) return 'privacy_blocked'
+  if (code?.includes('permission') || text.includes('permission') || text.includes('forbidden')) return 'permission'
+  if (code?.includes('auth') || text.includes('auth')) return 'auth'
+  if (code?.includes('validation') || text.includes('validation')) return 'validation'
+  if (code?.includes('timeout') || text.includes('timed out') || text.includes('timeout')) return 'timeout'
+  if (code?.includes('unsupported') || text.includes('unsupported')) return 'unsupported_feature'
+  if (code?.includes('unavailable') || code?.includes('no_route') || text.includes('unavailable') || text.includes('no route')) {
+    return 'unavailable_service'
+  }
+  if (code?.includes('native_permission') || text.includes('native permission')) return 'native_permission_missing'
+  if (code?.includes('transport') || text.includes('datachannel') || text.includes('not connected')) return 'transport_loss'
+  return 'unknown'
+}
+
+function readMeshErrorMessage(error: unknown): string {
+  if (typeof error === 'string') return error
+  if (isObject(error)) {
+    const value = error.message ?? error.error ?? error.detail ?? error.reason ?? error.reason_code ?? error.code
+    if (typeof value === 'string') return value
+  }
+  if (error instanceof Error) return error.message
+  return 'Mesh RPC request failed'
+}
+
+function readStatus(status: unknown): string | null {
+  if (typeof status === 'string') return status
+  if (typeof status === 'number') return String(status)
+  return null
+}
+
+function readString(data: unknown, ...keys: string[]): string | null {
+  if (!isObject(data)) return null
+  for (const key of keys) {
+    const value = data[key]
+    if (typeof value === 'string') return value
+  }
+  return null
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -4,6 +4,7 @@ import {
   AuroraClient,
   AuroraError,
   HttpGatewayTransport,
+  MeshP2PTransport,
   MockAuroraTransport,
   TauriLocalTransport,
   backendInventoryFixture,
@@ -702,6 +703,141 @@ describe('AuroraClient', () => {
     })
     expect(native.ok).toBe(false)
     if (!native.ok) expect(native.error.code).toBe('native_permission_missing')
+  })
+
+  it('routes SDK calls through a mesh peer bridge with selector, candidates, and audit metadata', async () => {
+    const calls: unknown[] = []
+    const transport = new MeshP2PTransport({
+      defaultPeerId: 'peer-kitchen',
+      fallbackPeerIds: ['peer-office'],
+      routeResolver: (request) => ({
+        peerId: 'peer-kitchen',
+        selector: { peer_id: 'peer-kitchen', module: 'TTS', service_instance_id: 'tts-remote' },
+        candidates: [
+          {
+            peerId: 'peer-kitchen',
+            providerId: 'remote:TTS:kitchen',
+            serviceInstanceId: 'tts-remote',
+            module: 'TTS',
+            eligible: true,
+            latencyMs: 12
+          }
+        ],
+        fallbackAllowed: true
+      }),
+      bridge: {
+        async call(request) {
+          calls.push(request)
+          return {
+            data: { ok: true, provider_peer_id: request.peerId },
+            correlationId: 'corr-mesh-1',
+            targetPeerId: request.peerId,
+            status: 'success',
+            secretsRedacted: true
+          }
+        }
+      }
+    })
+    const client = new AuroraClient({ transport })
+
+    const result = await client.requestResult<{ ok: boolean }>('TTS.Synthesize', { text: 'hello' })
+
+    expect(result.ok).toBe(true)
+    expect(calls[0]).toEqual(
+      expect.objectContaining({
+        peerId: 'peer-kitchen',
+        method: 'TTS.Synthesize',
+        busTopic: 'TTS.Synthesize',
+        payload: { text: 'hello' },
+        selector: { peer_id: 'peer-kitchen', module: 'TTS', service_instance_id: 'tts-remote' },
+        candidates: expect.arrayContaining([
+          expect.objectContaining({ peerId: 'peer-kitchen', eligible: true }),
+          expect.objectContaining({ peerId: 'peer-office', fallback: true })
+        ])
+      })
+    )
+    if (result.ok) {
+      expect(result.audit).toEqual(
+        expect.objectContaining({
+          correlationId: 'corr-mesh-1',
+          method: 'TTS.Synthesize',
+          busTopic: 'TTS.Synthesize',
+          targetPeerId: 'peer-kitchen',
+          status: 'success',
+          transport: 'mesh'
+        })
+      )
+    }
+  })
+
+  it('derives mesh target peer from explicit payload selector without inventing route state', async () => {
+    const transport = new MeshP2PTransport({
+      bridge: {
+        async call(request) {
+          return { data: { peer: request.peerId }, targetPeerId: request.peerId }
+        }
+      }
+    })
+    const client = new AuroraClient({ transport })
+
+    const result = await client.requestResult<{ peer: string }>('Tooling.ExecuteTool', {
+      mesh_selector: { peer_id: 'peer-den', tool_id: 'tool:remote:lights' },
+      args: {}
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.data.peer).toBe('peer-den')
+  })
+
+  it('classifies mesh permission, validation, timeout, unavailable, privacy, unsupported, and transport-loss paths', async () => {
+    const cases = [
+      [{ error: { code: 'permission_denied', message: 'Forbidden' } }, 'permission'],
+      [{ error: { reason_code: 'validation_error', message: 'Invalid payload' } }, 'validation'],
+      [{ error: { reason_code: 'timeout', message: 'Remote timed out' } }, 'timeout'],
+      [{ error: { reason_code: 'no_route', message: 'No route to provider' } }, 'unavailable_service'],
+      [{ error: { reason_code: 'privacy_blocked', message: 'Explicit selector required' } }, 'privacy_blocked'],
+      [{ error: { code: 'unsupported_feature', message: 'Unsupported method' } }, 'unsupported_feature'],
+      [new TypeError('DataChannel closed'), 'transport_loss']
+    ] as const
+
+    for (const [bridgeResult, expected] of cases) {
+      const transport = new MeshP2PTransport({
+        defaultPeerId: 'peer-kitchen',
+        bridge: {
+          async call() {
+            if (bridgeResult instanceof Error) throw bridgeResult
+            return bridgeResult
+          }
+        }
+      })
+      const client = new AuroraClient({ transport })
+      const result = await client.requestResult('TTS.Synthesize', { text: 'hello' })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error.code).toBe(expected)
+    }
+  })
+
+  it('blocks mesh requests when route resolution reports privacy or no eligible peer', async () => {
+    const privacyClient = new AuroraClient({
+      transport: new MeshP2PTransport({
+        bridge: { async call() { return { data: {} } } },
+        routeResolver: () => ({ privacyBlockedReason: 'selector required by policy' })
+      })
+    })
+    const privacy = await privacyClient.requestResult('TTS.Synthesize', { text: 'hello' })
+    expect(privacy.ok).toBe(false)
+    if (!privacy.ok) expect(privacy.error.code).toBe('privacy_blocked')
+
+    const unavailableClient = new AuroraClient({
+      transport: new MeshP2PTransport({
+        bridge: { async call() { return { data: {} } } },
+        routeResolver: () => ({ unavailableReason: 'stale_provider', candidates: [{ peerId: 'peer-old', eligible: false }] })
+      })
+    })
+    const unavailable = await unavailableClient.requestResult('TTS.Synthesize', { text: 'hello' })
+    expect(unavailable.ok).toBe(false)
+    if (!unavailable.ok) expect(unavailable.error.code).toBe('unavailable_service')
   })
 
   it('bridges SDK requests through Tauri invoke without rewriting method identity', async () => {


### PR DESCRIPTION
## Summary
- add `MeshP2PTransport` as a transport-independent peer RPC adapter for `@aurora/client`
- preserve method identity, bus topic, selector, route candidates, fallback hints, peer IDs, audit/correlation, and redaction metadata across mesh calls
- document HTTP, Tauri local, mesh, native mobile, and mock SDK usage, including mesh bridge examples and error classes
- add unit coverage for mesh success, explicit selectors, permission/validation/timeout/unavailable/privacy/unsupported/transport-loss failures, and route-resolution blocks

## Validation
- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test` (40 tests passed, includes backend inventory fixture comparison coverage)

## Notes
- No production UI screen wiring is included.
- The existing unstaged `assets/graph.png` change was present before this work and is not part of this PR.
