### PR TITLE
SDK-011: Implement event stream abstraction

### DIFF
--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -232,6 +232,106 @@ client.permissions.check(['TTS.Synthesize'], 'use').allowed
 
 Mesh errors are classified into the shared SDK codes: `auth`, `permission`, `validation`, `timeout`, `unavailable_service`, `unsupported_feature`, `privacy_blocked`, `native_permission_missing`, and `transport_loss`. Mesh UI should show selected provider peer, service instance, fallback behavior, blockers, and correlation/audit metadata when available.
 
+## Event Streams
+
+`client.events` provides one transport-independent event contract for assistant streaming, service health, config updates, pairing/admin/audit-style streams, and future BE-003 unified events. It returns an async iterable `AuroraEvent` subscription, preserving backend IDs, topics, correlation, peer/target peer, method/bus topic, status, and redaction metadata.
+
+```ts
+const subscription = client.events.streamAssistant({ prompt: 'Summarize status' }, {
+  reconnect: { maxAttempts: 3, initialDelayMs: 250 },
+  backfill: true
+})
+
+for await (const event of subscription) {
+  if (event.kind === 'assistant.delta') renderDelta(event.payload)
+  if (event.kind === 'tool.requested') showToolApproval(event.audit.toolId, event.audit.correlationId)
+}
+```
+
+HTTP transports support SSE by default and WebSocket when requested. The live backend path is intentionally configurable until the unified backend event contract lands:
+
+```ts
+const client = new AuroraClient({
+  transport: new HttpGatewayTransport({
+    baseUrl: 'https://aurora.example',
+    bearerToken: sessionToken,
+    eventStreamPath: '/api/events'
+  })
+})
+
+const health = client.events.watchHealth({
+  protocol: 'sse',
+  reconnect: true,
+  backfill: true
+})
+
+const assistant = client.events.streamAssistant({ prompt: 'Hello' }, {
+  protocol: 'websocket',
+  path: '/api/events'
+})
+```
+
+Tauri local shells expose the same API through an IPC command that returns backend/service event evidence:
+
+```ts
+const transport = new TauriLocalTransport({
+  invoke: window.__TAURI__.core.invoke,
+  commands: { eventSubscribe: 'aurora_event_subscribe' }
+})
+const client = new AuroraClient({ transport })
+
+for await (const event of client.events.watchConfig({ backfill: true })) {
+  event.audit.transport // "tauri-local"
+  event.audit.correlationId
+}
+```
+
+Mesh subscriptions are bridge-owned. The bridge may use WebRTC DataChannels, a local Gateway, or a native command, but it must return backend/peer event evidence:
+
+```ts
+const transport = new MeshP2PTransport({
+  defaultPeerId: 'peer-123',
+  bridge: {
+    async call(request) {
+      return meshRpc.call(request.peerId, request)
+    },
+    subscribe(request) {
+      return meshEvents.subscribe(request.peerId, {
+        stream: request.stream,
+        topics: request.topics,
+        lastEventId: request.lastEventId
+      })
+    }
+  }
+})
+
+const client = new AuroraClient({ transport })
+const events = client.events.watchHealth({ reconnect: true })
+```
+
+Native mobile shells use the same transport contract through their bridge layer. Android/iOS code should expose event support through a native/Tauri-style command only after the native manifest and backend route/policy evidence support the claimed feature:
+
+```ts
+const mobileClient = new AuroraClient({ transport: nativeMobileTransport })
+const configEvents = mobileClient.events.watchConfig({ kinds: ['config.updated'] })
+```
+
+Mocks can script success, failure, permission, and transport-loss paths deterministically:
+
+```ts
+const transport = new MockAuroraTransport()
+  .stream('assistant', [
+    { id: '1', kind: 'assistant.delta', payload: { text: 'hel' }, correlation_id: 'corr-1' },
+    { id: '2', kind: 'assistant.delta', payload: { text: 'lo' }, correlation_id: 'corr-1' }
+  ])
+  .failStream('config', 'permission', 'Forbidden stream')
+
+const client = new AuroraClient({ transport })
+const stream = client.events.streamAssistant(undefined, { reconnect: true, backfill: true })
+```
+
+Reconnects carry the last delivered event ID back into the next transport subscription as `lastEventId`; `backfill` and `replayFrom` are request hints for transports/backends that support replay. The SDK does not invent event delivery, pairing success, health, config, tool execution, or audit state; it only normalizes events supplied by the selected transport.
+
 ## Native Mobile
 
 ```ts

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -8,6 +8,7 @@ import {
   type AuroraResponse,
   type AuroraTransport
 } from './transport.js'
+import { EventStreamClient, type AuroraEventSubscription, type AuroraSubscribeOptions } from './events.js'
 import { describeRegistry, GATEWAY_METHODS, TOOLING_METHODS, routePath } from './descriptors.js'
 import { buildAdminOverviewManifest, buildCapabilityGraph, summarizeCapabilities } from './capabilities.js'
 import { buildPermissionCatalog, checkAccess, hasPermission, resolveEffectivePermissions } from './permissions.js'
@@ -51,6 +52,7 @@ export class AuroraClient {
   readonly routes: RouteClient
   readonly tools: ToolClient
   readonly native: NativeClient
+  readonly events: EventStreamClient
   private readonly defaultTimeoutMs: number
 
   constructor(options: AuroraClientOptions) {
@@ -64,6 +66,7 @@ export class AuroraClient {
     this.routes = new RouteClient(this)
     this.tools = new ToolClient(this)
     this.native = new NativeClient(this)
+    this.events = new EventStreamClient(this.transport)
   }
 
   async request<TData = unknown, TPayload = unknown>(
@@ -132,6 +135,12 @@ export class AuroraClient {
 
   result<TData>(operation: () => Promise<TData>): Promise<AuroraResponse<TData>> {
     return captureResult(operation, { transport: this.transport.kind })
+  }
+
+  subscribe<TEventPayload = unknown, TPayload = unknown>(
+    options: AuroraSubscribeOptions<TPayload> = {}
+  ): AuroraEventSubscription<TEventPayload> {
+    return this.events.subscribe<TEventPayload, TPayload>(options)
   }
 }
 

--- a/packages/aurora-sdk/src/events.ts
+++ b/packages/aurora-sdk/src/events.ts
@@ -124,9 +124,20 @@ export function createEventSubscription<TPayload = unknown>(
 ): AuroraEventSubscription<TPayload> {
   let closed = false
   let resolveClosed: () => void = () => undefined
+  const activeIterators = new Set<AsyncIterator<AuroraEvent<TPayload>>>()
+  const closeWaiters: Array<() => void> = []
   const closedPromise = new Promise<void>((resolve) => {
     resolveClosed = resolve
   })
+  const settleClosed = () => {
+    if (closed) return
+    closed = true
+    resolveClosed()
+    closeWaiters.splice(0).forEach((resolve) => resolve())
+    for (const iterator of activeIterators) {
+      void iterator.return?.()
+    }
+  }
 
   return {
     get closed() {
@@ -134,20 +145,46 @@ export function createEventSubscription<TPayload = unknown>(
     },
     close(reason?: unknown) {
       if (closed) return
-      closed = true
       onClose?.(reason)
-      resolveClosed()
+      settleClosed()
     },
-    async *[Symbol.asyncIterator]() {
-      try {
-        for await (const event of source) {
-          if (closed) break
-          yield event
-        }
-      } finally {
-        if (!closed) {
-          closed = true
-          resolveClosed()
+    [Symbol.asyncIterator]() {
+      const iterator = source[Symbol.asyncIterator]()
+      activeIterators.add(iterator)
+      const nextWhenClosed = (): Promise<IteratorResult<AuroraEvent<TPayload>>> => {
+        if (closed) return Promise.resolve({ done: true, value: undefined })
+        return new Promise<IteratorResult<AuroraEvent<TPayload>>>((resolve) => {
+          closeWaiters.push(() => resolve({ done: true, value: undefined }))
+        })
+      }
+      const closeIterator = (reason?: unknown) => {
+        onClose?.(reason)
+        settleClosed()
+        activeIterators.delete(iterator)
+      }
+      return {
+        async next(): Promise<IteratorResult<AuroraEvent<TPayload>>> {
+          if (closed) return { done: true, value: undefined }
+          try {
+            const result = await Promise.race([iterator.next(), nextWhenClosed()])
+            if (closed) return { done: true, value: undefined }
+            if (result.done) {
+              closeIterator()
+              return { done: true, value: undefined }
+            }
+            return result
+          } catch (error) {
+            closeIterator(error)
+            throw error
+          }
+        },
+        async return(): Promise<IteratorResult<AuroraEvent<TPayload>>> {
+          closeIterator()
+          return { done: true, value: undefined }
+        },
+        async throw(error?: unknown): Promise<IteratorResult<AuroraEvent<TPayload>>> {
+          closeIterator(error)
+          throw error
         }
       }
     }
@@ -212,18 +249,24 @@ function subscribeWithReconnect<TEventPayload, TPayload>(
   const reconnect = normalizeReconnect(request.reconnect)
   const controller = new AbortController()
   const source = reconnect.maxAttempts === 0
-    ? singleStream<TEventPayload, TPayload>(transport, request)
+    ? singleStream<TEventPayload, TPayload>(transport, request, controller.signal)
     : reconnectingStream<TEventPayload, TPayload>(transport, request, reconnect, controller.signal)
   return createEventSubscription(source, () => controller.abort())
 }
 
 async function* singleStream<TEventPayload, TPayload>(
   transport: AuroraEventStreamTransport,
-  request: AuroraStreamRequest<TPayload>
+  request: AuroraStreamRequest<TPayload>,
+  signal: AbortSignal
 ): AsyncIterable<AuroraEvent<TEventPayload>> {
   const subscription = await transport.subscribe<TEventPayload, TPayload>(request)
+  const iterator = subscription[Symbol.asyncIterator]()
   try {
-    for await (const event of subscription) yield event
+    while (!signal.aborted) {
+      const result = await Promise.race([iterator.next(), abortIteratorResult<TEventPayload>(signal)])
+      if (result.done || signal.aborted) return
+      yield result.value
+    }
   } finally {
     subscription.close()
   }
@@ -240,8 +283,12 @@ async function* reconnectingStream<TEventPayload, TPayload>(
   while (!signal.aborted) {
     const currentRequest = { ...request, lastEventId }
     const subscription = await transport.subscribe<TEventPayload, TPayload>(currentRequest)
+    const iterator = subscription[Symbol.asyncIterator]()
     try {
-      for await (const event of subscription) {
+      while (!signal.aborted) {
+        const result = await Promise.race([iterator.next(), abortIteratorResult<TEventPayload>(signal)])
+        if (result.done || signal.aborted) return
+        const event = result.value
         attempt = 0
         lastEventId = event.id ?? lastEventId
         yield event
@@ -252,8 +299,21 @@ async function* reconnectingStream<TEventPayload, TPayload>(
       attempt += 1
       if (attempt > reconnect.maxAttempts || signal.aborted) throw normalizeError(error)
       await delay(backoff(attempt, reconnect), signal)
+    } finally {
+      subscription.close()
     }
   }
+}
+
+function abortIteratorResult<TPayload>(signal: AbortSignal): Promise<IteratorResult<AuroraEvent<TPayload>>> {
+  if (signal.aborted) return Promise.resolve({ done: true, value: undefined })
+  return new Promise<IteratorResult<AuroraEvent<TPayload>>>((resolve) => {
+    signal.addEventListener(
+      'abort',
+      () => resolve({ done: true, value: undefined }),
+      { once: true }
+    )
+  })
 }
 
 function normalizeReconnect(value: AuroraSubscribeOptions['reconnect']): NormalizedReconnectOptions {

--- a/packages/aurora-sdk/src/events.ts
+++ b/packages/aurora-sdk/src/events.ts
@@ -1,0 +1,322 @@
+import { AuroraError } from './errors.js'
+import { createAuditReceipt, createAuroraEvent, normalizeError, unsupportedTransport, type AuroraTransport } from './transport.js'
+import type { AuditReceipt, AuroraEvent, AuroraTransportKind, JsonObject } from './types.js'
+
+export type AuroraEventStreamKind = 'generic' | 'assistant' | 'health' | 'config' | string
+export type AuroraStreamProtocol = 'sse' | 'websocket' | 'ipc' | 'mesh' | 'mock' | string
+
+export interface AuroraSubscribeOptions<TPayload = unknown> {
+  stream?: AuroraEventStreamKind | undefined
+  topics?: string[] | undefined
+  kinds?: string[] | undefined
+  path?: string | undefined
+  protocol?: AuroraStreamProtocol | undefined
+  payload?: TPayload | undefined
+  headers?: Record<string, string> | undefined
+  timeoutMs?: number | undefined
+  signal?: AbortSignal | undefined
+  lastEventId?: string | null | undefined
+  replayFrom?: string | null | undefined
+  backfill?: boolean | undefined
+  reconnect?: boolean | AuroraReconnectOptions | undefined
+  audit?: Partial<AuditReceipt> | undefined
+}
+
+export interface AuroraReconnectOptions {
+  maxAttempts?: number | undefined
+  initialDelayMs?: number | undefined
+  maxDelayMs?: number | undefined
+}
+
+interface NormalizedReconnectOptions {
+  maxAttempts: number
+  initialDelayMs: number
+  maxDelayMs: number
+}
+
+export interface AuroraStreamRequest<TPayload = unknown> extends AuroraSubscribeOptions<TPayload> {
+  stream: AuroraEventStreamKind
+  topics: string[]
+  kinds: string[]
+}
+
+export interface AuroraEventSubscription<TPayload = unknown> extends AsyncIterable<AuroraEvent<TPayload>> {
+  readonly closed: Promise<void>
+  close(reason?: unknown): void
+}
+
+export interface AuroraEventStreamTransport extends AuroraTransport {
+  subscribe<TEventPayload = unknown, TPayload = unknown>(
+    request: AuroraStreamRequest<TPayload>
+  ): AuroraEventSubscription<TEventPayload> | Promise<AuroraEventSubscription<TEventPayload>>
+}
+
+export class EventStreamClient {
+  constructor(private readonly transport: AuroraTransport) {}
+
+  subscribe<TEventPayload = unknown, TPayload = unknown>(
+    options: AuroraSubscribeOptions<TPayload> = {}
+  ): AuroraEventSubscription<TEventPayload> {
+    return subscribeWithReconnect<TEventPayload, TPayload>(this.transport, normalizeStreamRequest('generic', options))
+  }
+
+  streamAssistant<TEventPayload = unknown, TPayload = unknown>(
+    payload?: TPayload,
+    options: AuroraSubscribeOptions<TPayload> = {}
+  ): AuroraEventSubscription<TEventPayload> {
+    return subscribeWithReconnect<TEventPayload, TPayload>(
+      this.transport,
+      normalizeStreamRequest('assistant', {
+        topics: ['Orchestrator.Response'],
+        kinds: ['assistant.delta', 'assistant.completed', 'assistant.failed', 'tool.requested', 'tool.completed'],
+        ...options,
+        payload: payload ?? options.payload
+      })
+    )
+  }
+
+  watchHealth<TEventPayload = unknown>(
+    options: AuroraSubscribeOptions = {}
+  ): AuroraEventSubscription<TEventPayload> {
+    return subscribeWithReconnect<TEventPayload, unknown>(
+      this.transport,
+      normalizeStreamRequest('health', {
+        topics: ['Gateway.Health', 'Service.Announcement'],
+        kinds: ['health.updated', 'service.announced', 'service.stale'],
+        ...options
+      })
+    )
+  }
+
+  watchConfig<TEventPayload = unknown>(
+    options: AuroraSubscribeOptions = {}
+  ): AuroraEventSubscription<TEventPayload> {
+    return subscribeWithReconnect<TEventPayload, unknown>(
+      this.transport,
+      normalizeStreamRequest('config', {
+        topics: ['Config.Updated'],
+        kinds: ['config.updated', 'config.reload', 'config.validation_failed'],
+        ...options
+      })
+    )
+  }
+}
+
+export function normalizeStreamRequest<TPayload = unknown>(
+  stream: AuroraEventStreamKind,
+  options: AuroraSubscribeOptions<TPayload> = {}
+): AuroraStreamRequest<TPayload> {
+  return {
+    ...options,
+    stream: options.stream ?? stream,
+    topics: options.topics ?? [],
+    kinds: options.kinds ?? []
+  }
+}
+
+export function isEventStreamTransport(transport: AuroraTransport): transport is AuroraEventStreamTransport {
+  return typeof (transport as { subscribe?: unknown }).subscribe === 'function'
+}
+
+export function createEventSubscription<TPayload = unknown>(
+  source: AsyncIterable<AuroraEvent<TPayload>>,
+  onClose?: (reason?: unknown) => void
+): AuroraEventSubscription<TPayload> {
+  let closed = false
+  let resolveClosed: () => void = () => undefined
+  const closedPromise = new Promise<void>((resolve) => {
+    resolveClosed = resolve
+  })
+
+  return {
+    get closed() {
+      return closedPromise
+    },
+    close(reason?: unknown) {
+      if (closed) return
+      closed = true
+      onClose?.(reason)
+      resolveClosed()
+    },
+    async *[Symbol.asyncIterator]() {
+      try {
+        for await (const event of source) {
+          if (closed) break
+          yield event
+        }
+      } finally {
+        if (!closed) {
+          closed = true
+          resolveClosed()
+        }
+      }
+    }
+  }
+}
+
+export function eventFromUnknown<TPayload = unknown>(
+  raw: unknown,
+  fallback: { kind: string; transport: AuroraTransportKind; audit?: Partial<AuditReceipt> | undefined }
+): AuroraEvent<TPayload> {
+  if (isAuroraEvent<TPayload>(raw)) return raw
+  const payload = readPayload(raw) as TPayload
+  const kind = readString(raw, 'kind', 'event_kind', 'eventKind', 'type') ?? fallback.kind
+  if (!isObject(raw) || !('payload' in raw || 'data' in raw)) {
+    return createAuroraEvent(kind, payload, {
+      ...fallback.audit,
+      transport: fallback.transport
+    })
+  }
+  const audit = createAuditReceipt(raw, {
+    ...fallback.audit,
+    eventKind: kind,
+    transport: fallback.transport
+  })
+  return {
+    id: readString(raw, 'id', 'event_id', 'eventId'),
+    kind,
+    topic: readString(raw, 'topic'),
+    method: audit.method,
+    busTopic: audit.busTopic,
+    payload,
+    audit,
+    redaction: audit.redaction,
+    receivedAt: new Date().toISOString()
+  }
+}
+
+export function parseSseEvent<TPayload = unknown>(
+  raw: MessageEvent<string>,
+  fallback: { kind: string; transport: AuroraTransportKind; audit?: Partial<AuditReceipt> | undefined }
+): AuroraEvent<TPayload> {
+  const parsed = safeJson(raw.data)
+  const event = eventFromUnknown<TPayload>(parsed ?? { data: raw.data }, {
+    ...fallback,
+    kind: raw.type === 'message' ? fallback.kind : raw.type
+  })
+  return {
+    ...event,
+    id: event.id ?? raw.lastEventId ?? null
+  }
+}
+
+export function eventStreamUnsupported(kind: AuroraTransportKind): AuroraError {
+  return unsupportedTransport(kind, 'Event streams', 'unsupported_feature')
+}
+
+function subscribeWithReconnect<TEventPayload, TPayload>(
+  transport: AuroraTransport,
+  request: AuroraStreamRequest<TPayload>
+): AuroraEventSubscription<TEventPayload> {
+  if (!isEventStreamTransport(transport)) throw eventStreamUnsupported(transport.kind)
+  const reconnect = normalizeReconnect(request.reconnect)
+  const controller = new AbortController()
+  const source = reconnect.maxAttempts === 0
+    ? singleStream<TEventPayload, TPayload>(transport, request)
+    : reconnectingStream<TEventPayload, TPayload>(transport, request, reconnect, controller.signal)
+  return createEventSubscription(source, () => controller.abort())
+}
+
+async function* singleStream<TEventPayload, TPayload>(
+  transport: AuroraEventStreamTransport,
+  request: AuroraStreamRequest<TPayload>
+): AsyncIterable<AuroraEvent<TEventPayload>> {
+  const subscription = await transport.subscribe<TEventPayload, TPayload>(request)
+  try {
+    for await (const event of subscription) yield event
+  } finally {
+    subscription.close()
+  }
+}
+
+async function* reconnectingStream<TEventPayload, TPayload>(
+  transport: AuroraEventStreamTransport,
+  request: AuroraStreamRequest<TPayload>,
+  reconnect: NormalizedReconnectOptions,
+  signal: AbortSignal
+): AsyncIterable<AuroraEvent<TEventPayload>> {
+  let attempt = 0
+  let lastEventId = request.lastEventId ?? null
+  while (!signal.aborted) {
+    const currentRequest = { ...request, lastEventId }
+    const subscription = await transport.subscribe<TEventPayload, TPayload>(currentRequest)
+    try {
+      for await (const event of subscription) {
+        attempt = 0
+        lastEventId = event.id ?? lastEventId
+        yield event
+      }
+      return
+    } catch (error) {
+      subscription.close(error)
+      attempt += 1
+      if (attempt > reconnect.maxAttempts || signal.aborted) throw normalizeError(error)
+      await delay(backoff(attempt, reconnect), signal)
+    }
+  }
+}
+
+function normalizeReconnect(value: AuroraSubscribeOptions['reconnect']): NormalizedReconnectOptions {
+  if (value === false || value === undefined) {
+    return { maxAttempts: 0, initialDelayMs: 0, maxDelayMs: 0 }
+  }
+  if (value === true) {
+    return { maxAttempts: 3, initialDelayMs: 250, maxDelayMs: 2_000 }
+  }
+  return {
+    maxAttempts: value.maxAttempts ?? 3,
+    initialDelayMs: value.initialDelayMs ?? 250,
+    maxDelayMs: value.maxDelayMs ?? 2_000
+  }
+}
+
+function backoff(attempt: number, reconnect: NormalizedReconnectOptions): number {
+  return Math.min(reconnect.initialDelayMs * 2 ** Math.max(0, attempt - 1), reconnect.maxDelayMs)
+}
+
+async function delay(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0) return
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(resolve, ms)
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timeout)
+        reject(new AuroraError({ code: 'timeout', message: 'Event stream subscription was closed' }))
+      },
+      { once: true }
+    )
+  })
+}
+
+function readPayload(raw: unknown): unknown {
+  if (!isObject(raw)) return raw
+  if ('payload' in raw) return raw.payload
+  if ('data' in raw) return raw.data
+  return raw
+}
+
+function readString(value: unknown, ...keys: string[]): string | null {
+  if (!isObject(value)) return null
+  for (const key of keys) {
+    const found = value[key]
+    if (typeof found === 'string') return found
+  }
+  return null
+}
+
+function safeJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return null
+  }
+}
+
+function isAuroraEvent<TPayload>(value: unknown): value is AuroraEvent<TPayload> {
+  return isObject(value) && typeof value.kind === 'string' && 'payload' in value && 'audit' in value
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/packages/aurora-sdk/src/http.ts
+++ b/packages/aurora-sdk/src/http.ts
@@ -1,6 +1,14 @@
 import { AuroraError, classifyHttpError } from './errors.js'
+import {
+  createEventSubscription,
+  eventFromUnknown,
+  parseSseEvent,
+  type AuroraEventSubscription,
+  type AuroraStreamRequest
+} from './events.js'
 import { auditFromHeaders } from './transport.js'
 import type { AuroraTransport, AuroraTransportRequest, AuroraTransportResponse } from './transport.js'
+import type { AuroraEvent } from './types.js'
 
 type HttpMethod = NonNullable<AuroraTransportRequest['httpMethod']>
 
@@ -9,7 +17,28 @@ export interface HttpTransportOptions {
   apiKey?: string
   bearerToken?: string
   fetchImpl?: typeof fetch
+  eventSourceFactory?: EventSourceFactory | undefined
+  webSocketFactory?: WebSocketFactory | undefined
+  eventStreamPath?: string | undefined
   defaultTimeoutMs?: number
+}
+
+export type EventSourceFactory = (url: string, init?: EventSourceInit) => EventSourceLike
+export type WebSocketFactory = (url: string) => WebSocketLike
+
+export interface EventSourceLike {
+  onmessage: ((event: MessageEvent<string>) => void) | null
+  onerror: ((event: Event) => void) | null
+  addEventListener?(type: string, listener: (event: MessageEvent<string>) => void): void
+  close(): void
+}
+
+export interface WebSocketLike {
+  onmessage: ((event: MessageEvent<string>) => void) | null
+  onerror: ((event: Event) => void) | null
+  onclose: ((event: CloseEvent) => void) | null
+  send?(data: string): void
+  close(): void
 }
 
 export class HttpGatewayTransport implements AuroraTransport {
@@ -18,6 +47,9 @@ export class HttpGatewayTransport implements AuroraTransport {
   private readonly fetchImpl: typeof fetch
   private readonly apiKey: string | undefined
   private readonly bearerToken: string | undefined
+  private readonly eventSourceFactory: EventSourceFactory | undefined
+  private readonly webSocketFactory: WebSocketFactory | undefined
+  private readonly eventStreamPath: string
   private readonly defaultTimeoutMs: number
 
   constructor(options: HttpTransportOptions) {
@@ -25,6 +57,9 @@ export class HttpGatewayTransport implements AuroraTransport {
     this.fetchImpl = options.fetchImpl ?? fetch
     this.apiKey = options.apiKey
     this.bearerToken = options.bearerToken
+    this.eventSourceFactory = options.eventSourceFactory ?? defaultEventSourceFactory()
+    this.webSocketFactory = options.webSocketFactory ?? defaultWebSocketFactory()
+    this.eventStreamPath = options.eventStreamPath ?? '/api/events'
     this.defaultTimeoutMs = options.defaultTimeoutMs ?? 30_000
   }
 
@@ -104,6 +139,156 @@ export class HttpGatewayTransport implements AuroraTransport {
     if (this.apiKey) headers['X-API-Key'] = this.apiKey
     if (this.bearerToken) headers.Authorization = `Bearer ${this.bearerToken}`
     return headers
+  }
+
+  subscribe<TEventPayload = unknown, TPayload = unknown>(
+    request: AuroraStreamRequest<TPayload>
+  ): AuroraEventSubscription<TEventPayload> {
+    if (request.protocol === 'websocket') return this.subscribeWebSocket<TEventPayload, TPayload>(request)
+    return this.subscribeSse<TEventPayload, TPayload>(request)
+  }
+
+  private subscribeSse<TEventPayload, TPayload>(
+    request: AuroraStreamRequest<TPayload>
+  ): AuroraEventSubscription<TEventPayload> {
+    if (!this.eventSourceFactory) {
+      throw new AuroraError({
+        code: 'unsupported_feature',
+        message: 'HTTP SSE event streams require EventSource or an eventSourceFactory.'
+      })
+    }
+    let source: EventSourceLike | null = null
+    const stream = eventQueue<TEventPayload>((push, fail, done) => {
+      const url = this.streamUrl(request)
+      source = this.eventSourceFactory!(url, { withCredentials: false })
+      source.onmessage = (event) => push(parseSseEvent<TEventPayload>(event, { kind: request.stream, transport: this.kind, audit: request.audit }))
+      source.onerror = () => fail(new AuroraError({
+        code: 'transport_loss',
+        message: `HTTP SSE stream failed for ${request.stream}`,
+        detail: { stream: request.stream, topics: request.topics }
+      }))
+      for (const kind of request.kinds) {
+        source.addEventListener?.(kind, (event) => push(parseSseEvent<TEventPayload>(event, { kind, transport: this.kind, audit: request.audit })))
+      }
+      request.signal?.addEventListener('abort', done, { once: true })
+    })
+    return createEventSubscription(stream, () => source?.close())
+  }
+
+  private subscribeWebSocket<TEventPayload, TPayload>(
+    request: AuroraStreamRequest<TPayload>
+  ): AuroraEventSubscription<TEventPayload> {
+    if (!this.webSocketFactory) {
+      throw new AuroraError({
+        code: 'unsupported_feature',
+        message: 'HTTP WebSocket event streams require WebSocket or a webSocketFactory.'
+      })
+    }
+    let socket: WebSocketLike | null = null
+    const stream = eventQueue<TEventPayload>((push, fail, done) => {
+      socket = this.webSocketFactory!(this.websocketUrl(request))
+      socket.onmessage = (event) => push(eventFromUnknown<TEventPayload>(parseSocketData(event.data), {
+        kind: request.stream,
+        transport: this.kind,
+        audit: request.audit
+      }))
+      socket.onerror = () => fail(new AuroraError({
+        code: 'transport_loss',
+        message: `HTTP WebSocket stream failed for ${request.stream}`,
+        detail: { stream: request.stream, topics: request.topics }
+      }))
+      socket.onclose = () => done()
+      socket.send?.(JSON.stringify(streamHandshake(request)))
+      request.signal?.addEventListener('abort', done, { once: true })
+    })
+    return createEventSubscription(stream, () => socket?.close())
+  }
+
+  private streamUrl(request: AuroraStreamRequest): string {
+    const url = new URL(`${this.baseUrl}${request.path ?? this.eventStreamPath}`)
+    url.searchParams.set('stream', request.stream)
+    for (const topic of request.topics) url.searchParams.append('topic', topic)
+    for (const kind of request.kinds) url.searchParams.append('kind', kind)
+    if (request.lastEventId) url.searchParams.set('last_event_id', request.lastEventId)
+    if (request.replayFrom) url.searchParams.set('replay_from', request.replayFrom)
+    if (request.backfill) url.searchParams.set('backfill', 'true')
+    return url.toString()
+  }
+
+  private websocketUrl(request: AuroraStreamRequest): string {
+    const url = new URL(this.streamUrl(request))
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+    return url.toString()
+  }
+}
+
+function defaultEventSourceFactory(): EventSourceFactory | undefined {
+  return typeof EventSource === 'undefined' ? undefined : (url, init) => new EventSource(url, init)
+}
+
+function defaultWebSocketFactory(): WebSocketFactory | undefined {
+  return typeof WebSocket === 'undefined' ? undefined : (url) => new WebSocket(url)
+}
+
+function streamHandshake(request: AuroraStreamRequest): Record<string, unknown> {
+  return {
+    stream: request.stream,
+    topics: request.topics,
+    kinds: request.kinds,
+    payload: request.payload,
+    last_event_id: request.lastEventId ?? null,
+    replay_from: request.replayFrom ?? null,
+    backfill: request.backfill ?? false
+  }
+}
+
+function parseSocketData(data: unknown): unknown {
+  if (typeof data !== 'string') return data
+  try {
+    return JSON.parse(data) as unknown
+  } catch {
+    return { data }
+  }
+}
+
+function eventQueue<TPayload>(
+  start: (
+    push: (event: AuroraEvent<TPayload>) => void,
+    fail: (error: unknown) => void,
+    done: () => void
+  ) => void
+): AsyncIterable<AuroraEvent<TPayload>> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const events: Array<AuroraEvent<TPayload>> = []
+      const waiters: Array<() => void> = []
+      let failure: unknown
+      let closed = false
+      const wake = () => waiters.splice(0).forEach((resolve) => resolve())
+      start(
+        (event) => {
+          events.push(event)
+          wake()
+        },
+        (error) => {
+          failure = error
+          closed = true
+          wake()
+        },
+        () => {
+          closed = true
+          wake()
+        }
+      )
+      while (!closed || events.length > 0) {
+        if (events.length > 0) {
+          yield events.shift()!
+          continue
+        }
+        await new Promise<void>((resolve) => waiters.push(resolve))
+      }
+      if (failure) throw failure
+    }
   }
 }
 

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -6,6 +6,15 @@ export { TauriLocalTransport } from './tauri.js'
 export { AuthSession } from './session.js'
 export { AuroraError, classifyHttpError } from './errors.js'
 export {
+  EventStreamClient,
+  createEventSubscription,
+  eventFromUnknown,
+  eventStreamUnsupported,
+  isEventStreamTransport,
+  normalizeStreamRequest,
+  parseSseEvent
+} from './events.js'
+export {
   GATEWAY_METHODS,
   TOOLING_METHODS,
   buildBackendMethodTypes,
@@ -59,6 +68,15 @@ export {
 export type * from './types.js'
 export type * from './transport.js'
 export type {
+  AuroraEventStreamKind,
+  AuroraEventStreamTransport,
+  AuroraEventSubscription,
+  AuroraReconnectOptions,
+  AuroraStreamProtocol,
+  AuroraStreamRequest,
+  AuroraSubscribeOptions
+} from './events.js'
+export type {
   EffectivePermissionInput,
   PermissionAccessDecision,
   PermissionCatalogEntry,
@@ -67,7 +85,13 @@ export type {
   PermissionRequirementSource
 } from './permissions.js'
 export type { AuroraErrorCode, AuroraErrorOptions } from './errors.js'
-export type { HttpTransportOptions } from './http.js'
+export type {
+  EventSourceFactory,
+  EventSourceLike,
+  HttpTransportOptions,
+  WebSocketFactory,
+  WebSocketLike
+} from './http.js'
 export type {
   MeshAddressSelector,
   MeshP2PTransportOptions,
@@ -78,7 +102,8 @@ export type {
   MeshRouteResolution,
   MeshRouteResolver,
   MeshRpcRequest,
-  MeshRpcResponse
+  MeshRpcResponse,
+  MeshStreamRpcRequest
 } from './mesh.js'
 export type {
   LocalFilePickOptions,

--- a/packages/aurora-sdk/src/mesh.ts
+++ b/packages/aurora-sdk/src/mesh.ts
@@ -1,6 +1,12 @@
 import { AuroraError, readDetailCode, type AuroraErrorCode } from './errors.js'
+import {
+  createEventSubscription,
+  eventFromUnknown,
+  type AuroraEventSubscription,
+  type AuroraStreamRequest
+} from './events.js'
 import type { AuroraTransport, AuroraTransportRequest, AuroraTransportResponse } from './transport.js'
-import type { AuditReceipt, AuroraTransportEnvelope, JsonObject } from './types.js'
+import type { AuditReceipt, AuroraEvent, AuroraTransportEnvelope, JsonObject } from './types.js'
 
 export type MeshPeerId = string
 
@@ -79,7 +85,16 @@ export interface MeshPeerBridge {
   call<TPayload = unknown>(
     request: MeshRpcRequest<TPayload>
   ): Promise<MeshRpcResponse<unknown> | AuroraTransportEnvelope<unknown> | unknown>
+  subscribe?<TEventPayload = unknown>(
+    request: MeshStreamRpcRequest
+  ): AsyncIterable<AuroraEvent<TEventPayload> | Record<string, unknown>> | Iterable<AuroraEvent<TEventPayload> | Record<string, unknown>>
   getManifest?(peerId: string): Promise<MeshPeerManifest | null>
+}
+
+export interface MeshStreamRpcRequest extends AuroraStreamRequest {
+  peerId: string
+  selector?: MeshAddressSelector | undefined
+  candidates: MeshRouteCandidate[]
 }
 
 export interface MeshRouteResolver {
@@ -185,6 +200,49 @@ export class MeshP2PTransport implements AuroraTransport {
     return this.bridge.getManifest(peerId)
   }
 
+  async subscribe<TEventPayload = unknown>(
+    request: AuroraStreamRequest
+  ): Promise<AuroraEventSubscription<TEventPayload>> {
+    if (!this.bridge.subscribe) {
+      throw new AuroraError({
+        code: 'unsupported_feature',
+        message: 'Mesh event subscriptions are not supported by this bridge.',
+        detail: { stream: request.stream, topics: request.topics }
+      })
+    }
+    const resolution = await this.resolveRoute({
+      method: request.stream,
+      busTopic: request.topics[0] ?? request.stream,
+      payload: request.payload,
+      timeoutMs: request.timeoutMs,
+      signal: request.signal,
+      audit: request.audit
+    })
+    if (resolution.privacyBlockedReason) {
+      throw new AuroraError({
+        code: 'privacy_blocked',
+        message: resolution.privacyBlockedReason,
+        detail: { stream: request.stream, selector: resolution.selector ?? null }
+      })
+    }
+    if (!resolution.peerId) {
+      throw new AuroraError({
+        code: 'unavailable_service',
+        message: resolution.unavailableReason ?? `No mesh provider for ${request.stream}`,
+        detail: { stream: request.stream, candidates: resolution.candidates ?? [] }
+      })
+    }
+    const candidates = normalizeCandidates(resolution, this.fallbackPeerIds)
+    const streamRequest: MeshStreamRpcRequest = {
+      ...request,
+      peerId: resolution.peerId,
+      candidates
+    }
+    if (resolution.selector) streamRequest.selector = resolution.selector
+    const source = this.bridge.subscribe<TEventPayload>(streamRequest)
+    return createEventSubscription(normalizeMeshEvents<TEventPayload>(source, request, resolution.peerId))
+  }
+
   private async resolveRoute(request: AuroraTransportRequest): Promise<MeshRouteResolution> {
     const resolved = this.routeResolver ? await this.routeResolver.resolve(request) : {}
     const selector = resolved.selector ?? selectorFromPayload(request.payload)
@@ -196,6 +254,23 @@ export class MeshP2PTransport implements AuroraTransport {
       selector,
       candidates
     }
+  }
+}
+
+async function* normalizeMeshEvents<TPayload>(
+  source: AsyncIterable<AuroraEvent<TPayload> | Record<string, unknown>> | Iterable<AuroraEvent<TPayload> | Record<string, unknown>>,
+  request: AuroraStreamRequest,
+  targetPeerId: string
+): AsyncIterable<AuroraEvent<TPayload>> {
+  for await (const raw of source) {
+    yield eventFromUnknown<TPayload>(raw, {
+      kind: request.stream,
+      transport: 'mesh',
+      audit: {
+        ...request.audit,
+        targetPeerId
+      }
+    })
   }
 }
 

--- a/packages/aurora-sdk/src/mock.ts
+++ b/packages/aurora-sdk/src/mock.ts
@@ -1,6 +1,12 @@
 import { AuroraError, type AuroraErrorCode } from './errors.js'
+import {
+  createEventSubscription,
+  eventFromUnknown,
+  type AuroraEventSubscription,
+  type AuroraStreamRequest
+} from './events.js'
 import { cloneFixture, defaultMockAuroraFixtures, type MockAuroraFixtureSet } from './fixtures.js'
-import type { AuroraTransportEnvelope } from './types.js'
+import type { AuroraEvent, AuroraTransportEnvelope } from './types.js'
 import type { AuroraTransport, AuroraTransportRequest, AuroraTransportResponse } from './transport.js'
 
 export type MockHandler<TPayload = unknown, TData = unknown> = (
@@ -10,6 +16,9 @@ export type MockRegistration<TPayload = unknown, TData = unknown> =
   | MockHandler<TPayload, TData>
   | TData
   | AuroraTransportEnvelope<TData>
+export type MockEventRegistration<TPayload = unknown> =
+  | Array<AuroraEvent<TPayload> | Record<string, unknown>>
+  | ((request: AuroraStreamRequest) => AsyncIterable<AuroraEvent<TPayload> | Record<string, unknown>> | Iterable<AuroraEvent<TPayload> | Record<string, unknown>>)
 
 export interface MockAuroraTransportOptions {
   fixtures?: MockAuroraFixtureSet | false
@@ -18,6 +27,7 @@ export interface MockAuroraTransportOptions {
 export class MockAuroraTransport implements AuroraTransport {
   readonly kind = 'mock'
   private readonly handlers = new Map<string, MockHandler>()
+  private readonly eventHandlers = new Map<string, MockEventRegistration>()
 
   constructor(options: MockAuroraTransportOptions = {}) {
     const fixtures = options.fixtures === false ? null : options.fixtures ?? defaultMockAuroraFixtures
@@ -68,6 +78,17 @@ export class MockAuroraTransport implements AuroraTransport {
     })
   }
 
+  stream<TPayload = unknown>(stream: string, registration: MockEventRegistration<TPayload>): this {
+    this.eventHandlers.set(stream, registration as MockEventRegistration)
+    return this
+  }
+
+  failStream(stream: string, code: AuroraErrorCode, message: string): this {
+    return this.stream(stream, async function* () {
+      throw new AuroraError({ code, message, detail: { stream } })
+    })
+  }
+
   async request<TData = unknown, TPayload = unknown>(
     request: AuroraTransportRequest<TPayload>
   ): Promise<AuroraTransportResponse<TData>> {
@@ -91,6 +112,39 @@ export class MockAuroraTransport implements AuroraTransport {
         transport: this.kind
       }
     }
+  }
+
+  subscribe<TEventPayload = unknown>(
+    request: AuroraStreamRequest
+  ): AuroraEventSubscription<TEventPayload> {
+    const registration = this.eventHandlers.get(request.stream) ?? this.eventHandlers.get('*')
+    if (!registration) {
+      throw new AuroraError({
+        code: 'unsupported_feature',
+        message: `No mock event stream registered for ${request.stream}`,
+        detail: { stream: request.stream, topics: request.topics }
+      })
+    }
+    const source = (typeof registration === 'function' ? registration(request) : registration) as
+      | AsyncIterable<AuroraEvent<TEventPayload> | Record<string, unknown>>
+      | Iterable<AuroraEvent<TEventPayload> | Record<string, unknown>>
+    return createEventSubscription(normalizeMockEvents<TEventPayload>(source, request))
+  }
+}
+
+async function* normalizeMockEvents<TPayload>(
+  source: AsyncIterable<AuroraEvent<TPayload> | Record<string, unknown>> | Iterable<AuroraEvent<TPayload> | Record<string, unknown>>,
+  request: AuroraStreamRequest
+): AsyncIterable<AuroraEvent<TPayload>> {
+  for await (const raw of source) {
+    const event = eventFromUnknown<TPayload>(raw, {
+      kind: request.stream,
+      transport: 'mock',
+      audit: request.audit
+    })
+    if (request.lastEventId && event.id && event.id <= request.lastEventId) continue
+    if (request.kinds.length > 0 && !request.kinds.includes(event.kind)) continue
+    yield event
   }
 }
 

--- a/packages/aurora-sdk/src/tauri.ts
+++ b/packages/aurora-sdk/src/tauri.ts
@@ -1,6 +1,12 @@
 import { AuroraError, classifyHttpError, readDetailCode, type AuroraErrorCode } from './errors.js'
+import {
+  createEventSubscription,
+  eventFromUnknown,
+  type AuroraEventSubscription,
+  type AuroraStreamRequest
+} from './events.js'
 import type { AuroraTransport, AuroraTransportRequest, AuroraTransportResponse } from './transport.js'
-import type { AuditReceipt, AuroraTransportEnvelope, JsonObject, NativeCapabilityManifest } from './types.js'
+import type { AuditReceipt, AuroraEvent, AuroraTransportEnvelope, JsonObject, NativeCapabilityManifest } from './types.js'
 
 export type TauriInvoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>
 
@@ -14,6 +20,7 @@ export interface TauriCommandNames {
   localFileRead: string
   localFileWrite: string
   localFilePick: string
+  eventSubscribe: string
 }
 
 export interface TauriLocalTransportOptions {
@@ -84,7 +91,8 @@ const DEFAULT_COMMANDS: TauriCommandNames = {
   secureStorageDelete: 'aurora_secure_storage_delete',
   localFileRead: 'aurora_local_file_read',
   localFileWrite: 'aurora_local_file_write',
-  localFilePick: 'aurora_local_file_pick'
+  localFilePick: 'aurora_local_file_pick',
+  eventSubscribe: 'aurora_event_subscribe'
 }
 
 export class TauriLocalTransport implements AuroraTransport {
@@ -158,6 +166,19 @@ export class TauriLocalTransport implements AuroraTransport {
     return this.invokeCommand<LocalFilePickResult>(this.commands.localFilePick, { options })
   }
 
+  async subscribe<TEventPayload = unknown, TPayload = unknown>(
+    request: AuroraStreamRequest<TPayload>
+  ): Promise<AuroraEventSubscription<TEventPayload>> {
+    const context: TauriInvokeContext = { method: this.commands.eventSubscribe }
+    if (request.topics[0] !== undefined) context.busTopic = request.topics[0]
+    const response = await this.invokeCommand<unknown>(
+      this.commands.eventSubscribe,
+      { [this.requestArgName]: request },
+      context
+    )
+    return createEventSubscription(normalizeTauriEvents<TEventPayload>(response, request))
+  }
+
   async invokeNative<TResponse = unknown>(
     command: string,
     args?: Record<string, unknown>
@@ -182,6 +203,36 @@ export class TauriLocalTransport implements AuroraTransport {
       })
     }
   }
+}
+
+async function* normalizeTauriEvents<TPayload>(
+  response: unknown,
+  request: AuroraStreamRequest
+): AsyncIterable<AuroraEvent<TPayload>> {
+  if (isAsyncIterable<AuroraEvent<TPayload> | Record<string, unknown>>(response)) {
+    for await (const raw of response) {
+      yield eventFromUnknown<TPayload>(raw, { kind: request.stream, transport: 'tauri-local', audit: request.audit })
+    }
+    return
+  }
+  if (isIterable<AuroraEvent<TPayload> | Record<string, unknown>>(response)) {
+    for (const raw of response) {
+      yield eventFromUnknown<TPayload>(raw, { kind: request.stream, transport: 'tauri-local', audit: request.audit })
+    }
+    return
+  }
+  throw new AuroraError({
+    code: 'unsupported_feature',
+    message: 'Tauri event subscribe command must return an iterable event stream.'
+  })
+}
+
+function isAsyncIterable<T>(value: unknown): value is AsyncIterable<T> {
+  return typeof value === 'object' && value !== null && Symbol.asyncIterator in value
+}
+
+function isIterable<T>(value: unknown): value is Iterable<T> {
+  return typeof value === 'object' && value !== null && Symbol.iterator in value
 }
 
 interface TauriInvokeContext {

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -1200,7 +1200,188 @@ describe('AuroraClient', () => {
       })
     )
   })
+
+  it('subscribes to mock event streams with filtered event envelopes', async () => {
+    const transport = new MockAuroraTransport().stream('assistant', [
+      { id: '1', kind: 'assistant.delta', payload: { text: 'hel' }, correlation_id: 'corr-assistant-1' },
+      { id: '2', kind: 'tool.completed', payload: { ok: true }, tool_id: 'tool:notes' },
+      { id: '3', kind: 'ignored', payload: {} }
+    ])
+    const client = new AuroraClient({ transport })
+
+    const events = await collectEvents(client.events.streamAssistant(undefined, { kinds: ['assistant.delta', 'tool.completed'] }), 2)
+
+    expect(events.map((event) => event.kind)).toEqual(['assistant.delta', 'tool.completed'])
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        id: '1',
+        payload: { text: 'hel' },
+        audit: expect.objectContaining({
+          correlationId: 'corr-assistant-1',
+          eventKind: 'assistant.delta',
+          transport: 'mock'
+        })
+      })
+    )
+    expect(events[1]?.audit.toolId).toBe('tool:notes')
+  })
+
+  it('reconnects streams with last event backfill hints after transport loss', async () => {
+    let attempts = 0
+    const seenLastEventIds: Array<string | null | undefined> = []
+    const transport = new MockAuroraTransport().stream('health', async function* (request) {
+      attempts += 1
+      seenLastEventIds.push(request.lastEventId)
+      if (attempts === 1) {
+        yield { id: '1', kind: 'health.updated', payload: { status: 'starting' } }
+        throw new TypeError('mock stream dropped')
+      }
+      yield { id: '2', kind: 'health.updated', payload: { status: 'healthy' } }
+    })
+    const client = new AuroraClient({ transport })
+
+    const events = await collectEvents(client.events.watchHealth({ reconnect: { maxAttempts: 1, initialDelayMs: 0 } }), 2)
+
+    expect(events.map((event) => event.id)).toEqual(['1', '2'])
+    expect(seenLastEventIds).toEqual([null, '1'])
+  })
+
+  it('classifies event stream unsupported and scripted failures', async () => {
+    const unsupported = new AuroraClient({
+      transport: {
+        kind: 'mock',
+        request: async <TData = unknown>() => ({ data: {} as TData })
+      }
+    })
+    expect(() => unsupported.subscribe()).toThrow(AuroraError)
+
+    const failing = new AuroraClient({
+      transport: new MockAuroraTransport().failStream('config', 'permission', 'Forbidden stream')
+    })
+    await expect(collectEvents(failing.events.watchConfig(), 1)).rejects.toMatchObject({ code: 'permission' })
+  })
+
+  it('adapts HTTP SSE and WebSocket events into AuroraEvent envelopes', async () => {
+    let sse: { onmessage: ((event: MessageEvent<string>) => void) | null; onerror: ((event: Event) => void) | null; close: () => void } | null = null
+    const sseTransport = new HttpGatewayTransport({
+      baseUrl: 'http://aurora.local',
+      eventSourceFactory: (url) => {
+        expect(url).toContain('/api/events?stream=health')
+        sse = { onmessage: null, onerror: null, close: () => undefined }
+        return sse
+      }
+    })
+    const sseClient = new AuroraClient({ transport: sseTransport })
+    const sseEvents = collectEvents(sseClient.events.watchHealth(), 1)
+    await Promise.resolve()
+    expect(sse).not.toBeNull()
+    const currentSse = sse!
+    currentSse.onmessage?.(
+      new MessageEvent('message', {
+        data: JSON.stringify({ id: 'health-1', kind: 'health.updated', payload: { status: 'healthy' } }),
+        lastEventId: 'health-1'
+      })
+    )
+    expect((await sseEvents)[0]).toEqual(
+      expect.objectContaining({
+        id: 'health-1',
+        kind: 'health.updated',
+        payload: { status: 'healthy' }
+      })
+    )
+
+    let sent: string | null = null
+    let socket: { onmessage: ((event: MessageEvent<string>) => void) | null; onerror: ((event: Event) => void) | null; onclose: ((event: CloseEvent) => void) | null; send: (data: string) => void; close: () => void } | null = null
+    const wsTransport = new HttpGatewayTransport({
+      baseUrl: 'https://aurora.local',
+      webSocketFactory: (url) => {
+        expect(url.startsWith('wss://aurora.local/api/events?stream=assistant')).toBe(true)
+        socket = {
+          onmessage: null,
+          onerror: null,
+          onclose: null,
+          send: (data) => { sent = data },
+          close: () => undefined
+        }
+        return socket
+      }
+    })
+    const wsClient = new AuroraClient({ transport: wsTransport })
+    const wsEvents = collectEvents(wsClient.events.streamAssistant({ prompt: 'hello' }, { protocol: 'websocket' }), 1)
+    await Promise.resolve()
+    expect(JSON.parse(sent ?? '{}')).toEqual(expect.objectContaining({ stream: 'assistant' }))
+    expect(socket).not.toBeNull()
+    const currentSocket = socket!
+    currentSocket.onmessage?.(
+      new MessageEvent('message', {
+        data: JSON.stringify({ id: 'assistant-1', kind: 'assistant.delta', payload: { text: 'hello' } })
+      })
+    )
+    expect((await wsEvents)[0]?.kind).toBe('assistant.delta')
+  })
+
+  it('adapts Tauri and mesh event streams without changing backend evidence', async () => {
+    const tauri = new TauriLocalTransport({
+      invoke: async (command, args) => {
+        expect(command).toBe('aurora_event_subscribe')
+        expect(args?.request).toEqual(expect.objectContaining({ stream: 'config' }))
+        return [{ id: 'config-1', kind: 'config.updated', payload: { key: 'ui.dark_mode' }, correlation_id: 'corr-config' }]
+      }
+    })
+    const tauriClient = new AuroraClient({ transport: tauri })
+    const tauriEvents = await collectEvents(tauriClient.events.watchConfig(), 1)
+    expect(tauriEvents[0]).toEqual(
+      expect.objectContaining({
+        id: 'config-1',
+        audit: expect.objectContaining({
+          correlationId: 'corr-config',
+          transport: 'tauri-local'
+        })
+      })
+    )
+
+    const meshTransport = new MeshP2PTransport({
+      defaultPeerId: 'peer-kitchen',
+      bridge: {
+        async call() {
+          return { data: {} }
+        },
+        subscribe(request) {
+          expect(request.peerId).toBe('peer-kitchen')
+          return [{ id: 'mesh-1', kind: 'health.updated', payload: { peer: request.peerId } }]
+        }
+      }
+    })
+    const meshClient = new AuroraClient({ transport: meshTransport })
+    const meshEvents = await collectEvents(meshClient.events.watchHealth(), 1)
+    expect(meshEvents[0]).toEqual(
+      expect.objectContaining({
+        id: 'mesh-1',
+        payload: { peer: 'peer-kitchen' },
+        audit: expect.objectContaining({
+          targetPeerId: 'peer-kitchen',
+          transport: 'mesh'
+        })
+      })
+    )
+  })
 })
+
+async function collectEvents<TPayload>(
+  subscription: AsyncIterable<TPayload> & { close?: () => void },
+  count: number
+): Promise<TPayload[]> {
+  const events: TPayload[] = []
+  try {
+    for await (const event of subscription) {
+      events.push(event)
+      if (events.length >= count) break
+    }
+    return events
+  } finally {
+    subscription.close?.()
+  }
+}
 
 describe('permissions', () => {
   it('matches backend permission semantics without lowercasing backend IDs', () => {

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -1246,6 +1246,22 @@ describe('AuroraClient', () => {
     expect(seenLastEventIds).toEqual([null, '1'])
   })
 
+  it('settles a pending event iterator when an idle wrapped stream is closed', async () => {
+    const never = async function* () {
+      await new Promise(() => undefined)
+    }
+    const client = new AuroraClient({
+      transport: new MockAuroraTransport().stream('health', never)
+    })
+    const subscription = client.events.watchHealth()
+    const iterator = subscription[Symbol.asyncIterator]()
+
+    const pending = iterator.next().then(() => 'settled', () => 'rejected')
+    setTimeout(() => subscription.close('test-close'), 10)
+
+    await expect(raceWithTimeout(pending, 100)).resolves.toBe('settled')
+  })
+
   it('classifies event stream unsupported and scripted failures', async () => {
     const unsupported = new AuroraClient({
       transport: {
@@ -1320,6 +1336,35 @@ describe('AuroraClient', () => {
     expect((await wsEvents)[0]?.kind).toBe('assistant.delta')
   })
 
+  it('settles a pending HTTP SSE iterator when the subscription is closed without another event', async () => {
+    let closed = false
+    let sourceReady: () => void = () => undefined
+    const sourceReadyPromise = new Promise<void>((resolve) => {
+      sourceReady = resolve
+    })
+    const sseTransport = new HttpGatewayTransport({
+      baseUrl: 'http://aurora.local',
+      eventSourceFactory: () => {
+        sourceReady()
+        return {
+          onmessage: null,
+          onerror: null,
+          close: () => { closed = true }
+        }
+      }
+    })
+    const client = new AuroraClient({ transport: sseTransport })
+    const subscription = client.events.watchHealth()
+    const iterator = subscription[Symbol.asyncIterator]()
+
+    const pending = iterator.next().then(() => 'settled', () => 'rejected')
+    await sourceReadyPromise
+    subscription.close('test-close')
+
+    await expect(raceWithTimeout(pending, 100)).resolves.toBe('settled')
+    expect(closed).toBe(true)
+  })
+
   it('adapts Tauri and mesh event streams without changing backend evidence', async () => {
     const tauri = new TauriLocalTransport({
       invoke: async (command, args) => {
@@ -1381,6 +1426,15 @@ async function collectEvents<TPayload>(
   } finally {
     subscription.close?.()
   }
+}
+
+async function raceWithTimeout<TValue>(promise: Promise<TValue>, ms: number): Promise<TValue | 'timeout'> {
+  return Promise.race([
+    promise,
+    new Promise<'timeout'>((resolve) => {
+      setTimeout(() => resolve('timeout'), ms)
+    })
+  ])
 }
 
 describe('permissions', () => {


### PR DESCRIPTION
## Summary

- Adds transport-independent event stream contracts to `@aurora/client`, including `client.subscribe()`, `client.events.subscribe()`, `streamAssistant()`, `watchHealth()`, and `watchConfig()`.
- Implements SDK stream adapters for HTTP SSE/WebSocket, Tauri IPC, mesh bridge subscriptions, and deterministic mock streams.
- Documents public examples for HTTP, Tauri local, mesh, native mobile-style bridge, and mock usage, including reconnect/backfill boundaries.

## Notes

- The SDK normalizes event envelopes and preserves backend evidence such as event IDs, topics, correlation IDs, peer/target peer, method/bus topic, status, and redaction metadata.
- Live backend event delivery remains backend-owned; paths are configurable until the unified BE-003 event contract lands.
- The worktree has an unrelated pre-existing `assets/graph.png` modification that is not part of this PR.

## Verification

- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test`
- `pnpm --filter @aurora/client build`
