### PR TITLE
SDK-012: Implement route privacy policy engine

### DIFF
--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -202,10 +202,28 @@ const route = await client.routes.explain({
   selector: { peer_id: 'peer-123', module: 'TTS' }
 })
 
+const policy = await client.routes.evaluatePolicy({
+  route,
+  topic: 'TTS.Synthesize',
+  selector: { peer_id: 'peer-123', module: 'TTS' },
+  payload: { text: 'Hello' },
+  consentGranted: true,
+  privacyIndicatorShown: true,
+  approvalScopes: [{
+    scope: 'session',
+    decision: 'approve',
+    peerId: 'peer-123',
+    expiresAt: new Date(Date.now() + 5 * 60_000).toISOString()
+  }]
+})
+
 const capability = await client.capabilities.explain('method:TTS.Synthesize')
 
-if (route.security_privacy_blockers.length > 0) {
+if (!policy.allowed) {
   // Show the backend reason and keep execution disabled.
+  policy.reasonCode
+  policy.repairPath
+  policy.preview.blockers
 }
 
 if (capability.selectorRequired && !capability.selectedProvider) {
@@ -231,6 +249,78 @@ client.permissions.check(['TTS.Synthesize'], 'use').allowed
 `MeshP2PTransport` is an interface over peer RPC rather than a WebRTC implementation. The bridge owns DataChannel/native details; the SDK preserves `method`, `busTopic`, selector, route candidates, fallback hints, timeout, peer IDs, correlation ID, and redaction metadata. Route resolution can come from `Gateway.ExplainRoute`, `Gateway.GetCapabilityCatalog`, a Tauri local command, or a deterministic test resolver, but UI code should still use the same `AuroraClient` calls.
 
 Mesh errors are classified into the shared SDK codes: `auth`, `permission`, `validation`, `timeout`, `unavailable_service`, `unsupported_feature`, `privacy_blocked`, `native_permission_missing`, and `transport_loss`. Mesh UI should show selected provider peer, service instance, fallback behavior, blockers, and correlation/audit metadata when available.
+
+## Route And Privacy Policy
+
+`client.routes.evaluatePolicy()` combines backend `Gateway.ExplainRoute` output with `Gateway.GetCapabilityCatalog` policy facts. It does not guess the backend route; it preserves the selected candidate, denial code, explicit selector requirement, approval state, privacy class, redacted payload preview, fallback behavior, and audit target for RouteSheet/tool approval UI.
+
+HTTP/server-web example:
+
+```ts
+const evaluation = await client.routes.evaluatePolicy({
+  routeRequest: { topic: 'Tooling.ExecuteTool' },
+  toolId: 'tool:diagnostics.serviceHealth',
+  payload: { args: { service: 'Gateway' } }
+})
+
+if (evaluation.availability === 'privacy-blocked') showPrivacyGuard(evaluation.preview)
+```
+
+Tauri local example:
+
+```ts
+const manifest = await client.native.getManifest()
+client.native.requirePermission('secureStorage', manifest)
+
+const evaluation = await client.routes.evaluatePolicy({
+  routeRequest: { topic: 'Config.Set' },
+  payload: { key: 'ui.dark_mode', value: true },
+  approvalScopes: [{ scope: 'single', decision: 'approve', expiresAt: expiresAtIso }]
+})
+```
+
+Mesh example:
+
+```ts
+const evaluation = await client.routes.evaluatePolicy({
+  routeRequest: {
+    topic: 'TTS.Synthesize',
+    selector: { peer_id: 'peer-studio-gpu', module: 'TTS' }
+  },
+  selector: { peer_id: 'peer-studio-gpu', module: 'TTS' },
+  payload: { text: userText },
+  consentGranted: true,
+  privacyIndicatorShown: true
+})
+```
+
+Native mobile example:
+
+```ts
+const mobile = new AuroraClient({ transport: nativeMobileTransport })
+const evaluation = await mobile.routes.evaluatePolicy({
+  routeRequest: { topic: 'STT.Transcribe' },
+  payload: { media_ref: 'native://recording/latest' },
+  privacyClass: 'raw-audio',
+  consentGranted: microphoneConsent,
+  privacyIndicatorShown: recordingIndicatorVisible
+})
+```
+
+Mock/test example:
+
+```ts
+import { MockAuroraTransport, defaultMockAuroraFixtures } from '@aurora/client'
+
+const mockClient = new AuroraClient({ transport: new MockAuroraTransport(defaultMockAuroraFixtures) })
+const evaluation = await mockClient.routes.evaluatePolicy({
+  route: defaultMockAuroraFixtures.routeExplain,
+  catalog: defaultMockAuroraFixtures.capabilityCatalog,
+  payload: { api_key: 'hidden in preview' }
+})
+
+evaluation.preview.payloadPreview // { api_key: '[redacted]' }
+```
 
 ## Event Streams
 

--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -201,17 +201,20 @@ const route = await client.routes.explain({
   topic: 'TTS.Synthesize',
   selector: { peer_id: 'peer-123', module: 'TTS' }
 })
+const sessionId = 'assistant-session-123'
 
 const policy = await client.routes.evaluatePolicy({
   route,
   topic: 'TTS.Synthesize',
   selector: { peer_id: 'peer-123', module: 'TTS' },
   payload: { text: 'Hello' },
+  sessionId,
   consentGranted: true,
   privacyIndicatorShown: true,
   approvalScopes: [{
     scope: 'session',
     decision: 'approve',
+    sessionId,
     peerId: 'peer-123',
     expiresAt: new Date(Date.now() + 5 * 60_000).toISOString()
   }]
@@ -272,10 +275,22 @@ Tauri local example:
 const manifest = await client.native.getManifest()
 client.native.requirePermission('secureStorage', manifest)
 
+const payload = { key: 'ui.dark_mode', value: true }
+const argsHash = 'sha256:config-set-ui-dark-mode-true'
+const route = await client.routes.explain({ topic: 'Config.Set' })
 const evaluation = await client.routes.evaluatePolicy({
-  routeRequest: { topic: 'Config.Set' },
-  payload: { key: 'ui.dark_mode', value: true },
-  approvalScopes: [{ scope: 'single', decision: 'approve', expiresAt: expiresAtIso }]
+  route,
+  topic: 'Config.Set',
+  payload,
+  argsHash,
+  approvalScopes: [{
+    scope: 'single',
+    decision: 'approve',
+    approvalId: 'approval-config-set-1',
+    argsHash,
+    providerId: route.selected_provider_id ?? 'local:Config',
+    expiresAt: expiresAtIso
+  }]
 })
 ```
 

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -12,6 +12,7 @@ import { EventStreamClient, type AuroraEventSubscription, type AuroraSubscribeOp
 import { describeRegistry, GATEWAY_METHODS, TOOLING_METHODS, routePath } from './descriptors.js'
 import { buildAdminOverviewManifest, buildCapabilityGraph, summarizeCapabilities } from './capabilities.js'
 import { buildPermissionCatalog, checkAccess, hasPermission, resolveEffectivePermissions } from './permissions.js'
+import { evaluateRoutePolicy } from './policy.js'
 import type {
   AdminOverviewManifest,
   AdminOverviewManifestInput,
@@ -28,7 +29,9 @@ import type {
   PeerSummary,
   ContractMethodType,
   RouteExplainRequest,
-  RouteExplainResponse
+  RouteExplainResponse,
+  RoutePolicyEvaluation,
+  RoutePolicyInput
 } from './types.js'
 import type {
   EffectivePermissionInput,
@@ -238,6 +241,25 @@ export class RouteClient {
       request,
       { path: routePath('Gateway', 'ExplainRoute') }
     )
+  }
+
+  async evaluatePolicy(input: Omit<RoutePolicyInput, 'route' | 'catalog' | 'transportKind'> & {
+    route?: RouteExplainResponse
+    catalog?: RoutePolicyInput['catalog']
+    routeRequest?: RouteExplainRequest
+  }): Promise<RoutePolicyEvaluation> {
+    const fallbackRouteRequest: RouteExplainRequest = {}
+    if (input.topic !== undefined) fallbackRouteRequest.topic = input.topic
+    if (input.method !== undefined) fallbackRouteRequest.method = input.method
+    if (input.selector !== undefined) fallbackRouteRequest.selector = input.selector
+    const route = input.route ?? await this.explain(input.routeRequest ?? fallbackRouteRequest)
+    const catalog = input.catalog ?? await this.client.capabilities.listCatalog({ include_unavailable: true })
+    return evaluateRoutePolicy({
+      ...input,
+      route,
+      catalog,
+      transportKind: this.client.transport.kind
+    })
   }
 }
 

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -35,6 +35,11 @@ export {
   summarizeCapabilities
 } from './capabilities.js'
 export {
+  buildRoutePreview,
+  classifyPayloadPrivacy,
+  evaluateRoutePolicy
+} from './policy.js'
+export {
   PERMISSION_ALL,
   buildPermissionCatalog,
   buildPermissionCatalogFromBackendInventory,

--- a/packages/aurora-sdk/src/policy.ts
+++ b/packages/aurora-sdk/src/policy.ts
@@ -211,28 +211,95 @@ function evaluateApproval(
 ): RoutePolicyEvaluation['approval'] {
   if (!policy?.approval_required) return { required: false, status: 'not-required', scopes: [] }
   const now = Date.parse(input.now ?? new Date().toISOString())
-  const matchingScope = input.approvalScopes?.find((scope) => scopeMatches(scope, input, action, now)) ?? null
+  const scopes = input.approvalScopes ?? []
+  const matchingScope = scopes.find((scope) => scopeMatches(scope, input, action, now)) ?? null
   if (!matchingScope) {
-    return { required: true, status: 'required', scopes: input.approvalScopes ?? [] }
+    const hasExpiredScope = scopes.some((scope) => scope.decision === 'approve' && isExpired(scope, now))
+    return { required: true, status: hasExpiredScope ? 'expired' : 'required', scopes }
   }
   if (matchingScope.decision === 'deny' || matchingScope.decision === 'deny-all') {
-    return { required: true, status: 'rejected', scopes: input.approvalScopes ?? [], matchedScope: matchingScope }
+    return { required: true, status: 'rejected', scopes, matchedScope: matchingScope }
   }
-  return { required: true, status: 'approved', scopes: input.approvalScopes ?? [], matchedScope: matchingScope }
+  return { required: true, status: 'approved', scopes, matchedScope: matchingScope }
 }
 
 function scopeMatches(scope: ApprovalScope, input: RoutePolicyInput, action: CapabilityActionInfo | null, now: number): boolean {
-  if (scope.expiresAt && Date.parse(scope.expiresAt) <= now) return false
+  if (isExpired(scope, now)) return false
   if (scope.decision === 'deny-all') return true
   if (scope.decision !== 'approve') return false
+  if (!scope.scope) return false
   const peerId = input.route.selected_peer_id ?? action?.peer_id ?? null
   const providerId = input.route.selected_provider_id ?? action?.provider_id ?? null
-  if (scope.peerId && scope.peerId !== peerId) return false
-  if (scope.providerId && scope.providerId !== providerId) return false
-  if (scope.toolId && scope.toolId !== (input.toolId ?? action?.tool_id ?? null)) return false
-  if (scope.resourceId && scope.resourceId !== (input.resourceId ?? action?.resource_id ?? null)) return false
-  if (scope.argsHash && scope.argsHash !== input.argsHash) return false
+  const toolId = input.toolId ?? action?.tool_id ?? null
+  const resourceId = input.resourceId ?? action?.resource_id ?? null
+
+  switch (scope.scope) {
+    case 'single':
+      return Boolean(
+        scope.approvalId &&
+        scope.argsHash &&
+        input.argsHash &&
+        scope.argsHash === input.argsHash &&
+        targetMatches(scope, peerId, providerId) &&
+        actionIdentityMatches(scope, toolId, resourceId)
+      )
+    case 'tool-args':
+      return Boolean(
+        scope.toolId &&
+        toolId &&
+        scope.toolId === toolId &&
+        scope.argsHash &&
+        input.argsHash &&
+        scope.argsHash === input.argsHash &&
+        targetMatches(scope, peerId, providerId)
+      )
+    case 'peer-provider':
+      return Boolean(scope.peerId && scope.providerId && scope.peerId === peerId && scope.providerId === providerId)
+    case 'session':
+      return Boolean(
+        scope.sessionId &&
+        input.sessionId &&
+        scope.sessionId === input.sessionId &&
+        targetMatches(scope, peerId, providerId)
+      )
+    case 'local-safe-tools':
+      return localSafeToolScopeMatches(scope, input, action, toolId, providerId)
+    default:
+      return false
+  }
+}
+
+function isExpired(scope: ApprovalScope, now: number): boolean {
+  return Boolean(scope.expiresAt && Date.parse(scope.expiresAt) <= now)
+}
+
+function targetMatches(scope: ApprovalScope, peerId: string | null, providerId: string | null): boolean {
+  const peerMatches = Boolean(scope.peerId && peerId && scope.peerId === peerId)
+  const providerMatches = Boolean(scope.providerId && providerId && scope.providerId === providerId)
+  return peerMatches || providerMatches
+}
+
+function actionIdentityMatches(scope: ApprovalScope, toolId: string | null, resourceId: string | null): boolean {
+  if (scope.toolId) return Boolean(toolId && scope.toolId === toolId)
+  if (scope.resourceId) return Boolean(resourceId && scope.resourceId === resourceId)
   return true
+}
+
+function localSafeToolScopeMatches(
+  scope: ApprovalScope,
+  input: RoutePolicyInput,
+  action: CapabilityActionInfo | null,
+  toolId: string | null,
+  providerId: string | null
+): boolean {
+  if (!action || !toolId) return false
+  if (scope.toolId && scope.toolId !== toolId) return false
+  if (scope.providerId && scope.providerId !== providerId) return false
+  if (scope.sessionId && scope.sessionId !== input.sessionId) return false
+  const localTarget = input.route.selected_target === 'local' || action.provider_kind === 'local'
+  const safeClass = action.policy.safety_class === 'standard' && action.policy.operation_class !== 'admin'
+  const lowPrivacy = !HIGH_PRIVACY_CLASSES.includes(classifyPayloadPrivacy(input.payload, action.policy, action))
+  return localTarget && safeClass && lowPrivacy
 }
 
 function availabilityForPolicy(

--- a/packages/aurora-sdk/src/policy.ts
+++ b/packages/aurora-sdk/src/policy.ts
@@ -1,0 +1,395 @@
+import { privacyClassForAction } from './capabilities.js'
+import type {
+  ApprovalScope,
+  AvailabilityState,
+  CapabilityActionInfo,
+  CapabilityCatalogResponse,
+  CapabilityPolicyDecisionInfo,
+  PrivacyClass,
+  RouteBlockerInfo,
+  RouteCandidateDecision,
+  RouteExplainResponse,
+  RoutePolicyEvaluation,
+  RoutePolicyInput,
+  RoutePreview
+} from './types.js'
+
+const HIGH_PRIVACY_CLASSES: PrivacyClass[] = ['sensitive', 'secret', 'raw-audio', 'credential', 'admin-critical']
+const DEFAULT_SECRET_KEYS = [
+  'api_key',
+  'apikey',
+  'authorization',
+  'confirmation_token',
+  'credential',
+  'password',
+  'secret',
+  'token'
+]
+
+export function evaluateRoutePolicy(input: RoutePolicyInput): RoutePolicyEvaluation {
+  const catalogAction = findCatalogAction(input)
+  const policy = catalogAction?.policy
+  const provider = findSelectedCandidate(input.route)
+  const privacyClass = input.privacyClass ?? classifyPayloadPrivacy(input.payload, policy, catalogAction)
+  const dataClasses = unique([privacyClass, ...(input.dataClasses ?? [])])
+  const securityBlockers = [
+    ...input.route.security_privacy_blockers,
+    ...input.route.blockers.filter((blocker) => blocker.security_privacy)
+  ]
+  const policyBlockers = collectPolicyBlockers(input, policy, catalogAction, privacyClass)
+  const blockers = uniqueBlockers([
+    ...input.route.blockers,
+    ...securityBlockers,
+    ...policyBlockers
+  ])
+  const selectedTarget = input.route.selected_target || (provider ? provider.provider_kind : 'none')
+  const fallbackBlocked = isFallbackBlocked(input.route, input.allowCloudFallback ?? false)
+  const missingSelector = !input.route.selector_valid || blockers.some((blocker) => isSelectorBlocker(blocker.code))
+  const explicitSelectorRequired = Boolean(policy?.explicit_selector_required || policy?.selector_required || missingSelector)
+  const approval = evaluateApproval(input, policy, catalogAction)
+  const allowed =
+    blockers.length === 0 &&
+    input.route.selector_valid &&
+    !fallbackBlocked &&
+    approval.status !== 'required' &&
+    approval.status !== 'expired' &&
+    approval.status !== 'rejected'
+  const decision = allowed
+    ? 'allowed'
+    : blockers.some((blocker) => blocker.security_privacy) || HIGH_PRIVACY_CLASSES.includes(privacyClass) || fallbackBlocked
+      ? 'privacy-blocked'
+      : 'blocked'
+
+  return {
+    decision,
+    allowed,
+    availability: availabilityForPolicy(decision, input.route, catalogAction),
+    reasonCode: reasonCodeFor(decision, input.route, blockers, approval.status),
+    repairPath: repairPathFor({ blockers, approvalStatus: approval.status, explicitSelectorRequired, fallbackBlocked }),
+    privacyClass,
+    dataClasses,
+    explicitSelectorRequired,
+    approval,
+    route: input.route,
+    selectedCandidate: provider,
+    blockers,
+    preview: buildRoutePreview(input, {
+      provider,
+      privacyClass,
+      dataClasses,
+      blockers,
+      selectedTarget,
+      catalogAction
+    })
+  }
+}
+
+export function classifyPayloadPrivacy(
+  payload: unknown,
+  policy: CapabilityPolicyDecisionInfo | null | undefined = null,
+  action: CapabilityActionInfo | null | undefined = null
+): PrivacyClass {
+  if (policy?.resource_scope === 'credential') return 'credential'
+  if (policy?.resource_scope === 'raw-audio') return 'raw-audio'
+  if (policy?.operation_class === 'admin' || policy?.safety_class === 'admin') return 'admin-critical'
+  if (policy?.safety_class === 'secret') return 'secret'
+  if (policy?.safety_class === 'sensitive' || policy?.consent_required || policy?.privacy_indicator_required) {
+    return 'sensitive'
+  }
+  if (action) return privacyClassForAction(action)
+  if (containsSecretLikeKey(payload)) return 'secret'
+  if (containsPersonalPayload(payload)) return 'personal'
+  return 'public'
+}
+
+export function buildRoutePreview(
+  input: RoutePolicyInput,
+  context: {
+    provider: RouteCandidateDecision | null
+    privacyClass: PrivacyClass
+    dataClasses: PrivacyClass[]
+    blockers: RouteBlockerInfo[]
+    selectedTarget: string
+    catalogAction: CapabilityActionInfo | null
+  }
+): RoutePreview {
+  const action = context.catalogAction
+  const selector = readSelector(input.route, input.selector)
+  return {
+    topic: input.route.topic,
+    module: input.route.module,
+    method: input.method ?? action?.method ?? null,
+    providerId: input.route.selected_provider_id ?? context.provider?.provider_id ?? action?.provider_id ?? null,
+    peerId: input.route.selected_peer_id ?? context.provider?.peer_id ?? action?.peer_id ?? null,
+    serviceInstanceId:
+      input.route.selected_service_instance_id ?? context.provider?.service_instance_id ?? action?.service_instance_id ?? null,
+    providerKind: context.provider?.provider_kind ?? action?.provider_kind ?? context.selectedTarget,
+    trustTier: action?.policy.trust_tier ?? 'unknown',
+    transport: input.transportKind ?? null,
+    fallbackBehavior: input.route.fallback_behavior,
+    egressDestination: egressDestinationFor(context.selectedTarget, context.provider, action),
+    expectedPersistence: expectedPersistenceFor(action?.policy),
+    auditReceiptTarget: input.auditReceiptTarget ?? auditTargetFor(context.provider, action),
+    dataClasses: context.dataClasses,
+    privacyClass: context.privacyClass,
+    selector,
+    payloadPreview: redactPayload(input.payload),
+    secretsRedacted: input.route.secrets_redacted,
+    blockers: context.blockers.map((blocker) => ({
+      code: blocker.code,
+      message: blocker.message,
+      securityPrivacy: blocker.security_privacy
+    }))
+  }
+}
+
+function findCatalogAction(input: RoutePolicyInput): CapabilityActionInfo | null {
+  if (!input.catalog) return null
+  const topic = input.route.topic || input.topic
+  const actionId = input.actionId
+  const toolId = input.toolId
+  const resourceId = input.resourceId
+  return (
+    input.catalog.actions.find((action) => actionId && action.action_id === actionId) ??
+    input.catalog.actions.find((action) => toolId && action.tool_id === toolId) ??
+    input.catalog.actions.find((action) => resourceId && action.resource_id === resourceId) ??
+    input.catalog.actions.find((action) => action.topic === topic && matchesSelectedProvider(action, input.route)) ??
+    input.catalog.actions.find((action) => action.topic === topic) ??
+    null
+  )
+}
+
+function matchesSelectedProvider(action: CapabilityActionInfo, route: RouteExplainResponse): boolean {
+  if (route.selected_provider_id) return action.provider_id === route.selected_provider_id
+  if (route.selected_peer_id) return action.peer_id === route.selected_peer_id
+  return true
+}
+
+function findSelectedCandidate(route: RouteExplainResponse): RouteCandidateDecision | null {
+  return (
+    route.candidates.find((candidate) => candidate.selected) ??
+    route.candidates.find((candidate) => candidate.provider_id === route.selected_provider_id) ??
+    route.candidates.find((candidate) => candidate.included) ??
+    null
+  )
+}
+
+function collectPolicyBlockers(
+  input: RoutePolicyInput,
+  policy: CapabilityPolicyDecisionInfo | null | undefined,
+  action: CapabilityActionInfo | null,
+  privacyClass: PrivacyClass
+): RouteBlockerInfo[] {
+  const providerId = input.route.selected_provider_id ?? action?.provider_id ?? null
+  const peerId = input.route.selected_peer_id ?? action?.peer_id ?? null
+  const blockers: RouteBlockerInfo[] = []
+  for (const reason of policy?.denial_reasons ?? []) {
+    blockers.push(blocker(reason, `Policy denied this route: ${reason}.`, providerId, peerId, true))
+  }
+  if (policy?.local_only && isRemoteTarget(input.route, action)) {
+    blockers.push(blocker('local_only', 'Policy allows this capability only on the local node.', providerId, peerId, true))
+  }
+  if ((policy?.explicit_selector_required || policy?.selector_required) && !hasSelector(input)) {
+    blockers.push(blocker('explicit_selector_required', 'Select the target peer/resource before execution.', providerId, peerId, true))
+  }
+  if (policy?.consent_required && !input.consentGranted) {
+    blockers.push(blocker('consent_required', 'Consent is required before this payload can leave the local node.', providerId, peerId, true))
+  }
+  if (policy?.privacy_indicator_required && !input.privacyIndicatorShown) {
+    blockers.push(blocker('privacy_indicator_required', 'Show the privacy indicator before execution.', providerId, peerId, true))
+  }
+  if (HIGH_PRIVACY_CLASSES.includes(privacyClass) && isCloudTarget(input.route) && !input.allowCloudFallback) {
+    blockers.push(blocker('cloud_fallback_blocked', 'Cloud fallback is blocked for this privacy class.', providerId, peerId, true))
+  }
+  return blockers
+}
+
+function evaluateApproval(
+  input: RoutePolicyInput,
+  policy: CapabilityPolicyDecisionInfo | null | undefined,
+  action: CapabilityActionInfo | null
+): RoutePolicyEvaluation['approval'] {
+  if (!policy?.approval_required) return { required: false, status: 'not-required', scopes: [] }
+  const now = Date.parse(input.now ?? new Date().toISOString())
+  const matchingScope = input.approvalScopes?.find((scope) => scopeMatches(scope, input, action, now)) ?? null
+  if (!matchingScope) {
+    return { required: true, status: 'required', scopes: input.approvalScopes ?? [] }
+  }
+  if (matchingScope.decision === 'deny' || matchingScope.decision === 'deny-all') {
+    return { required: true, status: 'rejected', scopes: input.approvalScopes ?? [], matchedScope: matchingScope }
+  }
+  return { required: true, status: 'approved', scopes: input.approvalScopes ?? [], matchedScope: matchingScope }
+}
+
+function scopeMatches(scope: ApprovalScope, input: RoutePolicyInput, action: CapabilityActionInfo | null, now: number): boolean {
+  if (scope.expiresAt && Date.parse(scope.expiresAt) <= now) return false
+  if (scope.decision === 'deny-all') return true
+  if (scope.decision !== 'approve') return false
+  const peerId = input.route.selected_peer_id ?? action?.peer_id ?? null
+  const providerId = input.route.selected_provider_id ?? action?.provider_id ?? null
+  if (scope.peerId && scope.peerId !== peerId) return false
+  if (scope.providerId && scope.providerId !== providerId) return false
+  if (scope.toolId && scope.toolId !== (input.toolId ?? action?.tool_id ?? null)) return false
+  if (scope.resourceId && scope.resourceId !== (input.resourceId ?? action?.resource_id ?? null)) return false
+  if (scope.argsHash && scope.argsHash !== input.argsHash) return false
+  return true
+}
+
+function availabilityForPolicy(
+  decision: RoutePolicyEvaluation['decision'],
+  route: RouteExplainResponse,
+  action: CapabilityActionInfo | null
+): AvailabilityState {
+  if (decision === 'privacy-blocked') return 'privacy-blocked'
+  if (decision === 'blocked') return 'denied'
+  if (route.fallback_behavior === 'fallback-used') return 'degraded'
+  if (action?.freshness.stale) return 'stale'
+  if ((route.selected_target || action?.provider_kind) === 'local') return 'available-local'
+  return 'available-remote'
+}
+
+function reasonCodeFor(
+  decision: RoutePolicyEvaluation['decision'],
+  route: RouteExplainResponse,
+  blockers: RouteBlockerInfo[],
+  approvalStatus: RoutePolicyEvaluation['approval']['status']
+): string {
+  if (approvalStatus === 'required' || approvalStatus === 'expired') return 'approval_required'
+  if (approvalStatus === 'rejected') return 'approval_denied'
+  if (blockers[0]?.code) return blockers[0].code
+  if (!route.selector_valid) return route.selector_validation_code || 'selector_invalid'
+  return decision
+}
+
+function repairPathFor(input: {
+  blockers: RouteBlockerInfo[]
+  approvalStatus: RoutePolicyEvaluation['approval']['status']
+  explicitSelectorRequired: boolean
+  fallbackBlocked: boolean
+}): string | null {
+  if (input.approvalStatus === 'required' || input.approvalStatus === 'expired') return 'request user approval'
+  if (input.approvalStatus === 'rejected') return 'choose a different approval scope or target'
+  if (input.explicitSelectorRequired) return 'choose an explicit peer/provider/resource selector'
+  if (input.fallbackBlocked) return 'choose an eligible non-cloud provider'
+  const first = input.blockers[0]
+  if (!first) return null
+  if (first.security_privacy) return 'satisfy the route privacy policy before execution'
+  return first.message || first.code
+}
+
+function isFallbackBlocked(route: RouteExplainResponse, allowCloudFallback: boolean): boolean {
+  return !allowCloudFallback && ['cloud', 'cloud-fallback', 'fallback-cloud'].includes(route.fallback_behavior)
+}
+
+function isRemoteTarget(route: RouteExplainResponse, action: CapabilityActionInfo | null): boolean {
+  const target = route.selected_target || action?.provider_kind
+  return Boolean(target && !['local', 'none'].includes(target))
+}
+
+function isCloudTarget(route: RouteExplainResponse): boolean {
+  return route.selected_target === 'cloud' || route.fallback_behavior.includes('cloud')
+}
+
+function hasSelector(input: RoutePolicyInput): boolean {
+  return Boolean(input.selector ?? input.route.selected_peer_id ?? input.route.selected_provider_id ?? readSelector(input.route, null))
+}
+
+function readSelector(route: RouteExplainResponse, explicit: unknown): unknown {
+  if (explicit !== undefined) return explicit
+  return route.selected_peer_id || route.selected_provider_id
+    ? {
+        peer_id: route.selected_peer_id,
+        provider_id: route.selected_provider_id,
+        service_instance_id: route.selected_service_instance_id
+      }
+    : null
+}
+
+function blocker(
+  code: string,
+  message: string,
+  providerId: string | null,
+  peerId: string | null,
+  securityPrivacy: boolean
+): RouteBlockerInfo {
+  return {
+    code,
+    message,
+    severity: 'error',
+    provider_id: providerId,
+    peer_id: peerId,
+    security_privacy: securityPrivacy
+  }
+}
+
+function uniqueBlockers(blockers: RouteBlockerInfo[]): RouteBlockerInfo[] {
+  const seen = new Set<string>()
+  return blockers.filter((blocker) => {
+    const key = `${blocker.code}:${blocker.provider_id ?? ''}:${blocker.peer_id ?? ''}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function unique<T extends string>(items: T[]): T[] {
+  return [...new Set(items)]
+}
+
+function isSelectorBlocker(code: string): boolean {
+  return code.includes('selector') || code.includes('target')
+}
+
+function egressDestinationFor(
+  selectedTarget: string,
+  provider: RouteCandidateDecision | null,
+  action: CapabilityActionInfo | null
+): RoutePreview['egressDestination'] {
+  if (selectedTarget === 'local' || action?.provider_kind === 'local') return 'local'
+  if (selectedTarget.includes('cloud') || action?.provider_kind === 'cloud') return 'cloud'
+  if (provider?.peer_id || action?.peer_id) return 'peer'
+  return 'none'
+}
+
+function expectedPersistenceFor(policy: CapabilityPolicyDecisionInfo | undefined): string {
+  if (policy?.operation_class === 'audio') return 'transient unless backend retention policy says otherwise'
+  if (policy?.operation_class === 'admin') return 'audit log'
+  if (policy?.resource_scope === 'credential') return 'secure storage or audit reference only'
+  return 'backend-defined'
+}
+
+function auditTargetFor(provider: RouteCandidateDecision | null, action: CapabilityActionInfo | null): string | null {
+  return provider?.provider_id ?? action?.provider_id ?? null
+}
+
+function redactPayload(payload: unknown): unknown {
+  if (payload === null || payload === undefined) return null
+  if (Array.isArray(payload)) return payload.map(redactPayload)
+  if (typeof payload !== 'object') return payload
+  return Object.fromEntries(
+    Object.entries(payload as Record<string, unknown>).map(([key, value]) => [
+      key,
+      isSecretKey(key) ? '[redacted]' : redactPayload(value)
+    ])
+  )
+}
+
+function containsSecretLikeKey(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsSecretLikeKey)
+  if (typeof value !== 'object' || value === null) return false
+  return Object.entries(value as Record<string, unknown>).some(([key, nested]) => isSecretKey(key) || containsSecretLikeKey(nested))
+}
+
+function containsPersonalPayload(value: unknown): boolean {
+  if (typeof value === 'string') return value.length > 80
+  if (Array.isArray(value)) return value.some(containsPersonalPayload)
+  if (typeof value !== 'object' || value === null) return false
+  return Object.keys(value as Record<string, unknown>).some((key) =>
+    ['text', 'prompt', 'message', 'query', 'document', 'device_name'].includes(key.toLowerCase())
+  )
+}
+
+function isSecretKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[-\s]/g, '_')
+  return DEFAULT_SECRET_KEYS.some((secretKey) => normalized.includes(secretKey))
+}

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -712,6 +712,7 @@ export interface RoutePolicyInput {
   actionId?: string | null
   toolId?: string | null
   resourceId?: string | null
+  sessionId?: string | null
   argsHash?: string | null
   dataClasses?: PrivacyClass[]
   privacyClass?: PrivacyClass

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -689,6 +689,88 @@ export interface RouteExplainResponse {
   secrets_redacted: boolean
 }
 
+export interface ApprovalScope {
+  scope: 'single' | 'tool-args' | 'peer-provider' | 'session' | 'local-safe-tools' | 'deny-all' | string
+  decision: 'approve' | 'deny' | 'deny-all'
+  approvalId?: string | null
+  peerId?: string | null
+  providerId?: string | null
+  toolId?: string | null
+  resourceId?: string | null
+  argsHash?: string | null
+  sessionId?: string | null
+  expiresAt?: string | null
+}
+
+export interface RoutePolicyInput {
+  route: RouteExplainResponse
+  catalog?: CapabilityCatalogResponse | null
+  payload?: unknown
+  selector?: unknown
+  topic?: string | null
+  method?: string | null
+  actionId?: string | null
+  toolId?: string | null
+  resourceId?: string | null
+  argsHash?: string | null
+  dataClasses?: PrivacyClass[]
+  privacyClass?: PrivacyClass
+  approvalScopes?: ApprovalScope[]
+  consentGranted?: boolean
+  privacyIndicatorShown?: boolean
+  allowCloudFallback?: boolean
+  auditReceiptTarget?: string | null
+  transportKind?: AuroraTransportKind | null
+  now?: string
+}
+
+export interface RoutePreview {
+  topic: string
+  module: string
+  method: string | null
+  providerId: string | null
+  peerId: string | null
+  serviceInstanceId: string | null
+  providerKind: string
+  trustTier: string
+  transport: AuroraTransportKind | null
+  fallbackBehavior: string
+  egressDestination: 'local' | 'peer' | 'cloud' | 'none'
+  expectedPersistence: string
+  auditReceiptTarget: string | null
+  dataClasses: PrivacyClass[]
+  privacyClass: PrivacyClass
+  selector: unknown
+  payloadPreview: unknown
+  secretsRedacted: boolean
+  blockers: Array<{
+    code: string
+    message: string
+    securityPrivacy: boolean
+  }>
+}
+
+export interface RoutePolicyEvaluation {
+  decision: 'allowed' | 'blocked' | 'privacy-blocked'
+  allowed: boolean
+  availability: AvailabilityState
+  reasonCode: string
+  repairPath: string | null
+  privacyClass: PrivacyClass
+  dataClasses: PrivacyClass[]
+  explicitSelectorRequired: boolean
+  approval: {
+    required: boolean
+    status: 'not-required' | 'required' | 'approved' | 'expired' | 'rejected'
+    scopes: ApprovalScope[]
+    matchedScope?: ApprovalScope
+  }
+  route: RouteExplainResponse
+  selectedCandidate: RouteCandidateDecision | null
+  blockers: RouteBlockerInfo[]
+  preview: RoutePreview
+}
+
 export interface AuditReference {
   correlationId: string | null
   eventKind: string | null

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -504,6 +504,76 @@ describe('AuroraClient', () => {
         actionId: 'tool-local-notes',
         toolId: 'tool:notes',
         argsHash: 'args-local-1',
+        approvalScopes: [{ scope: 'single', decision: 'approve' }],
+        now: '2026-06-20T10:00:00Z'
+      })
+    ).resolves.toEqual(expect.objectContaining({ allowed: false, reasonCode: 'approval_required' }))
+
+    await expect(
+      client.routes.evaluatePolicy({
+        route,
+        catalog,
+        actionId: 'tool-local-notes',
+        toolId: 'tool:notes',
+        argsHash: 'args-local-1',
+        approvalScopes: [
+          {
+            scope: 'future-approve-all',
+            decision: 'approve',
+            providerId: 'local:TTS',
+            argsHash: 'args-local-1'
+          }
+        ],
+        now: '2026-06-20T10:00:00Z'
+      })
+    ).resolves.toEqual(expect.objectContaining({ allowed: false, reasonCode: 'approval_required' }))
+
+    await expect(
+      client.routes.evaluatePolicy({
+        route,
+        catalog,
+        actionId: 'tool-local-notes',
+        toolId: 'tool:notes',
+        argsHash: 'args-local-1',
+        approvalScopes: [
+          {
+            scope: 'tool-args',
+            decision: 'approve',
+            toolId: 'tool:notes',
+            providerId: 'local:TTS',
+            argsHash: 'different'
+          }
+        ],
+        now: '2026-06-20T10:00:00Z'
+      })
+    ).resolves.toEqual(expect.objectContaining({ allowed: false, reasonCode: 'approval_required' }))
+
+    await expect(
+      client.routes.evaluatePolicy({
+        route,
+        catalog,
+        actionId: 'tool-local-notes',
+        toolId: 'tool:notes',
+        argsHash: 'args-local-1',
+        approvalScopes: [
+          {
+            scope: 'local-safe-tools',
+            decision: 'approve',
+            toolId: 'tool:notes',
+            providerId: 'local:TTS'
+          }
+        ],
+        now: '2026-06-20T10:00:00Z'
+      })
+    ).resolves.toEqual(expect.objectContaining({ allowed: false, reasonCode: 'approval_required' }))
+
+    await expect(
+      client.routes.evaluatePolicy({
+        route,
+        catalog,
+        actionId: 'tool-local-notes',
+        toolId: 'tool:notes',
+        argsHash: 'args-local-1',
         payload: { token: 'must-not-render', operation: 'delete notes' },
         approvalScopes: [
           {
@@ -530,7 +600,7 @@ describe('AuroraClient', () => {
     )
   })
 
-  it('rejects expired, denied, and mismatched remote approval scopes', () => {
+  it('requires scoped session, provider, and args evidence for remote approvals', () => {
     const remoteAllowedRoute = {
       ...routeExplainFixture,
       selected_target: 'remote',
@@ -574,9 +644,17 @@ describe('AuroraClient', () => {
       catalog,
       actionId: 'tts-remote-privacy-blocked',
       argsHash: 'args-remote-1',
+      sessionId: 'session-remote-1',
       selector: { peer_id: 'peer-studio-gpu', module: 'TTS' },
       now: '2026-06-20T10:00:00Z'
     }
+
+    expect(
+      evaluateRoutePolicy({
+        ...base,
+        approvalScopes: [{ scope: 'session', decision: 'approve' }]
+      })
+    ).toEqual(expect.objectContaining({ allowed: false, reasonCode: 'approval_required' }))
 
     expect(
       evaluateRoutePolicy({
@@ -585,13 +663,90 @@ describe('AuroraClient', () => {
           {
             scope: 'session',
             decision: 'approve',
+            sessionId: 'session-remote-1',
+            providerId: 'mesh:studio-gpu:TTS',
+            expiresAt: '2026-06-20T10:05:00Z'
+          }
+        ]
+      })
+    ).toEqual(
+      expect.objectContaining({
+        allowed: true,
+        approval: expect.objectContaining({ status: 'approved' })
+      })
+    )
+
+    expect(
+      evaluateRoutePolicy({
+        ...base,
+        approvalScopes: [
+          {
+            scope: 'session',
+            decision: 'approve',
+            sessionId: 'other-session',
+            providerId: 'mesh:studio-gpu:TTS',
+            expiresAt: '2026-06-20T10:05:00Z'
+          }
+        ]
+      })
+    ).toEqual(expect.objectContaining({ allowed: false, reasonCode: 'approval_required' }))
+
+    expect(
+      evaluateRoutePolicy({
+        ...base,
+        approvalScopes: [
+          {
+            scope: 'peer-provider',
+            decision: 'approve',
+            peerId: 'peer-studio-gpu',
+            providerId: 'mesh:studio-gpu:TTS',
+            expiresAt: '2026-06-20T10:05:00Z'
+          }
+        ]
+      })
+    ).toEqual(
+      expect.objectContaining({
+        allowed: true,
+        approval: expect.objectContaining({ status: 'approved' })
+      })
+    )
+
+    expect(
+      evaluateRoutePolicy({
+        ...base,
+        approvalScopes: [
+          {
+            scope: 'peer-provider',
+            decision: 'approve',
+            peerId: 'other-peer',
+            providerId: 'mesh:studio-gpu:TTS',
+            expiresAt: '2026-06-20T10:05:00Z'
+          }
+        ]
+      })
+    ).toEqual(expect.objectContaining({ allowed: false, reasonCode: 'approval_required' }))
+
+    expect(
+      evaluateRoutePolicy({
+        ...base,
+        approvalScopes: [
+          {
+            scope: 'session',
+            decision: 'approve',
+            sessionId: 'session-remote-1',
             peerId: 'peer-studio-gpu',
             providerId: 'mesh:studio-gpu:TTS',
             expiresAt: '2026-06-20T09:59:00Z'
           }
         ]
       })
-    ).toEqual(expect.objectContaining({ allowed: false, reasonCode: 'approval_required' }))
+    ).toEqual(
+      expect.objectContaining({
+        allowed: false,
+        reasonCode: 'approval_required',
+        approval: expect.objectContaining({ status: 'expired' })
+      })
+    )
 
     expect(
       evaluateRoutePolicy({
@@ -613,6 +768,7 @@ describe('AuroraClient', () => {
           {
             scope: 'tool-args',
             decision: 'approve',
+            toolId: 'tool:remote-danger',
             peerId: 'other-peer',
             providerId: 'mesh:studio-gpu:TTS',
             argsHash: 'different'

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -21,6 +21,7 @@ import {
   defaultMockAuroraFixtures,
   describeBackendInventory,
   describeRegistry,
+  evaluateRoutePolicy,
   gatewayBuiltinRoutesFixture,
   gatewayServicesFixture,
   gatewayRegistryFixture,
@@ -382,6 +383,243 @@ describe('AuroraClient', () => {
     )
     expect(toolCatalog.tools[0]?.global_tool_id).toBe('tool:local:diagnostics.serviceHealth')
     expect(uiMockReferenceFixtureSummary.privacyClasses).toContain('admin-critical')
+  })
+
+  it('evaluates route policy denials without downgrading privacy blockers to unavailable', () => {
+    const evaluation = evaluateRoutePolicy({
+      route: routeExplainFixture,
+      catalog: capabilityCatalogFixture,
+      payload: { text: 'Remote speech synthesis should be reviewed before egress.' },
+      privacyIndicatorShown: false,
+      consentGranted: false,
+      transportKind: 'mock'
+    })
+
+    expect(evaluation).toEqual(
+      expect.objectContaining({
+        allowed: false,
+        decision: 'privacy-blocked',
+        availability: 'privacy-blocked',
+        reasonCode: 'explicit_selector_required',
+        explicitSelectorRequired: true,
+        repairPath: 'choose an explicit peer/provider/resource selector',
+        privacyClass: 'raw-audio'
+      })
+    )
+    expect(evaluation.preview).toEqual(
+      expect.objectContaining({
+        egressDestination: 'peer',
+        providerId: 'mesh:studio-gpu:TTS',
+        peerId: 'peer-studio-gpu',
+        secretsRedacted: true,
+        dataClasses: expect.arrayContaining(['raw-audio'])
+      })
+    )
+    expect(evaluation.blockers.map((blocker) => blocker.code)).toEqual(
+      expect.arrayContaining(['explicit_selector_required', 'privacy_indicator_required'])
+    )
+  })
+
+  it('requires approval for local dangerous tools and accepts matching approval scopes', async () => {
+    const route = {
+      topic: 'Tooling.ExecuteTool',
+      module: 'Tooling',
+      selected_target: 'local',
+      selected_peer_id: 'local-peer',
+      selected_service_instance_id: 'tooling-local',
+      selected_provider_id: 'local:TTS',
+      selector_valid: true,
+      selector_validation_code: '',
+      selector_validation_message: '',
+      fallback_behavior: '',
+      candidates: [
+        {
+          provider_id: 'local:TTS',
+          peer_id: 'local-peer',
+          provider_kind: 'local',
+          service_instance_id: 'tooling-local',
+          module: 'Tooling',
+          version: '0.1.0',
+          included: true,
+          selected: true,
+          reason_code: 'eligible',
+          reason: 'Local dangerous tool is available after approval.',
+          latency_ms: 1,
+          active_calls: 0,
+          max_concurrent: 2,
+          available_capacity: 2,
+          blockers: []
+        }
+      ],
+      blockers: [],
+      security_privacy_blockers: [],
+      secrets_redacted: true
+    }
+    const catalog = {
+      ...capabilityGraphCatalogFixture,
+      actions: capabilityGraphCatalogFixture.actions.map((action) =>
+        action.action_id === 'tool-local-notes'
+          ? {
+              ...action,
+              policy: {
+                ...action.policy,
+                approval_required: true,
+                operation_class: 'admin',
+                safety_class: 'admin'
+              }
+            }
+          : action
+      )
+    }
+    const transport = new MockAuroraTransport()
+      .register('Gateway.ExplainRoute', route)
+      .register('Gateway.GetCapabilityCatalog', catalog)
+    const client = new AuroraClient({ transport })
+
+    await expect(
+      client.routes.evaluatePolicy({
+        routeRequest: { topic: 'Tooling.ExecuteTool' },
+        actionId: 'tool-local-notes',
+        toolId: 'tool:notes',
+        argsHash: 'args-local-1',
+        payload: { token: 'must-not-render', operation: 'delete notes' },
+        now: '2026-06-20T10:00:00Z'
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        allowed: false,
+        decision: 'privacy-blocked',
+        reasonCode: 'approval_required',
+        approval: expect.objectContaining({ required: true, status: 'required' }),
+        preview: expect.objectContaining({
+          payloadPreview: expect.objectContaining({ token: '[redacted]' })
+        })
+      })
+    )
+
+    await expect(
+      client.routes.evaluatePolicy({
+        route,
+        catalog,
+        actionId: 'tool-local-notes',
+        toolId: 'tool:notes',
+        argsHash: 'args-local-1',
+        payload: { token: 'must-not-render', operation: 'delete notes' },
+        approvalScopes: [
+          {
+            scope: 'tool-args',
+            decision: 'approve',
+            approvalId: 'approval-local-1',
+            toolId: 'tool:notes',
+            providerId: 'local:TTS',
+            argsHash: 'args-local-1',
+            expiresAt: '2026-06-20T10:05:00Z'
+          }
+        ],
+        now: '2026-06-20T10:00:00Z'
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        allowed: true,
+        decision: 'allowed',
+        approval: expect.objectContaining({
+          status: 'approved',
+          matchedScope: expect.objectContaining({ approvalId: 'approval-local-1' })
+        })
+      })
+    )
+  })
+
+  it('rejects expired, denied, and mismatched remote approval scopes', () => {
+    const remoteAllowedRoute = {
+      ...routeExplainFixture,
+      selected_target: 'remote',
+      selected_peer_id: 'peer-studio-gpu',
+      selected_provider_id: 'mesh:studio-gpu:TTS',
+      selected_service_instance_id: 'tts-remote-01',
+      selector_valid: true,
+      selector_validation_code: '',
+      selector_validation_message: '',
+      blockers: [],
+      security_privacy_blockers: [],
+      candidates: routeExplainFixture.candidates.map((candidate) => ({
+        ...candidate,
+        selected: true,
+        included: true,
+        blockers: []
+      }))
+    }
+    const catalog = {
+      ...capabilityCatalogFixture,
+      actions: capabilityCatalogFixture.actions.map((action) =>
+        action.action_id === 'tts-remote-privacy-blocked'
+          ? {
+              ...action,
+              bindability: 'available',
+              route_blockers: [],
+              policy: {
+                ...action.policy,
+                approval_required: true,
+                explicit_selector_required: false,
+                selector_required: false,
+                consent_required: false,
+                privacy_indicator_required: false
+              }
+            }
+          : action
+      )
+    }
+    const base = {
+      route: remoteAllowedRoute,
+      catalog,
+      actionId: 'tts-remote-privacy-blocked',
+      argsHash: 'args-remote-1',
+      selector: { peer_id: 'peer-studio-gpu', module: 'TTS' },
+      now: '2026-06-20T10:00:00Z'
+    }
+
+    expect(
+      evaluateRoutePolicy({
+        ...base,
+        approvalScopes: [
+          {
+            scope: 'session',
+            decision: 'approve',
+            peerId: 'peer-studio-gpu',
+            providerId: 'mesh:studio-gpu:TTS',
+            expiresAt: '2026-06-20T09:59:00Z'
+          }
+        ]
+      })
+    ).toEqual(expect.objectContaining({ allowed: false, reasonCode: 'approval_required' }))
+
+    expect(
+      evaluateRoutePolicy({
+        ...base,
+        approvalScopes: [{ scope: 'deny-all', decision: 'deny-all' }]
+      })
+    ).toEqual(
+      expect.objectContaining({
+        allowed: false,
+        reasonCode: 'approval_denied',
+        approval: expect.objectContaining({ status: 'rejected' })
+      })
+    )
+
+    expect(
+      evaluateRoutePolicy({
+        ...base,
+        approvalScopes: [
+          {
+            scope: 'tool-args',
+            decision: 'approve',
+            peerId: 'other-peer',
+            providerId: 'mesh:studio-gpu:TTS',
+            argsHash: 'different'
+          }
+        ]
+      })
+    ).toEqual(expect.objectContaining({ allowed: false, reasonCode: 'approval_required' }))
   })
 
   it('returns cloned fixture data so tests cannot mutate shared backend truth', async () => {


### PR DESCRIPTION
## Summary

- Adds a transport-independent route/privacy policy engine to `@aurora/client`.
- Wires `client.routes.evaluatePolicy()` over backend `Gateway.ExplainRoute` plus `Gateway.GetCapabilityCatalog` evidence.
- Produces redacted route previews with provider, peer, trust tier, data classes, egress, persistence, blockers, selector, and audit target.
- Documents HTTP, Tauri local, mesh, native mobile, and mock examples.

## Validation

- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test`
- `pnpm --filter @aurora/client build`

The SDK test suite includes backend inventory fixture comparison coverage and new route/privacy tests for selector denial preservation, local dangerous-tool approval, remote dangerous-tool approval scopes, approve/deny behavior, expired/mismatched approval rejection, and redacted previews.

## Notes

- `assets/graph.png` was already modified in the working tree and is intentionally not part of this PR.
- `packages/aurora-sdk/dist/` is ignored; build was used as validation only.
