### PR TITLE
SDK-013: Implement AdminAction client controller

### DIFF
--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -508,6 +508,125 @@ const transport = new MockAuroraTransport()
 
 The mock fixtures are test/development data only. Production UI code should call `AuroraClient` namespaces and treat Gateway/native responses as the truth source.
 
+## AdminAction And Tool Approval Controllers
+
+`client.admin` wraps the backend-enforced AdminAction draft/confirm/submit flow for admin-critical mutations. The SDK displays and returns backend-issued `action_id`, `nonce`, `digest`, expiry, required phrase, affected resources, confirmation token, and audit receipt; it does not compute or synthesize confirmation tokens.
+
+HTTP/server-web example:
+
+```ts
+const payload = { key: 'services.gateway.enabled', value: true }
+const draft = await client.admin.draft({
+  method_id: 'Config.Set',
+  payload,
+  affected_resources: ['key:services.gateway.enabled']
+})
+
+showAdminConfirmDialog({
+  method: draft.method_id,
+  digest: draft.digest,
+  affectedResources: draft.affected_resources,
+  expiresAt: draft.expires_at,
+  requiredPhrase: draft.required_phrase
+})
+
+const confirmation = await client.admin.confirm(draft, {
+  reason: 'Enable Gateway for local admin',
+  reauthConfirmed: recentAdminUnlock,
+  phrase: 'CONFIRM'
+})
+
+await client.admin.submit({
+  methodId: 'Config.Set',
+  payload,
+  confirmation
+})
+```
+
+Tauri local example:
+
+```ts
+const client = new AuroraClient({ transport: new TauriLocalTransport({ invoke }) })
+const result = await client.admin.execute({
+  methodId: 'Config.Rollback',
+  payload: { version_id: selectedVersionId },
+  reason: 'Rollback after failed plugin update',
+  reauthConfirmed: await nativeAdminUnlock()
+})
+
+result.confirmation.audit_receipt
+```
+
+Tauri/native bridges must forward AdminAction headers through their backend request command. They must not bypass Gateway enforcement with direct Python service calls.
+
+Mesh example:
+
+```ts
+const approval = await client.approvals.request({
+  global_tool_id: 'tool:remote-danger',
+  provider_peer_id: 'peer-kitchen',
+  provider_service_instance_id: 'tooling-remote',
+  args_hash: argsHash,
+  redacted_args_preview: { target: 'garage', api_key: '[redacted]' },
+  risk_class: 'admin-critical',
+  requested_approval_scope: 'tool-args',
+  expected_audit_event: 'tooling.approval.approved',
+  args: { target: 'garage' }
+})
+
+const token = await client.approvals.approve({
+  approval_request_id: approval.approval_request_id!,
+  approver_principal_id: client.auth.snapshot().principalId ?? 'operator',
+  reason: 'Operator approved one garage diagnostic run'
+})
+
+await client.requestResult('Tooling.ExecuteTool', {
+  global_tool_id: 'tool:remote-danger',
+  approval_token: token.approvalToken,
+  args: { target: 'garage' }
+})
+```
+
+Tool approvals are intentionally separate from AdminAction. A dangerous/admin tool can compose both: first get a backend-issued tool approval token through `client.approvals`, then wrap the final `Tooling.ExecuteTool` mutation in `client.admin.submit()` when backend policy marks the execution admin-critical.
+
+Native mobile example:
+
+```ts
+const mobileClient = new AuroraClient({ transport: nativeMobileTransport })
+const manifest = await mobileClient.native.getManifest()
+mobileClient.native.requirePermission('secureStorage', manifest)
+
+const draft = await mobileClient.admin.draft({
+  method_id: 'Auth.DeleteDevice',
+  payload: { device_id: lostDeviceId }
+})
+const confirmation = await mobileClient.admin.confirm(draft, {
+  reason: 'Revoke lost phone',
+  reauthConfirmed: await biometricAdminUnlock()
+})
+```
+
+Mock/test example:
+
+```ts
+const transport = new MockAuroraTransport({ fixtures: false })
+  .register('Gateway.AdminActionDraft', draftFixture)
+  .register('Gateway.AdminActionConfirm', confirmationFixture)
+  .register('Config.Set', { success: true })
+
+const client = new AuroraClient({ transport })
+const result = await client.result(() =>
+  client.admin.execute({
+    methodId: 'Config.Set',
+    payload: { key: 'ui.dark_mode', value: true },
+    reason: 'Test admin flow',
+    reauthConfirmed: true
+  })
+)
+```
+
+AdminAction and approval failures normalize into the shared SDK error codes: `auth`, `permission`, `validation`, `timeout`, `unavailable_service`, `unsupported_feature`, `privacy_blocked`, `native_permission_missing`, and `transport_loss`. Replay, changed args/provider, expired approval, and downgraded-risk responses become typed `AuroraError` failures instead of successful data objects.
+
 ## Capability Graph
 
 `client.capabilities.getGraph()` merges backend capability catalog actions, registry-only method exposure, native manifests, provider freshness, routeability, policy flags, and privacy/permission requirements into deterministic feature nodes. It preserves provider identity instead of collapsing local and remote providers:

--- a/packages/aurora-sdk/src/admin.ts
+++ b/packages/aurora-sdk/src/admin.ts
@@ -1,0 +1,350 @@
+import { AuroraError, type AuroraErrorCode } from './errors.js'
+import { GATEWAY_METHODS, TOOLING_METHODS, routePath } from './descriptors.js'
+import type { AuroraResponse, AuroraTransport } from './transport.js'
+import type { AuditReceipt, JsonObject, JsonValue } from './types.js'
+
+export interface AdminActionHeaderNames {
+  action_id: string
+  confirmation_token: string
+  digest: string
+}
+
+export interface AdminActionDraftRequest {
+  method_id: string
+  payload?: JsonObject
+  affected_resources?: string[]
+}
+
+export interface AdminActionDraftResponse {
+  action_id: string
+  nonce: string
+  digest: string
+  method_id: string
+  affected_resources: string[]
+  required_phrase: string
+  required_reason: boolean
+  required_reauth: boolean
+  expires_at: string
+  expires_in_seconds: number
+  confirmation_headers: AdminActionHeaderNames
+}
+
+export interface AdminActionConfirmRequest {
+  action_id: string
+  nonce: string
+  digest: string
+  reason: string
+  reauth_confirmed: boolean
+  phrase?: string
+}
+
+export interface AdminActionConfirmResponse {
+  action_id: string
+  confirmation_token: string
+  digest: string
+  confirmed: boolean
+  expires_at: string
+  audit_receipt: string
+  confirmation_headers: AdminActionHeaderNames
+}
+
+export interface AdminActionSubmitOptions {
+  methodId: string
+  payload?: JsonObject
+  confirmation: AdminActionConfirmResponse
+  path?: string
+  httpMethod?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+  timeoutMs?: number
+  extraHeaders?: Record<string, string>
+}
+
+export interface ToolApprovalRequest {
+  global_tool_id?: string
+  local_name?: string
+  provider_peer_id?: string | null
+  provider_service_instance_id?: string | null
+  mesh_selector?: JsonObject | null
+  resource_selector?: JsonObject | null
+  args?: JsonObject
+  args_hash?: string | null
+  args_preview?: JsonObject | null
+  redacted_args_preview?: JsonObject | null
+  risk_class?: string | null
+  requested_approval_scope?: string | null
+  expected_audit_event?: string | null
+  requested_by_principal_id?: string | null
+  caller_principal_id?: string | null
+  dry_run?: boolean
+  [key: string]: JsonValue | undefined
+}
+
+export interface ToolApprovalPolicyDecision {
+  decision_id?: string | null
+  allowed?: boolean
+  approval_required?: boolean
+  approval_mode?: string
+  token_ttl_seconds?: number
+  reason?: string | null
+  risk_class?: string | null
+  safety_class?: string | null
+  [key: string]: JsonValue | undefined
+}
+
+export interface ToolApprovalRequestResponse {
+  ok: boolean
+  approval_request_id: string | null
+  policy_decision: ToolApprovalPolicyDecision
+  expires_at: number | null
+  correlation_id: string
+  error: string | null
+}
+
+export interface ToolApprovalConfirmRequest {
+  approval_request_id: string
+  approver_principal_id: string
+  approve?: boolean
+  reason?: string | null
+  correlation_id?: string | null
+}
+
+export interface ToolApprovalConfirmResponse {
+  ok: boolean
+  approval_token: string | null
+  expires_at: number | null
+  policy_decision_id: string | null
+  correlation_id: string | null
+  error: string | null
+}
+
+export interface ApprovalTokenScope {
+  approvalRequestId: string
+  approvalToken: string
+  expiresAt: number | null
+  policyDecisionId: string | null
+  correlationId: string | null
+}
+
+export interface AdminActionControllerClient {
+  request<TData = unknown, TPayload = unknown>(
+    method: string,
+    payload?: TPayload,
+    options?: {
+      path?: string
+      busTopic?: string
+      httpMethod?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+      timeoutMs?: number
+      headers?: Record<string, string>
+    }
+  ): Promise<TData>
+  requestResult<TData = unknown, TPayload = unknown>(
+    method: string,
+    payload?: TPayload,
+    options?: {
+      path?: string
+      busTopic?: string
+      httpMethod?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+      timeoutMs?: number
+      headers?: Record<string, string>
+    }
+  ): Promise<AuroraResponse<TData>>
+  readonly transport: AuroraTransport
+}
+
+export class AdminActionClient {
+  constructor(private readonly client: AdminActionControllerClient) {}
+
+  draft(request: AdminActionDraftRequest): Promise<AdminActionDraftResponse> {
+    return this.client.request<AdminActionDraftResponse, AdminActionDraftRequest>(
+      GATEWAY_METHODS.adminActionDraft,
+      request,
+      { path: routePath('Gateway', 'AdminActionDraft') }
+    )
+  }
+
+  confirm(
+    draft: AdminActionDraftResponse,
+    input: { reason: string; reauthConfirmed: boolean; phrase?: string }
+  ): Promise<AdminActionConfirmResponse> {
+    const request: AdminActionConfirmRequest = {
+      action_id: draft.action_id,
+      nonce: draft.nonce,
+      digest: draft.digest,
+      reason: input.reason,
+      reauth_confirmed: input.reauthConfirmed,
+      phrase: input.phrase ?? draft.required_phrase
+    }
+    return this.client.request<AdminActionConfirmResponse, AdminActionConfirmRequest>(
+      GATEWAY_METHODS.adminActionConfirm,
+      request,
+      { path: routePath('Gateway', 'AdminActionConfirm') }
+    )
+  }
+
+  headers(confirmation: AdminActionConfirmResponse): Record<string, string> {
+    return {
+      [confirmation.confirmation_headers.action_id]: confirmation.action_id,
+      [confirmation.confirmation_headers.confirmation_token]: confirmation.confirmation_token,
+      [confirmation.confirmation_headers.digest]: confirmation.digest
+    }
+  }
+
+  async submit<TData = unknown>(options: AdminActionSubmitOptions): Promise<TData> {
+    const requestOptions: Parameters<AdminActionControllerClient['request']>[2] = {
+      path: options.path ?? pathFromMethodId(options.methodId),
+      httpMethod: options.httpMethod ?? 'POST',
+      headers: {
+        ...this.headers(options.confirmation),
+        ...options.extraHeaders
+      }
+    }
+    if (options.timeoutMs !== undefined) requestOptions.timeoutMs = options.timeoutMs
+    return this.client.request<TData, JsonObject>(
+      options.methodId,
+      options.payload ?? {},
+      requestOptions
+    )
+  }
+
+  async execute<TData = unknown>(input: {
+    methodId: string
+    payload?: JsonObject
+    reason: string
+    reauthConfirmed: boolean
+    phrase?: string
+    affectedResources?: string[]
+    path?: string
+    timeoutMs?: number
+  }): Promise<{ draft: AdminActionDraftResponse; confirmation: AdminActionConfirmResponse; data: TData }> {
+    const draftRequest: AdminActionDraftRequest = {
+      method_id: input.methodId,
+      payload: input.payload ?? {}
+    }
+    if (input.affectedResources !== undefined) draftRequest.affected_resources = input.affectedResources
+    const draft = await this.draft(draftRequest)
+    const confirmInput: { reason: string; reauthConfirmed: boolean; phrase?: string } = {
+      reason: input.reason,
+      reauthConfirmed: input.reauthConfirmed
+    }
+    if (input.phrase !== undefined) confirmInput.phrase = input.phrase
+    const confirmation = await this.confirm(draft, confirmInput)
+    const submitOptions: AdminActionSubmitOptions = {
+      methodId: input.methodId,
+      payload: input.payload ?? {},
+      confirmation
+    }
+    if (input.path !== undefined) submitOptions.path = input.path
+    if (input.timeoutMs !== undefined) submitOptions.timeoutMs = input.timeoutMs
+    const data = await this.submit<TData>(submitOptions)
+    return { draft, confirmation, data }
+  }
+}
+
+export class ApprovalClient {
+  constructor(private readonly client: AdminActionControllerClient) {}
+
+  async request(input: ToolApprovalRequest): Promise<ToolApprovalRequestResponse> {
+    const response = await this.client.request<ToolApprovalRequestResponse, ToolApprovalRequest>(
+      TOOLING_METHODS.requestApproval,
+      input,
+      { path: routePath('Tooling', 'RequestApproval') }
+    )
+    assertBackendOk(response.ok, response.error, {
+      method: TOOLING_METHODS.requestApproval,
+      correlationId: response.correlation_id,
+      detail: response
+    })
+    return response
+  }
+
+  async confirm(input: ToolApprovalConfirmRequest): Promise<ToolApprovalConfirmResponse> {
+    const response = await this.client.request<ToolApprovalConfirmResponse, ToolApprovalConfirmRequest>(
+      TOOLING_METHODS.confirmExecution,
+      input,
+      { path: routePath('Tooling', 'ConfirmExecution') }
+    )
+    const context: { method: string; correlationId?: string; detail: unknown } = {
+      method: TOOLING_METHODS.confirmExecution,
+      detail: response
+    }
+    const correlationId = response.correlation_id ?? input.correlation_id
+    if (correlationId !== null && correlationId !== undefined) context.correlationId = correlationId
+    assertBackendOk(response.ok, response.error, context)
+    return response
+  }
+
+  async approve(input: ToolApprovalConfirmRequest): Promise<ApprovalTokenScope> {
+    const response = await this.confirm({ ...input, approve: input.approve ?? true })
+    if (!response.approval_token) {
+      throw new AuroraError({
+        code: 'validation',
+        message: 'Tool approval confirmation did not include a backend-issued approval token',
+        method: TOOLING_METHODS.confirmExecution,
+        correlationId: response.correlation_id ?? undefined,
+        detail: response
+      })
+    }
+    return {
+      approvalRequestId: input.approval_request_id,
+      approvalToken: response.approval_token,
+      expiresAt: response.expires_at,
+      policyDecisionId: response.policy_decision_id,
+      correlationId: response.correlation_id
+    }
+  }
+}
+
+export function adminActionAudit(confirmation: AdminActionConfirmResponse): Partial<AuditReceipt> {
+  return {
+    eventKind: 'admin_action.confirmed',
+    method: GATEWAY_METHODS.adminActionConfirm,
+    status: confirmation.confirmed ? 'confirmed' : 'unconfirmed'
+  }
+}
+
+function pathFromMethodId(methodId: string): string {
+  const separator = methodId.indexOf('.')
+  if (separator <= 0 || separator === methodId.length - 1) {
+    throw new AuroraError({
+      code: 'validation',
+      message: `AdminAction method ID must be a backend bus topic like Service.Method: ${methodId}`,
+      method: methodId
+    })
+  }
+  return routePath(methodId.slice(0, separator), methodId.slice(separator + 1))
+}
+
+function assertBackendOk(
+  ok: boolean,
+  backendError: string | null | undefined,
+  context: { method: string; correlationId?: string; detail: unknown }
+): void {
+  if (ok) return
+  const backendCode = backendError ?? 'approval_failed'
+  throw new AuroraError({
+    code: approvalErrorCode(backendCode),
+    message: backendCode.replace(/_/g, ' '),
+    method: context.method,
+    correlationId: context.correlationId,
+    detail: context.detail
+  })
+}
+
+function approvalErrorCode(backendCode: string): AuroraErrorCode {
+  if (backendCode.includes('expired')) return 'timeout'
+  if (backendCode.includes('denied')) return 'permission'
+  if (backendCode.includes('permission') || backendCode.includes('forbidden')) return 'permission'
+  if (backendCode.includes('privacy')) return 'privacy_blocked'
+  if (backendCode.includes('unavailable') || backendCode.includes('not_found')) return 'unavailable_service'
+  if (backendCode.includes('auth')) return 'auth'
+  if (
+    backendCode.includes('mismatch') ||
+    backendCode.includes('replay') ||
+    backendCode.includes('changed') ||
+    backendCode.includes('downgraded') ||
+    backendCode.includes('invalid') ||
+    backendCode.includes('required')
+  ) {
+    return 'validation'
+  }
+  return 'unknown'
+}

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -9,6 +9,7 @@ import {
   type AuroraTransport
 } from './transport.js'
 import { EventStreamClient, type AuroraEventSubscription, type AuroraSubscribeOptions } from './events.js'
+import { AdminActionClient, ApprovalClient } from './admin.js'
 import { describeRegistry, GATEWAY_METHODS, TOOLING_METHODS, routePath } from './descriptors.js'
 import { buildAdminOverviewManifest, buildCapabilityGraph, summarizeCapabilities } from './capabilities.js'
 import { buildPermissionCatalog, checkAccess, hasPermission, resolveEffectivePermissions } from './permissions.js'
@@ -54,6 +55,8 @@ export class AuroraClient {
   readonly permissions: PermissionClient
   readonly routes: RouteClient
   readonly tools: ToolClient
+  readonly admin: AdminActionClient
+  readonly approvals: ApprovalClient
   readonly native: NativeClient
   readonly events: EventStreamClient
   private readonly defaultTimeoutMs: number
@@ -68,6 +71,8 @@ export class AuroraClient {
     this.permissions = new PermissionClient(this)
     this.routes = new RouteClient(this)
     this.tools = new ToolClient(this)
+    this.admin = new AdminActionClient(this)
+    this.approvals = new ApprovalClient(this)
     this.native = new NativeClient(this)
     this.events = new EventStreamClient(this.transport)
   }
@@ -75,7 +80,7 @@ export class AuroraClient {
   async request<TData = unknown, TPayload = unknown>(
     method: string,
     payload?: TPayload,
-    options: { path?: string; busTopic?: string; httpMethod?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'; timeoutMs?: number } = {}
+    options: { path?: string; busTopic?: string; httpMethod?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'; timeoutMs?: number; headers?: Record<string, string> } = {}
   ): Promise<TData> {
     try {
       const response = await this.transport.request<TData, TPayload>({
@@ -84,6 +89,7 @@ export class AuroraClient {
         path: options.path,
         httpMethod: options.httpMethod,
         payload,
+        headers: options.headers,
         timeoutMs: options.timeoutMs ?? this.defaultTimeoutMs
       })
       return response.data
@@ -96,7 +102,7 @@ export class AuroraClient {
   async requestResult<TData = unknown, TPayload = unknown>(
     method: string,
     payload?: TPayload,
-    options: { path?: string; busTopic?: string; httpMethod?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'; timeoutMs?: number } = {}
+    options: { path?: string; busTopic?: string; httpMethod?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'; timeoutMs?: number; headers?: Record<string, string> } = {}
   ): Promise<AuroraResponse<TData>> {
     const busTopic = options.busTopic ?? method
     try {
@@ -106,6 +112,7 @@ export class AuroraClient {
         path: options.path,
         httpMethod: options.httpMethod,
         payload,
+        headers: options.headers,
         timeoutMs: options.timeoutMs ?? this.defaultTimeoutMs
       })
       return {

--- a/packages/aurora-sdk/src/descriptors.ts
+++ b/packages/aurora-sdk/src/descriptors.ts
@@ -20,7 +20,9 @@ export const GATEWAY_METHODS = {
   getCapabilityCatalog: 'Gateway.GetCapabilityCatalog',
   explainRoute: 'Gateway.ExplainRoute',
   listEvents: 'Gateway.ListEvents',
-  getSupportBundle: 'Gateway.GetSupportBundle'
+  getSupportBundle: 'Gateway.GetSupportBundle',
+  adminActionDraft: 'Gateway.AdminActionDraft',
+  adminActionConfirm: 'Gateway.AdminActionConfirm'
 } as const
 
 export const TOOLING_METHODS = {

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -1,4 +1,5 @@
 export { AuroraClient } from './client.js'
+export { AdminActionClient, ApprovalClient, adminActionAudit } from './admin.js'
 export { HttpGatewayTransport } from './http.js'
 export { MeshP2PTransport } from './mesh.js'
 export { MockAuroraTransport } from './mock.js'
@@ -71,6 +72,7 @@ export {
   uiMockReferenceFixtureSummary
 } from './fixtures.js'
 export type * from './types.js'
+export type * from './admin.js'
 export type * from './transport.js'
 export type {
   AuroraEventStreamKind,

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -839,6 +839,268 @@ describe('AuroraClient', () => {
     if (!loss.ok) expect(loss.error.code).toBe('transport_loss')
   })
 
+  it('drafts, confirms, and submits AdminAction routes with backend-issued headers', async () => {
+    const calls: Array<{ method: string; payload: unknown; headers?: Record<string, string> }> = []
+    const recordCall = (method: string, payload: unknown, headers?: Record<string, string>) => {
+      const call: { method: string; payload: unknown; headers?: Record<string, string> } = { method, payload }
+      if (headers !== undefined) call.headers = headers
+      calls.push(call)
+    }
+    const transport = new MockAuroraTransport({ fixtures: false })
+      .register('Gateway.AdminActionDraft', (request) => {
+        recordCall(request.method, request.payload, request.headers)
+        return {
+          action_id: 'aa-config-set',
+          nonce: 'nonce-config-set',
+          digest: 'digest-config-set',
+          method_id: 'Config.Set',
+          affected_resources: ['key:services.gateway.enabled'],
+          required_phrase: 'CONFIRM',
+          required_reason: true,
+          required_reauth: true,
+          expires_at: '2026-06-20T10:05:00Z',
+          expires_in_seconds: 300,
+          confirmation_headers: {
+            action_id: 'X-Aurora-AdminAction-Id',
+            confirmation_token: 'X-Aurora-AdminAction-Token',
+            digest: 'X-Aurora-AdminAction-Digest'
+          }
+        }
+      })
+      .register('Gateway.AdminActionConfirm', (request) => {
+        recordCall(request.method, request.payload, request.headers)
+        expect(request.payload).toEqual(
+          expect.objectContaining({
+            action_id: 'aa-config-set',
+            nonce: 'nonce-config-set',
+            digest: 'digest-config-set',
+            reason: 'Enable Gateway for local admin',
+            reauth_confirmed: true,
+            phrase: 'CONFIRM'
+          })
+        )
+        return {
+          action_id: 'aa-config-set',
+          confirmation_token: 'token-config-set',
+          digest: 'digest-config-set',
+          confirmed: true,
+          expires_at: '2026-06-20T10:05:00Z',
+          audit_receipt: 'aar-config-set',
+          confirmation_headers: {
+            action_id: 'X-Aurora-AdminAction-Id',
+            confirmation_token: 'X-Aurora-AdminAction-Token',
+            digest: 'X-Aurora-AdminAction-Digest'
+          }
+        }
+      })
+      .register('Config.Set', (request) => {
+        recordCall(request.method, request.payload, request.headers)
+        return { success: true, correlation_id: 'corr-config-set' }
+      })
+    const client = new AuroraClient({ transport })
+    const payload = { key: 'services.gateway.enabled', value: true }
+
+    const draft = await client.admin.draft({ method_id: 'Config.Set', payload })
+    const confirmation = await client.admin.confirm(draft, {
+      reason: 'Enable Gateway for local admin',
+      reauthConfirmed: true
+    })
+    const submitted = await client.admin.submit<{ success: boolean }>({
+      methodId: 'Config.Set',
+      payload,
+      confirmation
+    })
+
+    expect(submitted.success).toBe(true)
+    expect(calls.at(-1)).toEqual(
+      expect.objectContaining({
+        method: 'Config.Set',
+        payload,
+        headers: {
+          'X-Aurora-AdminAction-Id': 'aa-config-set',
+          'X-Aurora-AdminAction-Token': 'token-config-set',
+          'X-Aurora-AdminAction-Digest': 'digest-config-set'
+        }
+      })
+    )
+  })
+
+  it('keeps AdminAction and tool approval separate but composable for dangerous tools', async () => {
+    const transport = new MockAuroraTransport({ fixtures: false })
+      .register('Tooling.RequestApproval', {
+        ok: true,
+        approval_request_id: 'tool-approval-1',
+        policy_decision: {
+          decision_id: 'policy-1',
+          allowed: true,
+          approval_required: true,
+          approval_mode: 'ask_each_time',
+          token_ttl_seconds: 300,
+          risk_class: 'admin-critical'
+        },
+        expires_at: 1781953500,
+        correlation_id: 'corr-approval-1',
+        error: null
+      })
+      .register('Tooling.ConfirmExecution', {
+        ok: true,
+        approval_token: 'tool-token-1',
+        expires_at: 1781953500,
+        policy_decision_id: 'policy-1',
+        correlation_id: 'corr-approval-1',
+        error: null
+      })
+      .register('Gateway.AdminActionDraft', {
+        action_id: 'aa-tool',
+        nonce: 'nonce-tool',
+        digest: 'digest-tool',
+        method_id: 'Tooling.ExecuteTool',
+        affected_resources: ['tool:tool:remote-danger'],
+        required_phrase: 'CONFIRM',
+        required_reason: true,
+        required_reauth: true,
+        expires_at: '2026-06-20T10:05:00Z',
+        expires_in_seconds: 300,
+        confirmation_headers: {
+          action_id: 'X-Aurora-AdminAction-Id',
+          confirmation_token: 'X-Aurora-AdminAction-Token',
+          digest: 'X-Aurora-AdminAction-Digest'
+        }
+      })
+      .register('Gateway.AdminActionConfirm', {
+        action_id: 'aa-tool',
+        confirmation_token: 'admin-token-tool',
+        digest: 'digest-tool',
+        confirmed: true,
+        expires_at: '2026-06-20T10:05:00Z',
+        audit_receipt: 'aar-tool',
+        confirmation_headers: {
+          action_id: 'X-Aurora-AdminAction-Id',
+          confirmation_token: 'X-Aurora-AdminAction-Token',
+          digest: 'X-Aurora-AdminAction-Digest'
+        }
+      })
+      .register('Tooling.ExecuteTool', (request) => ({
+        ok: true,
+        used_tool_approval_token: (request.payload as { approval_token?: string }).approval_token,
+        admin_header: request.headers?.['X-Aurora-AdminAction-Id']
+      }))
+    const client = new AuroraClient({ transport })
+
+    const approval = await client.approvals.request({
+      global_tool_id: 'tool:remote-danger',
+      provider_peer_id: 'peer-kitchen',
+      provider_service_instance_id: 'tooling-remote',
+      args_hash: 'sha256:danger-args',
+      redacted_args_preview: { target: 'garage', api_key: '[redacted]' },
+      risk_class: 'admin-critical',
+      requested_approval_scope: 'tool-args',
+      expected_audit_event: 'tooling.approval.approved',
+      args: { target: 'garage' }
+    })
+    const token = await client.approvals.approve({
+      approval_request_id: approval.approval_request_id!,
+      approver_principal_id: 'admin-1',
+      reason: 'Operator approved garage diagnostic'
+    })
+    const adminDraft = await client.admin.draft({
+      method_id: 'Tooling.ExecuteTool',
+      payload: {
+        global_tool_id: 'tool:remote-danger',
+        approval_token: token.approvalToken,
+        args: { target: 'garage' }
+      }
+    })
+    const adminConfirmation = await client.admin.confirm(adminDraft, {
+      reason: 'Dangerous tool requires admin confirmation',
+      reauthConfirmed: true
+    })
+    const execution = await client.admin.submit<{ ok: boolean; used_tool_approval_token: string; admin_header: string }>({
+      methodId: 'Tooling.ExecuteTool',
+      payload: {
+        global_tool_id: 'tool:remote-danger',
+        approval_token: token.approvalToken,
+        args: { target: 'garage' }
+      },
+      confirmation: adminConfirmation
+    })
+
+    expect(execution).toEqual({
+      ok: true,
+      used_tool_approval_token: 'tool-token-1',
+      admin_header: 'aa-tool'
+    })
+  })
+
+  it('classifies approval denial, expiry, replay, changed args, changed provider, and downgraded risk as typed errors', async () => {
+    const cases = [
+      ['approval_denied', 'permission'],
+      ['approval_request_expired', 'timeout'],
+      ['approval_request_replayed', 'validation'],
+      ['approval_token_args_hash_mismatch', 'validation'],
+      ['approval_token_provider_peer_id_mismatch', 'validation'],
+      ['approval_token_downgraded_risk', 'validation']
+    ] as const
+
+    for (const [backendError, expectedCode] of cases) {
+      const client = new AuroraClient({
+        transport: new MockAuroraTransport({ fixtures: false }).register('Tooling.ConfirmExecution', {
+          ok: false,
+          approval_token: null,
+          expires_at: null,
+          policy_decision_id: null,
+          correlation_id: `corr-${backendError}`,
+          error: backendError
+        })
+      })
+
+      await expect(
+        client.approvals.confirm({
+          approval_request_id: `approval-${backendError}`,
+          approver_principal_id: 'admin-1'
+        })
+      ).rejects.toMatchObject({
+        code: expectedCode,
+        method: 'Tooling.ConfirmExecution',
+        correlationId: `corr-${backendError}`
+      })
+    }
+  })
+
+  it('returns controller result errors for auth, permission, validation, timeout, unavailable, unsupported, privacy, native permission, and transport loss', async () => {
+    const cases = [
+      ['auth', 'Gateway.AdminActionDraft'],
+      ['permission', 'Gateway.AdminActionDraft'],
+      ['validation', 'Gateway.AdminActionDraft'],
+      ['timeout', 'Gateway.AdminActionDraft'],
+      ['unavailable_service', 'Gateway.AdminActionDraft'],
+      ['unsupported_feature', 'Gateway.AdminActionDraft'],
+      ['privacy_blocked', 'Gateway.AdminActionDraft'],
+      ['native_permission_missing', 'Gateway.AdminActionDraft']
+    ] as const
+
+    for (const [code, method] of cases) {
+      const client = new AuroraClient({
+        transport: new MockAuroraTransport({ fixtures: false }).fail(method, code, `failure ${code}`)
+      })
+      const result = await client.result(() =>
+        client.admin.draft({ method_id: 'Config.Set', payload: { key: 'x', value: true } })
+      )
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error.code).toBe(code)
+    }
+
+    const lossClient = new AuroraClient({
+      transport: new MockAuroraTransport({ fixtures: false }).lose('Gateway.AdminActionDraft')
+    })
+    const loss = await lossClient.result(() =>
+      lossClient.admin.draft({ method_id: 'Config.Set', payload: { key: 'x', value: true } })
+    )
+    expect(loss.ok).toBe(false)
+    if (!loss.ok) expect(loss.error.code).toBe('transport_loss')
+  })
+
   it('normalizes successful results with audit and redaction metadata', async () => {
     const transport = new MockAuroraTransport().register('Gateway.ExplainRoute', {
       data: {


### PR DESCRIPTION
## Summary

- Add transport-independent `client.admin` for Gateway AdminAction draft, confirm, header generation, submit, and composed execute flows.
- Add `client.approvals` for Tooling approval request/confirm/approve flows with backend-issued token handling and typed SDK errors for denial, expiry, replay, changed args/provider, and downgraded risk.
- Document HTTP, Tauri local, mesh, native mobile, and mock usage examples for AdminAction and approval composition.

## Verification

- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test`
- `pnpm --filter @aurora/client build`

## Notes

- Production UI must still treat backend/Gateway responses as truth; this SDK layer does not synthesize AdminAction confirmations or approval tokens.
- Existing unrelated local change `assets/graph.png` was not included.
