### PR TITLE
[PER-198] Add tooling risk approval policy

### DIFF
--- a/app/services/config/config_defaults.json
+++ b/app/services/config/config_defaults.json
@@ -254,6 +254,12 @@
         "required_capabilities": [],
         "require_explicit_selector": false
       },
+      "approval_policy": {
+        "default_share": true,
+        "default_approval_mode": "approve_all_local_safe",
+        "default_token_ttl_seconds": 300,
+        "rules": []
+      },
       "hardware_acceleration": {
         "ocr_bg": false,
         "ocr_curr": false

--- a/app/services/config/config_schema.json
+++ b/app/services/config/config_schema.json
@@ -909,6 +909,7 @@
               "default": true
             },
             "mesh_sharing": { "$ref": "#/$defs/mesh_sharing" },
+            "approval_policy": { "$ref": "#/$defs/tooling_approval_policy" },
             "hardware_acceleration": {
               "type": "object",
               "description": "Hardware acceleration for OCR features",
@@ -1242,6 +1243,114 @@
           "type": "boolean",
           "description": "Require callers to provide an explicit mesh peer/provider/resource selector before this service may route remotely.",
           "default": false
+        }
+      }
+    },
+    "tooling_approval_policy": {
+      "type": "object",
+      "description": "Per-service, toolkit, tool, and peer approval policy for Tooling execution",
+      "additionalProperties": false,
+      "properties": {
+        "default_share": {
+          "type": "boolean",
+          "description": "Whether tools are discoverable/executable unless a more specific rule overrides this",
+          "default": true
+        },
+        "default_approval_mode": {
+          "type": "string",
+          "enum": [
+            "deny_all",
+            "ask_each_time",
+            "allow_once",
+            "allow_until_expiry",
+            "approve_all_for_session",
+            "approve_all_for_peer",
+            "approve_all_local_safe",
+            "dry_run_only"
+          ],
+          "description": "Default approval behavior when no scoped rule matches",
+          "default": "approve_all_local_safe"
+        },
+        "default_token_ttl_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Default lifetime for approval tokens issued by matching rules",
+          "default": 300
+        },
+        "rules": {
+          "type": "array",
+          "description": "First-match scoped sharing and approval rules. Unset fields act as wildcards.",
+          "default": [],
+          "items": { "$ref": "#/$defs/tooling_approval_policy_rule" }
+        }
+      }
+    },
+    "tooling_approval_policy_rule": {
+      "type": "object",
+      "description": "Scoped Tooling approval policy rule",
+      "required": ["rule_id"],
+      "additionalProperties": false,
+      "properties": {
+        "rule_id": {
+          "type": "string",
+          "description": "Stable operator-defined rule identifier"
+        },
+        "share": {
+          "type": "boolean",
+          "description": "Whether matching tools are shared/discoverable/executable",
+          "default": true
+        },
+        "approval_mode": {
+          "type": "string",
+          "enum": [
+            "deny_all",
+            "ask_each_time",
+            "allow_once",
+            "allow_until_expiry",
+            "approve_all_for_session",
+            "approve_all_for_peer",
+            "approve_all_local_safe",
+            "dry_run_only"
+          ],
+          "default": "ask_each_time"
+        },
+        "tool_name": { "type": ["string", "null"], "default": null },
+        "global_tool_id": { "type": ["string", "null"], "default": null },
+        "execution_location": {
+          "type": ["string", "null"],
+          "enum": ["local", "remote", null],
+          "default": null
+        },
+        "source_type": {
+          "type": ["string", "null"],
+          "enum": ["core", "plugin", "mcp", "toolkit", "unknown", null],
+          "default": null
+        },
+        "toolkit_name": { "type": ["string", "null"], "default": null },
+        "safety_class": {
+          "type": ["string", "null"],
+          "enum": ["standard", "sensitive", "dangerous", null],
+          "default": null
+        },
+        "operation_class": {
+          "type": ["string", "null"],
+          "enum": ["read", "write", "external", "admin", "hardware", "data-egress", null],
+          "default": null
+        },
+        "resource_namespace": { "type": ["string", "null"], "default": null },
+        "hardware_target": { "type": ["string", "null"], "default": null },
+        "data_scope": { "type": ["string", "null"], "default": null },
+        "caller_peer_id": { "type": ["string", "null"], "default": null },
+        "caller_principal_id": { "type": ["string", "null"], "default": null },
+        "caller_device_id": { "type": ["string", "null"], "default": null },
+        "provider_peer_id": { "type": ["string", "null"], "default": null },
+        "provider_service_instance_id": { "type": ["string", "null"], "default": null },
+        "route_privacy_class": { "type": ["string", "null"], "default": null },
+        "token_ttl_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Approval token lifetime for this rule",
+          "default": 300
         }
       }
     }

--- a/app/services/tooling/service.py
+++ b/app/services/tooling/service.py
@@ -23,6 +23,7 @@ from app.helpers.aurora_logger import log_debug, log_error, log_info, log_warnin
 from app.messaging import MessageBus
 from app.messaging.priority_helpers import get_interactive_priority, get_system_priority
 from app.services.tooling.tools_manager import ToolsManager, set_tools_manager
+from app.shared.config.interface import ConfigAPI
 from app.shared.contracts.models.auth import (
     AuthMethods,
     PrincipalGetRequest,
@@ -54,6 +55,7 @@ from app.shared.contracts.models.tooling import (
     ToolingPolicyDecision,
     ToolingPrepareExecutionRequest,
     ToolingPrepareExecutionResponse,
+    ToolingRateLimitHints,
     ToolingReloadMCPRequest,
     ToolingRequestApprovalRequest,
     ToolingRequestApprovalResponse,
@@ -106,6 +108,7 @@ class ToolingService(BaseService):
             summary="Tool management and execution service",
             capabilities=["tool_discovery", "tool_execution", "mcp_integration"],
         )
+        self._config = ConfigAPI()
         self.tools_manager = ToolsManager(self.bus)
         self._catalog_cache: dict[str, tuple[float, ToolingGetToolsResponse]] = {}
         self._sharing_policy = ToolingSharingPolicy()
@@ -115,6 +118,7 @@ class ToolingService(BaseService):
     async def on_start(self) -> None:
         """Start the tooling service and initialize tools."""
         log_info("Starting Tooling service...")
+        await self._load_sharing_policy_from_config()
 
         # Set as global instance
         set_tools_manager(self.tools_manager)
@@ -151,9 +155,12 @@ class ToolingService(BaseService):
         log_info(f"Reloading ToolingService configuration: section={config_section}")
         # Reload tools if MCP config changed
         if config_section is None or config_section in ["services"]:
+            await self._load_sharing_policy_from_config()
             log_info("Reloading tools due to config change...")
             await self.tools_manager.reload()
             self._catalog_cache.clear()
+        elif config_section == "services.tooling":
+            await self._load_sharing_policy_from_config()
         log_info("ToolingService configuration reloaded")
 
     @staticmethod
@@ -268,9 +275,18 @@ class ToolingService(BaseService):
         )
         display_name = f"{namespace}.{local_name}" if is_remote else local_name
         args_schema = self._serialize_tool_schema(tool)
-        required_permissions = getattr(tool, "required_permissions", None) or [
-            ToolingMethods.EXECUTE_TOOL
-        ]
+        raw_required_permissions = getattr(tool, "required_permissions", None)
+        required_permissions = (
+            list(raw_required_permissions)
+            if isinstance(raw_required_permissions, (list, tuple, set))
+            else [ToolingMethods.EXECUTE_TOOL]
+        )
+        safety_class = self._safe_metadata_value(
+            getattr(tool, "safety_class", "standard"),
+            {"standard", "sensitive", "dangerous"},
+            "standard",
+        )
+        operation_class = self._operation_class(tool, safety_class)
 
         return ToolingToolInfo(
             name=bindable_name,
@@ -286,14 +302,16 @@ class ToolingService(BaseService):
             schema=args_schema,
             source_type=source_type,
             execution_location="remote" if is_remote else "local",
-            safety_class=self._safe_metadata_value(
-                getattr(tool, "safety_class", "standard"),
-                {"standard", "sensitive", "dangerous"},
-                "standard",
-            ),
-            required_permissions=list(required_permissions),
+            safety_class=safety_class,
+            risk_class=self._risk_class(tool, safety_class),
+            data_egress=self._tool_data_egress(tool, operation_class),
+            mutating=self._tool_mutating(tool, operation_class),
+            external=self._tool_external(tool, operation_class),
+            admin=self._tool_admin(tool, operation_class),
+            privacy_hints=self._tool_privacy_hints(tool, safety_class, operation_class),
+            required_permissions=required_permissions,
             confirmation_required=bool(getattr(tool, "confirmation_required", False)),
-            rate_limit_hints=getattr(tool, "rate_limit_hints", None),
+            rate_limit_hints=self._tool_rate_limit_hints(tool),
             provenance=ToolingToolProvenance(
                 provider_peer_id=provider_peer_id,
                 provider_service_instance_id=service_instance_id,
@@ -766,6 +784,88 @@ class ToolingService(BaseService):
         if safety_class == "sensitive":
             return "data-egress"
         return "read"
+
+    def _risk_class(self, tool: Any, safety_class: str) -> str:
+        return self._safe_metadata_value(
+            getattr(tool, "risk_class", safety_class),
+            {"standard", "sensitive", "dangerous"},
+            safety_class,
+        )
+
+    @staticmethod
+    def _tool_data_egress(tool: Any, operation_class: str) -> bool:
+        return bool(getattr(tool, "data_egress", False)) or operation_class == "data-egress"
+
+    @staticmethod
+    def _tool_mutating(tool: Any, operation_class: str) -> bool:
+        return bool(getattr(tool, "mutating", False)) or operation_class in {
+            "write",
+            "admin",
+            "hardware",
+        }
+
+    @staticmethod
+    def _tool_external(tool: Any, operation_class: str) -> bool:
+        return bool(getattr(tool, "external", False)) or operation_class == "external"
+
+    @staticmethod
+    def _tool_admin(tool: Any, operation_class: str) -> bool:
+        return bool(getattr(tool, "admin", False)) or operation_class == "admin"
+
+    def _tool_privacy_hints(
+        self, tool: Any, safety_class: str, operation_class: str
+    ) -> list[str]:
+        raw_hints = getattr(tool, "privacy_hints", None)
+        hints: list[str] = []
+        if isinstance(raw_hints, (list, tuple, set)):
+            hints.extend(str(hint) for hint in raw_hints if hint)
+        if safety_class in {"sensitive", "dangerous"}:
+            hints.append(f"risk:{safety_class}")
+        if self._tool_data_egress(tool, operation_class):
+            hints.append("data_egress")
+        if self._tool_mutating(tool, operation_class):
+            hints.append("mutating")
+        if self._tool_external(tool, operation_class):
+            hints.append("external")
+        if self._tool_admin(tool, operation_class):
+            hints.append("admin")
+        return sorted(set(hints))
+
+    @staticmethod
+    def _tool_rate_limit_hints(tool: Any) -> Any | None:
+        hints = getattr(tool, "rate_limit_hints", None)
+        if hints is None or isinstance(hints, (dict, ToolingRateLimitHints)):
+            return hints
+        return None
+
+    async def _load_sharing_policy_from_config(self) -> None:
+        """Load the Tooling approval policy from schema-backed config if present."""
+
+        try:
+            raw_policy = await self._config.aget(
+                "services.tooling.approval_policy",
+                default=None,
+                config_timeout=20.0,
+            )
+            if raw_policy is None:
+                return
+            policy = (
+                raw_policy
+                if isinstance(raw_policy, ToolingSharingPolicy)
+                else ToolingSharingPolicy.model_validate(raw_policy)
+            )
+            self._sharing_policy = policy
+            await self._audit_tooling_event(
+                "tooling.policy.loaded",
+                principal_id=None,
+                details={
+                    "default_share": policy.default_share,
+                    "default_approval_mode": policy.default_approval_mode,
+                    "rule_count": len(policy.rules),
+                },
+            )
+        except Exception as error:
+            log_warning(f"Failed to load Tooling approval policy from config: {error}")
 
     def _toolkit_name(self, tool: Any) -> str | None:
         return (

--- a/app/shared/config/keys.py
+++ b/app/shared/config/keys.py
@@ -687,6 +687,25 @@ class _ServicesSttWakewordConfigPath(ConfigPath):
         return self
 
 
+class _ServicesToolingApprovalPolicyConfigPath(ConfigPath):
+    default_approval_mode: ConfigPath
+    default_share: ConfigPath
+    default_token_ttl_seconds: ConfigPath
+    rules: ConfigPath
+
+    def __new__(cls) -> _ServicesToolingApprovalPolicyConfigPath:
+        self = super().__new__(cls, "services.tooling.approval_policy")
+        self.default_approval_mode = ConfigPath(
+            "services.tooling.approval_policy.default_approval_mode"
+        )
+        self.default_share = ConfigPath("services.tooling.approval_policy.default_share")
+        self.default_token_ttl_seconds = ConfigPath(
+            "services.tooling.approval_policy.default_token_ttl_seconds"
+        )
+        self.rules = ConfigPath("services.tooling.approval_policy.rules")
+        return self
+
+
 class _ServicesToolingHardwareAccelerationConfigPath(ConfigPath):
     ocr_bg: ConfigPath
     ocr_curr: ConfigPath
@@ -898,6 +917,7 @@ class _ServicesSttConfigPath(ConfigPath):
 
 
 class _ServicesToolingConfigPath(ConfigPath):
+    approval_policy: _ServicesToolingApprovalPolicyConfigPath
     enabled: ConfigPath
     hardware_acceleration: _ServicesToolingHardwareAccelerationConfigPath
     mcp: _ServicesToolingMcpConfigPath
@@ -906,6 +926,7 @@ class _ServicesToolingConfigPath(ConfigPath):
 
     def __new__(cls) -> _ServicesToolingConfigPath:
         self = super().__new__(cls, "services.tooling")
+        self.approval_policy = _ServicesToolingApprovalPolicyConfigPath()
         self.enabled = ConfigPath("services.tooling.enabled")
         self.hardware_acceleration = _ServicesToolingHardwareAccelerationConfigPath()
         self.mcp = _ServicesToolingMcpConfigPath()

--- a/app/shared/config/models.py
+++ b/app/shared/config/models.py
@@ -684,6 +684,52 @@ class MeshSharing(BaseConfigModel):
     """
 
 
+class ToolingApprovalPolicyRule(BaseConfigModel):
+    rule_id: str
+    """
+    Stable operator-defined rule identifier
+    """
+    share: bool | None = True
+    """
+    Whether matching tools are shared/discoverable/executable
+    """
+    approval_mode: (
+        Literal[
+            "deny_all",
+            "ask_each_time",
+            "allow_once",
+            "allow_until_expiry",
+            "approve_all_for_session",
+            "approve_all_for_peer",
+            "approve_all_local_safe",
+            "dry_run_only",
+        ]
+        | None
+    ) = "ask_each_time"
+    tool_name: str | None = None
+    global_tool_id: str | None = None
+    execution_location: Literal["local", "remote"] | None = None
+    source_type: Literal["core", "plugin", "mcp", "toolkit", "unknown"] | None = None
+    toolkit_name: str | None = None
+    safety_class: Literal["standard", "sensitive", "dangerous"] | None = None
+    operation_class: (
+        Literal["read", "write", "external", "admin", "hardware", "data-egress"] | None
+    ) = None
+    resource_namespace: str | None = None
+    hardware_target: str | None = None
+    data_scope: str | None = None
+    caller_peer_id: str | None = None
+    caller_principal_id: str | None = None
+    caller_device_id: str | None = None
+    provider_peer_id: str | None = None
+    provider_service_instance_id: str | None = None
+    route_privacy_class: str | None = None
+    token_ttl_seconds: int | None = Field(300, ge=1)
+    """
+    Approval token lifetime for this rule
+    """
+
+
 class Tts(BaseConfigModel):
     enabled: bool | None = False
     """
@@ -847,12 +893,52 @@ class Db(BaseConfigModel):
     """
 
 
+class Scheduler(BaseConfigModel):
+    enabled: bool | None = True
+    """
+    Enable scheduler service
+    """
+    mesh_sharing: MeshSharing | None = None
+
+
+class ToolingApprovalPolicy(BaseConfigModel):
+    default_share: bool | None = True
+    """
+    Whether tools are discoverable/executable unless a more specific rule overrides this
+    """
+    default_approval_mode: (
+        Literal[
+            "deny_all",
+            "ask_each_time",
+            "allow_once",
+            "allow_until_expiry",
+            "approve_all_for_session",
+            "approve_all_for_peer",
+            "approve_all_local_safe",
+            "dry_run_only",
+        ]
+        | None
+    ) = "approve_all_local_safe"
+    """
+    Default approval behavior when no scoped rule matches
+    """
+    default_token_ttl_seconds: int | None = Field(300, ge=1)
+    """
+    Default lifetime for approval tokens issued by matching rules
+    """
+    rules: list[ToolingApprovalPolicyRule] | None = Field([], validate_default=True)
+    """
+    First-match scoped sharing and approval rules. Unset fields act as wildcards.
+    """
+
+
 class Tooling(BaseConfigModel):
     enabled: bool | None = True
     """
     Enable tooling service
     """
     mesh_sharing: MeshSharing | None = None
+    approval_policy: ToolingApprovalPolicy | None = None
     hardware_acceleration: HardwareAcceleration | None = None
     """
     Hardware acceleration for OCR features
@@ -865,14 +951,6 @@ class Tooling(BaseConfigModel):
     """
     Plugin integrations
     """
-
-
-class Scheduler(BaseConfigModel):
-    enabled: bool | None = True
-    """
-    Enable scheduler service
-    """
-    mesh_sharing: MeshSharing | None = None
 
 
 class Services(BaseConfigModel):

--- a/app/shared/contracts/models/tooling.py
+++ b/app/shared/contracts/models/tooling.py
@@ -56,6 +56,8 @@ ToolingExecutionLocation = Literal["local", "remote"]
 
 ToolingSafetyClass = Literal["standard", "sensitive", "dangerous"]
 
+ToolingRiskClass = Literal["standard", "sensitive", "dangerous"]
+
 
 class ToolingGetToolsRequest(IOModel):
     """Request to get available tools."""
@@ -108,6 +110,12 @@ class ToolingToolInfo(IOModel):
     source_type: Literal["local", "mesh_peer"] = "local"
     execution_location: ToolingExecutionLocation = "local"
     safety_class: ToolingSafetyClass = "standard"
+    risk_class: ToolingRiskClass = "standard"
+    data_egress: bool = False
+    mutating: bool = False
+    external: bool = False
+    admin: bool = False
+    privacy_hints: list[str] = Field(default_factory=list)
     required_permissions: list[str] = Field(default_factory=list)
     confirmation_required: bool = False
     rate_limit_hints: ToolingRateLimitHints | None = None

--- a/docs/SERVICE_METHODS_REFERENCE.md
+++ b/docs/SERVICE_METHODS_REFERENCE.md
@@ -459,6 +459,12 @@ ToolingToolInfo(
     source_type="mesh_peer",                    # "local" | "mesh_peer"
     execution_location="remote",                # "local" | "remote"
     safety_class="standard",
+    risk_class="standard",                      # "standard" | "sensitive" | "dangerous"
+    data_egress=False,
+    mutating=False,
+    external=False,
+    admin=False,
+    privacy_hints=[],
     required_permissions=["Tooling.ExecuteTool"],
     confirmation_required=False,
     provenance={...},
@@ -479,6 +485,12 @@ remote tools, the LLM-visible name remains the collision-safe `name`, but the
 graph stores hidden binding metadata and executes with the tool's
 `global_tool_id` plus a `MeshAddressSelector` containing provider peer,
 service instance, and tool ID.
+
+Tool discovery also exposes policy-facing risk hints. `risk_class` is the
+canonical coarse risk label. `data_egress`, `mutating`, `external`, and `admin`
+identify privacy-relevant behavior that clients can render before execution.
+`privacy_hints` is a normalized list of additional labels such as
+`contains_user_data`, `risk:sensitive`, or `data_egress`.
 
 #### `Tooling.ExecuteTool` (Both)
 **Purpose**: Execute a provider-local or explicitly selected remote tool with
@@ -504,6 +516,14 @@ without invoking the tool. Every outcome writes an `Auth.StoreAuditEvent`
 record containing caller peer/principal, target/provider peer, tool identity,
 resource selector, correlation ID, status/error code, and a redacted argument
 hash rather than raw argument values.
+
+Tooling loads `services.tooling.approval_policy` from schema-backed config on
+startup and on `services` / `services.tooling` reloads. The policy supports
+default sharing/approval behavior plus first-match rules scoped by tool,
+toolkit, safety/operation class, caller peer/principal/device, provider peer,
+service instance, and route privacy class. Loading a valid policy records a
+`tooling.policy.loaded` audit event; invalid policy config is rejected without
+falling back to broad raw execution.
 
 ### Mesh Correlation Debugging
 

--- a/tests/unit/tooling/test_service.py
+++ b/tests/unit/tooling/test_service.py
@@ -224,9 +224,52 @@ class TestToolingServiceQueries:
         assert tool_info.provider_peer_id == "local"
         assert tool_info.source_type == "local"
         assert tool_info.execution_location == "local"
+        assert tool_info.risk_class == "standard"
+        assert tool_info.data_egress is False
+        assert tool_info.mutating is False
+        assert tool_info.external is False
+        assert tool_info.admin is False
+        assert tool_info.privacy_hints == []
         assert tool_info.global_tool_id == "local:local_Tooling:tool:test_tool"
         assert tool_info.provenance.advertised_name == "test_tool"
         assert "input" in tool_info.args_schema["properties"]
+
+    @pytest.mark.asyncio
+    async def test_get_tools_includes_risk_and_privacy_hints(self, tooling_service):
+        """Discovery exposes canonical risk, egress, mutation, external, and admin hints."""
+        from app.shared.contracts.models.tooling import ToolingGetToolsRequest
+
+        risky_tool = Mock()
+        risky_tool.name = "send_admin_report"
+        risky_tool.description = "Send an admin report externally"
+        risky_tool.args_schema = None
+        risky_tool.safety_class = "sensitive"
+        risky_tool.risk_class = "dangerous"
+        risky_tool.operation_class = "admin"
+        risky_tool.data_egress = True
+        risky_tool.external = True
+        risky_tool.privacy_hints = ["contains_user_data"]
+
+        tooling_service.tools_manager.get_tools = Mock(return_value=[risky_tool])
+
+        response = await tooling_service._on_get_tools(ToolingGetToolsRequest(query=None, top_k=10))
+
+        assert response.count == 1
+        tool_info = response.tools[0]
+        assert tool_info.risk_class == "dangerous"
+        assert tool_info.safety_class == "sensitive"
+        assert tool_info.data_egress is True
+        assert tool_info.mutating is True
+        assert tool_info.external is True
+        assert tool_info.admin is True
+        assert tool_info.privacy_hints == [
+            "admin",
+            "contains_user_data",
+            "data_egress",
+            "external",
+            "mutating",
+            "risk:sensitive",
+        ]
 
     @pytest.mark.asyncio
     async def test_get_tool_catalog_aggregates_local_and_remote_safe_tools(
@@ -1328,6 +1371,47 @@ class TestToolingSharingPolicyAndApproval:
         assert "tooling.approval.requested" in event_names
         assert "tooling.approval.approved" in event_names
         assert "tooling.execute" in event_names
+
+    @pytest.mark.asyncio
+    async def test_config_loaded_policy_enforces_peer_scoped_rule(
+        self, tooling_service, mock_bus
+    ):
+        """Schema-backed approval_policy loads into runtime sharing enforcement."""
+        from app.shared.contracts.models.tooling import ToolingExecuteToolRequest
+
+        mock_bus.request = AsyncMock()
+        tooling_service._config.aget = AsyncMock(
+            return_value={
+                "default_share": True,
+                "default_approval_mode": "approve_all_local_safe",
+                "default_token_ttl_seconds": 300,
+                "rules": [
+                    {
+                        "rule_id": "deny-untrusted-peer",
+                        "caller_peer_id": "untrusted-peer",
+                        "approval_mode": "deny_all",
+                        "token_ttl_seconds": 120,
+                    }
+                ],
+            }
+        )
+        mock_tool = self._mock_tool()
+        tooling_service.tools_manager.get_all_tool_names = Mock(return_value=["safe_tool"])
+        tooling_service.tools_manager.get_tool_by_name = Mock(return_value=mock_tool)
+
+        await tooling_service._load_sharing_policy_from_config()
+        response = await tooling_service._on_execute_tool(
+            ToolingExecuteToolRequest(
+                tool_name="safe_tool",
+                arguments={},
+                caller_peer_id="untrusted-peer",
+            )
+        )
+
+        assert response.ok is False
+        assert response.status == "denied"
+        assert response.error_code == "policy_denied"
+        mock_tool.ainvoke.assert_not_called()
 
 
 class TestToolingServiceMCPReload:


### PR DESCRIPTION
## Summary
- Add Tooling discovery risk/privacy metadata (`risk_class`, egress/mutation/external/admin flags, and normalized privacy hints).
- Add schema-backed `services.tooling.approval_policy` defaults/rules and load it on Tooling startup/reload.
- Cover risk hint serialization and config-loaded peer-scoped policy enforcement with unit tests, and document the new API/config surface.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache /home/developer/.local/bin/uv run pytest tests/unit/tooling/test_service.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache /home/developer/.local/bin/uv run ruff check app/shared/contracts/models/tooling.py app/services/tooling/service.py tests/unit/tooling/test_service.py`
- `UV_CACHE_DIR=/tmp/uv-cache /home/developer/.local/bin/uv run python scripts/generate_config_artifacts.py --check`
