### PR TITLE
UI-002 capability-driven navigation and feature drawer

### DIFF
--- a/packages/aurora-ui/src/shell-data.ts
+++ b/packages/aurora-ui/src/shell-data.ts
@@ -2,8 +2,9 @@ import type {
   AuroraClient,
   AuroraError,
   AvailabilityState,
-  CapabilityCatalogResponse,
-  CapabilitySummary,
+  CapabilityExplanation,
+  CapabilityGraph,
+  CapabilityProviderCandidate,
   NativeCapabilityManifest
 } from '@aurora/client'
 import { auroraNavSections, navItemSnapshot, type AuroraNavItem, type AuroraNavItemSnapshot } from './nav'
@@ -16,8 +17,31 @@ export interface RouteAvailability {
   explanation: string
   providerLabel: string
   blockers: string[]
+  repairActions: RepairAction[]
+  candidateProviders: RouteProviderCandidate[]
+  evidenceSources: string[]
+  selectorRequired: boolean
+  approvalRequired: boolean
+  routeable: boolean
   disabled: boolean
   requiresAdminAction: boolean
+}
+
+export interface RepairAction {
+  id: string
+  label: string
+  href: string
+  disabled: boolean
+  reason: string
+}
+
+export interface RouteProviderCandidate {
+  id: string
+  label: string
+  state: AvailabilityState
+  selectable: boolean
+  reason: string
+  requiredAction: string | null
 }
 
 export interface AuroraShellSnapshot {
@@ -56,34 +80,32 @@ export const loadingShellSnapshot: AuroraShellSnapshot = {
 
 export async function buildShellSnapshot(client: AuroraClient): Promise<AuroraShellSnapshot> {
   try {
-    const [catalog, summaries, native] = await Promise.all([
-      client.capabilities.listCatalog({ include_unavailable: true, include_internal: true }),
-      client.capabilities.listSummaries({ include_unavailable: true, include_internal: true }),
+    const [graph, native] = await Promise.all([
+      client.capabilities.getGraph({ include_unavailable: true, include_internal: true }),
       client.native.getManifest().catch(() => null)
     ])
-    return snapshotFromCatalog(client.transport.kind, catalog, summaries, native)
+    return snapshotFromGraph(client.transport.kind, graph, native)
   } catch (error) {
     return errorShellSnapshot(client.transport.kind, error)
   }
 }
 
-export function snapshotFromCatalog(
+export function snapshotFromGraph(
   transportKind: string,
-  catalog: CapabilityCatalogResponse,
-  summaries: CapabilitySummary[],
+  graph: CapabilityGraph,
   native: NativeCapabilityManifest | null
 ): AuroraShellSnapshot {
   const routes = auroraNavSections.flatMap((section) =>
-    section.items.map((item) => routeAvailability(item, summaries))
+    section.items.map((item) => routeAvailability(item, graph.explain(featureIdForNavItem(item)), native))
   )
   return {
     loadState: 'ready',
-    nodeName: catalog.local_node_name || 'Aurora node',
-    localPeerId: catalog.local_peer_id,
+    nodeName: graph.localNodeName || 'Aurora node',
+    localPeerId: graph.localPeerId,
     transportKind,
     evidenceSource: transportKind === 'mock' ? 'SDK mock transport fixture' : 'AuroraClient backend response',
-    generatedAt: catalog.generated_at,
-    secretsRedacted: catalog.secrets_redacted,
+    generatedAt: graph.generatedAt,
+    secretsRedacted: graph.secretsRedacted,
     routeCount: routes.length,
     availableCount: routes.filter((route) => !route.disabled).length,
     blockedCount: routes.filter((route) => route.disabled).length,
@@ -101,10 +123,16 @@ export function errorShellSnapshot(transportKind: string, error: unknown): Auror
       state: 'unsupported' as const,
       explanation: 'Capability state could not be loaded from AuroraClient.',
       providerLabel: 'No backend evidence',
-      blockers: ['sdk_error'],
-      disabled: true,
-      requiresAdminAction: item.methodType === 'manage'
-    }))
+        blockers: ['sdk_error'],
+        repairActions: [repairAction('retry', 'Retry SDK request', '/', true, 'The shell needs a fresh AuroraClient response.')],
+        candidateProviders: [],
+        evidenceSources: ['AuroraClient error'],
+        selectorRequired: false,
+        approvalRequired: false,
+        routeable: false,
+        disabled: true,
+        requiresAdminAction: item.methodType === 'manage'
+      }))
   )
   return {
     ...loadingShellSnapshot,
@@ -119,26 +147,41 @@ export function errorShellSnapshot(transportKind: string, error: unknown): Auror
   }
 }
 
-function routeAvailability(item: AuroraNavItem, summaries: CapabilitySummary[]): RouteAvailability {
-  const match = summaries.find((summary) =>
-    summary.module === item.capabilityModule &&
-    (!item.capabilityMethod || summary.method === item.capabilityMethod)
-  )
-  const state = match?.availability ?? item.fallbackState
-  const disabled = !['available-local', 'available-remote', 'degraded', 'pending'].includes(state)
+function routeAvailability(
+  item: AuroraNavItem,
+  explanation: CapabilityExplanation,
+  native: NativeCapabilityManifest | null
+): RouteAvailability {
+  if (item.capabilityModule === 'Native') return nativeRouteAvailability(item, native)
+  const state = graphStateForItem(item, explanation)
+  const blockers = sortedUnique([
+    explanation.disabledReason,
+    ...explanation.providerCandidates.flatMap((provider) => provider.disabledReasons),
+    ...(!explanation.routeable && explanation.providerCandidates.length === 0 ? ['capability_not_advertised'] : [])
+  ])
+  const repairActions = repairActionsFor(item, explanation, blockers)
+  const disabled = !['available-local', 'available-remote', 'degraded'].includes(state)
   return {
     item: navItemSnapshot(item),
     state,
-    explanation: routeExplanation(state, match),
-    providerLabel: match ? providerLabel(match) : `${item.expectedTask} pending`,
-    blockers: match?.routeBlockers ?? ['capability_not_advertised'],
+    explanation: routeExplanation(state, explanation),
+    providerLabel: providerLabel(explanation, item),
+    blockers,
+    repairActions,
+    candidateProviders: explanation.providerCandidates.map(candidateForRoute),
+    evidenceSources: explanation.evidence.sources,
+    selectorRequired: explanation.selectorRequired,
+    approvalRequired: explanation.approvalRequired,
+    routeable: explanation.routeable,
     disabled,
     requiresAdminAction: item.methodType === 'manage'
   }
 }
 
-function routeExplanation(state: AvailabilityState, summary: CapabilitySummary | undefined): string {
-  if (!summary) return 'No executable capability catalog entry exists yet; the route stays visible with a repair task.'
+function routeExplanation(state: AvailabilityState, explanation: CapabilityExplanation): string {
+  if (explanation.providerCandidates.length === 0) {
+    return 'No executable capability catalog entry exists yet; the route stays visible with a repair task.'
+  }
   if (state === 'available-local') return 'Backend catalog reports a local provider that can serve this route.'
   if (state === 'available-remote') return 'Backend catalog reports a remote provider; target identity must remain visible.'
   if (state === 'degraded') return 'The route is partially usable with backend-reported limitations.'
@@ -149,9 +192,158 @@ function routeExplanation(state: AvailabilityState, summary: CapabilitySummary |
   return 'The route is unsupported in this backend or deployment mode.'
 }
 
-function providerLabel(summary: CapabilitySummary): string {
-  const location = summary.raw.provider_kind === 'local' ? 'local' : `remote ${summary.peerId}`
-  return `${location} / ${summary.module}.${summary.method}`
+function providerLabel(explanation: CapabilityExplanation, item: AuroraNavItem): string {
+  const provider = explanation.selectedProvider ?? explanation.providerCandidates[0]
+  if (!provider) return `${item.expectedTask} pending`
+  return `${provider.providerIdentity} / ${provider.module}.${provider.method}`
+}
+
+function graphStateForItem(item: AuroraNavItem, explanation: CapabilityExplanation): AvailabilityState {
+  if (explanation.providerCandidates.length === 0) return item.fallbackState
+  return explanation.state
+}
+
+function featureIdForNavItem(item: AuroraNavItem): string {
+  return `method:${item.capabilityModule}.${item.capabilityMethod}`
+}
+
+function nativeRouteAvailability(
+  item: AuroraNavItem,
+  native: NativeCapabilityManifest | null
+): RouteAvailability {
+  const missingPermissions = Object.entries(native?.permissions ?? {})
+    .filter(([, granted]) => !granted)
+    .map(([permission]) => permission)
+  const enabledCapabilities = Object.entries(native?.capabilities ?? {})
+    .filter(([, enabled]) => enabled)
+    .map(([capability]) => capability)
+  const state: AvailabilityState = !native
+    ? 'unsupported'
+    : missingPermissions.length > 0
+      ? 'privacy-blocked'
+      : enabledCapabilities.length > 0
+        ? 'available-local'
+        : 'unsupported'
+  const blockers = native
+    ? missingPermissions.map((permission) => `native permission missing: ${permission}`)
+    : ['native_manifest_missing']
+  const base: CapabilityExplanation = {
+    featureId: `native:${native?.platform ?? 'unknown'}`,
+    state,
+    summary: `native manifest is ${state}`,
+    selectedProvider: null,
+    providerCandidates: [],
+    alternateProviders: [],
+    disabledReason: blockers[0] ?? null,
+    nextRepairAction: state === 'privacy-blocked' ? 'grant required native permission' : 'enable native capability in manifest',
+    selectorRequired: false,
+    approvalRequired: false,
+    routeable: state === 'available-local',
+    requiredPermissions: missingPermissions,
+    privacyClass: item.privacyClass,
+    evidence: {
+      generatedAt: nullToPending(native ? new Date(0).toISOString() : null),
+      secretsRedacted: true,
+      sources: native ? ['native-manifest'] : []
+    }
+  }
+  return {
+    item: navItemSnapshot(item),
+    state,
+    explanation: native
+      ? 'SDK native manifest reports platform capabilities and permission gates.'
+      : 'No native manifest was reported by the SDK for this deployment mode.',
+    providerLabel: native ? `native:${native.platform}` : `${item.expectedTask} pending`,
+    blockers,
+    repairActions: repairActionsFor(item, base, blockers),
+    candidateProviders: enabledCapabilities.map((capability) => ({
+      id: `native:${native?.platform}:${capability}`,
+      label: `native:${native?.platform} / ${capability}`,
+      state,
+      selectable: state === 'available-local',
+      reason: missingPermissions.join(', ') || 'native-manifest',
+      requiredAction: state === 'available-local' ? null : 'grant required native permission'
+    })),
+    evidenceSources: native ? ['native-manifest'] : [],
+    selectorRequired: false,
+    approvalRequired: false,
+    routeable: state === 'available-local',
+    disabled: !['available-local', 'available-remote', 'degraded'].includes(state),
+    requiresAdminAction: item.methodType === 'manage'
+  }
+}
+
+function candidateForRoute(candidate: CapabilityProviderCandidate): RouteProviderCandidate {
+  return {
+    id: candidate.id,
+    label: `${candidate.providerIdentity} / ${candidate.module}.${candidate.method}`,
+    state: candidate.availability,
+    selectable: candidate.selectable,
+    reason: candidate.disabledReasons.join(', ') || candidate.routeability,
+    requiredAction: candidate.requiredAction
+  }
+}
+
+function repairActionsFor(
+  item: AuroraNavItem,
+  explanation: CapabilityExplanation,
+  blockers: string[]
+): RepairAction[] {
+  const actionIds = new Set<string>()
+  const actions: RepairAction[] = []
+  const add = (action: RepairAction) => {
+    if (actionIds.has(action.id)) return
+    actionIds.add(action.id)
+    actions.push(action)
+  }
+
+  const blockerText = blockers.join(' ').toLowerCase()
+  const repairText = (explanation.nextRepairAction ?? '').toLowerCase()
+
+  if (blockerText.includes('auth') || blockerText.includes('permission') || explanation.requiredPermissions.length > 0) {
+    add(repairAction('authenticate', 'Authenticate', '/onboarding', Boolean(item.adminGated), 'Current principal or session lacks required backend permission evidence.'))
+    add(repairAction('grant-permission', 'Grant permission', '/admin/access', !Boolean(item.adminGated), 'Required permissions must be granted through admin access controls.'))
+  }
+  if (blockerText.includes('peer') || blockerText.includes('pair') || blockerText.includes('stale')) {
+    add(repairAction('pair', 'Pair or reconnect peer', '/admin/pairing', false, 'Peer trust or freshness must be restored before this feature can run.'))
+  }
+  if (blockerText.includes('service') || blockerText.includes('provider') || blockerText.includes('capability_not_advertised')) {
+    add(repairAction('start-service', 'Start service', '/admin/services', Boolean(item.adminGated), 'The required service/provider is not currently advertised as executable.'))
+  }
+  if (explanation.selectorRequired || repairText.includes('selector') || repairText.includes('route')) {
+    add(repairAction('configure-route', 'Configure route', '/mesh', false, 'A backend-accepted selector or route policy is required.'))
+  }
+  if (blockerText.includes('native') || item.capabilityModule === 'Native') {
+    add(repairAction('grant-native', 'Grant native permission', '/settings/native', false, 'Native manifest or platform permission evidence is missing.'))
+  }
+  if (item.id === 'plugins' || item.id === 'tools' || blockerText.includes('plugin')) {
+    add(repairAction('install-plugin', 'Install plugin', '/admin/plugins', Boolean(item.adminGated), 'Plugin/tool catalog support must be installed and enabled.'))
+  }
+  if (actions.length === 0 && explanation.nextRepairAction) {
+    add(repairAction('inspect', 'Inspect blocker', item.href, true, explanation.nextRepairAction))
+  }
+  if (actions.length === 0) {
+    add(repairAction('wait', 'Await backend contract', item.href, true, `${item.expectedTask} owns this production wiring.`))
+  }
+  return actions
+}
+
+function repairAction(
+  id: string,
+  label: string,
+  href: string,
+  disabled: boolean,
+  reason: string
+): RepairAction {
+  return { id, label, href, disabled, reason }
+}
+
+function sortedUnique(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))].sort()
+}
+
+function nullToPending(value: string | null): string {
+  return value ?? 'pending'
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/aurora-ui/src/shell.tsx
+++ b/packages/aurora-ui/src/shell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { Lock, Menu, PanelRight, Sparkles } from 'lucide-react'
+import { ChevronRight, Lock, Menu, PanelRight, Sparkles } from 'lucide-react'
 import { auroraMobileTabs, auroraNavSections, getAuroraNavItem } from './nav'
 import type { AuroraShellSnapshot, RouteAvailability } from './shell-data'
 import { EvidenceBadge, PrivacyBadge, StatusBadge } from './status-badges'
@@ -123,7 +123,63 @@ function RouteCard({ route }: { route: RouteAvailability }) {
         <div><dt>Task</dt><dd>{route.item.expectedTask}</dd></div>
         <div><dt>AdminAction</dt><dd>{route.requiresAdminAction ? 'required for mutation' : 'not required'}</dd></div>
       </dl>
+      <FeatureDrawer route={route} />
     </article>
+  )
+}
+
+function FeatureDrawer({ route }: { route: RouteAvailability }) {
+  return (
+    <details className="aui-feature-drawer">
+      <summary>
+        <span>Feature details</span>
+        <ChevronRight size={15} aria-hidden />
+      </summary>
+      <div className="aui-feature-drawer-body">
+        <section aria-label={`${route.item.label} repair actions`}>
+          <h4>Repair actions</h4>
+          <div className="aui-repair-actions">
+            {route.repairActions.map((action) => (
+              action.disabled ? (
+                <button key={action.id} type="button" className="aui-action-chip" disabled title={action.reason}>
+                  {action.label}
+                </button>
+              ) : (
+                <a key={action.id} className="aui-action-chip" href={action.href} title={action.reason}>
+                  {action.label}
+                </a>
+              )
+            ))}
+          </div>
+        </section>
+        <section aria-label={`${route.item.label} capability blockers`}>
+          <h4>Capability evidence</h4>
+          <dl>
+            <div><dt>Routeable</dt><dd>{route.routeable ? 'yes' : 'no'}</dd></div>
+            <div><dt>Selector</dt><dd>{route.selectorRequired ? 'required' : 'not required'}</dd></div>
+            <div><dt>Approval</dt><dd>{route.approvalRequired ? 'required' : 'not required'}</dd></div>
+            <div><dt>Sources</dt><dd>{route.evidenceSources.join(', ') || 'none'}</dd></div>
+            <div><dt>Blockers</dt><dd>{route.blockers.join(', ') || 'none'}</dd></div>
+          </dl>
+        </section>
+        <section aria-label={`${route.item.label} provider candidates`}>
+          <h4>Providers</h4>
+          {route.candidateProviders.length > 0 ? (
+            <ul className="aui-provider-list">
+              {route.candidateProviders.map((provider) => (
+                <li key={provider.id}>
+                  <span>{provider.label}</span>
+                  <StatusBadge state={provider.state} />
+                  <small>{provider.requiredAction ?? provider.reason}</small>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No candidate provider was reported by the capability graph.</p>
+          )}
+        </section>
+      </div>
+    </details>
   )
 }
 

--- a/packages/aurora-ui/src/styles.css
+++ b/packages/aurora-ui/src/styles.css
@@ -69,13 +69,29 @@ button, input, select, textarea { font: inherit; }
 .aui-state-surface h1 { margin: .2rem 0 0; font-size: clamp(1.8rem, 3vw, 2.7rem); line-height: 1.05; }
 .aui-state-surface p { max-width: 48rem; margin: 0; color: var(--aui-muted); line-height: 1.55; }
 .aui-state-surface code { width: fit-content; max-width: 100%; overflow-wrap: anywhere; border: 1px solid var(--aui-border); border-radius: .35rem; padding: .35rem .45rem; background: var(--aui-surface-2); color: var(--aui-muted); }
-.aui-button { width: fit-content; border: 1px solid var(--aui-border); border-radius: .45rem; padding: .6rem .8rem; background: var(--aui-surface-2); color: var(--aui-muted); }
+.aui-button, .aui-action-chip { width: fit-content; border: 1px solid var(--aui-border); border-radius: .45rem; padding: .6rem .8rem; background: var(--aui-surface-2); color: var(--aui-muted); }
+.aui-action-chip { display: inline-flex; align-items: center; min-height: 2rem; padding: .4rem .55rem; font-size: .78rem; font-weight: 700; }
+.aui-action-chip:not(:disabled):hover { border-color: color-mix(in srgb, var(--aui-primary) 35%, var(--aui-border)); color: var(--aui-primary); }
+.aui-action-chip:disabled { cursor: not-allowed; opacity: .58; }
 .aui-route-matrix { display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: .85rem; margin-top: 1rem; }
 .aui-route-card { min-width: 0; border: 1px solid var(--aui-border); border-radius: .5rem; padding: .9rem; background: var(--aui-surface); }
 .aui-route-card-header { display: flex; align-items: center; gap: .55rem; }
 .aui-route-card h3 { margin: 0; flex: 1; font-size: .98rem; }
 .aui-route-card p { min-height: 3.2rem; color: var(--aui-muted); line-height: 1.45; }
 .aui-route-card dl { display: grid; gap: .55rem; margin: .8rem 0 0; }
+.aui-feature-drawer { margin-top: .85rem; border-top: 1px solid var(--aui-border); padding-top: .7rem; }
+.aui-feature-drawer summary { display: flex; align-items: center; justify-content: space-between; gap: .5rem; color: var(--aui-primary); cursor: pointer; font-size: .82rem; font-weight: 750; list-style: none; }
+.aui-feature-drawer summary::-webkit-details-marker { display: none; }
+.aui-feature-drawer[open] summary svg { transform: rotate(90deg); }
+.aui-feature-drawer-body { display: grid; gap: .85rem; margin-top: .75rem; }
+.aui-feature-drawer h4 { margin: 0 0 .45rem; font-size: .8rem; text-transform: uppercase; color: var(--aui-muted); }
+.aui-feature-drawer dl { margin: 0; }
+.aui-feature-drawer p { min-height: 0; margin: 0; }
+.aui-repair-actions { display: flex; flex-wrap: wrap; gap: .45rem; }
+.aui-provider-list { display: grid; gap: .45rem; margin: 0; padding: 0; list-style: none; }
+.aui-provider-list li { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: .35rem .5rem; align-items: center; border: 1px solid var(--aui-border); border-radius: .45rem; padding: .55rem; background: color-mix(in srgb, var(--aui-surface-2) 55%, white); }
+.aui-provider-list span, .aui-provider-list small { min-width: 0; overflow-wrap: anywhere; }
+.aui-provider-list small { grid-column: 1 / -1; color: var(--aui-muted); }
 
 @media (max-width: 1100px) {
   .aui-content-grid { grid-template-columns: minmax(0, 1fr); }

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -1,6 +1,14 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { AuroraClient, MockAuroraTransport } from '@aurora/client'
+import {
+  AuroraClient,
+  MockAuroraTransport,
+  capabilityCatalogFixture,
+  cloneFixture,
+  type CapabilityActionInfo,
+  type CapabilityCatalogResponse,
+  type CapabilityProviderInfo
+} from '@aurora/client'
 import {
   AppShell,
   RouteMatrix,
@@ -18,6 +26,8 @@ describe('Aurora production shell', () => {
     expect(snapshot.routes.some((route) => route.state === 'available-local')).toBe(true)
     expect(snapshot.routes.some((route) => route.state === 'privacy-blocked')).toBe(true)
     expect(snapshot.routes.some((route) => route.requiresAdminAction)).toBe(true)
+    expect(snapshot.routes.every((route) => route.repairActions.length > 0)).toBe(true)
+    expect(snapshot.routes.every((route) => Array.isArray(route.candidateProviders))).toBe(true)
   })
 
   it('renders accessible navigation and route state without direct backend calls', async () => {
@@ -32,6 +42,35 @@ describe('Aurora production shell', () => {
     expect(markup).toContain('aria-current="page"')
     expect(markup).toContain('AdminAction')
     expect(markup).toContain('privacy-blocked')
+    expect(markup).toContain('Feature details')
+    expect(markup).toContain('Repair actions')
+  })
+
+  it('maps capability graph states into disabled routes and repair actions', async () => {
+    const transport = new MockAuroraTransport()
+    transport.register('Gateway.GetCapabilityCatalog', () => stateMatrixCatalog())
+    const snapshot = await buildShellSnapshot(new AuroraClient({ transport }))
+
+    const services = route(snapshot, 'services')
+    const config = route(snapshot, 'config')
+    const tools = route(snapshot, 'tools')
+    const memory = route(snapshot, 'memory')
+
+    expect(services.state).toBe('degraded')
+    expect(services.disabled).toBe(false)
+    expect(config.state).toBe('denied')
+    expect(config.disabled).toBe(true)
+    expect(config.repairActions.map((action) => action.id)).toContain('grant-permission')
+    expect(tools.state).toBe('privacy-blocked')
+    expect(tools.repairActions.map((action) => action.id)).toContain('configure-route')
+    expect(memory.state).toBe('stale')
+    expect(memory.repairActions.map((action) => action.id)).toContain('pair')
+
+    const markup = renderToStaticMarkup(<RouteMatrix routes={[services, config, tools, memory]} />)
+    expect(markup).toContain('Grant permission')
+    expect(markup).toContain('Configure route')
+    expect(markup).toContain('Pair or reconnect peer')
+    expect(markup).toContain('Providers')
   })
 
   it('keeps SDK errors visible as disabled shell state', () => {
@@ -39,6 +78,7 @@ describe('Aurora production shell', () => {
 
     expect(snapshot.loadState).toBe('error')
     expect(snapshot.routes.every((route) => route.disabled)).toBe(true)
+    expect(snapshot.routes.every((route) => route.blockers.includes('sdk_error'))).toBe(true)
 
     const markup = renderToStaticMarkup(
       <StateSurface
@@ -52,3 +92,133 @@ describe('Aurora production shell', () => {
     expect(markup).toContain('AuroraClient error')
   })
 })
+
+function route(snapshot: Awaited<ReturnType<typeof buildShellSnapshot>>, id: string) {
+  const match = snapshot.routes.find((candidate) => candidate.item.id === id)
+  if (!match) throw new Error(`missing route ${id}`)
+  return match
+}
+
+function stateMatrixCatalog(): CapabilityCatalogResponse {
+  const catalog = cloneFixture(capabilityCatalogFixture)
+  const baseProvider = catalog.providers[0]!
+  const baseAction = catalog.actions[0]!
+  const localServices = provider(baseProvider, {
+    provider_id: 'local:Gateway-services',
+    module: 'Gateway',
+    service_instance_id: 'gateway-services',
+    reason_code: 'fallback_used',
+    reason: 'Service list is available through reduced diagnostics.'
+  })
+  const deniedConfig = provider(baseProvider, {
+    provider_id: 'local:Config-denied',
+    module: 'Config',
+    service_instance_id: 'config-denied',
+    eligible: false,
+    reason_code: 'permission_denied',
+    reason: 'Current principal lacks Config.manage.'
+  })
+  const blockedTooling = provider(baseProvider, {
+    provider_id: 'mesh:tools',
+    peer_id: 'tool-peer',
+    provider_kind: 'remote',
+    module: 'Tooling',
+    service_instance_id: 'tooling-remote',
+    eligible: false,
+    reason_code: 'explicit_selector_required',
+    reason: 'Remote tool catalog needs an explicit provider selector.'
+  })
+  const staleDb = provider(baseProvider, {
+    provider_id: 'mesh:db',
+    peer_id: 'db-peer',
+    provider_kind: 'remote',
+    module: 'DB',
+    service_instance_id: 'db-remote',
+    status: 'stale',
+    eligible: false,
+    reason_code: 'stale_provider',
+    reason: 'DB provider heartbeat is stale.',
+    freshness: { ...baseProvider.freshness, stale: true, last_probe_age_s: 900 }
+  })
+
+  catalog.providers = [...catalog.providers, localServices, deniedConfig, blockedTooling, staleDb]
+  catalog.actions = [
+    ...catalog.actions,
+    action(baseAction, localServices, {
+      action_id: 'gateway-services-degraded',
+      method: 'GetServices',
+      bindability: 'degraded',
+      route_blockers: []
+    }),
+    action(baseAction, deniedConfig, {
+      action_id: 'config-get-denied',
+      method: 'Get',
+      bindability: 'denied',
+      policy: {
+        ...baseAction.policy,
+        required_permissions: ['Config.manage'],
+        denial_reasons: ['permission_denied'],
+        operation_class: 'admin',
+        safety_class: 'admin'
+      }
+    }),
+    action(baseAction, blockedTooling, {
+      action_id: 'tooling-catalog-selector',
+      method: 'GetToolCatalog',
+      bindability: 'unavailable',
+      route_blockers: ['explicit_selector_required'],
+      policy: {
+        ...baseAction.policy,
+        required_permissions: ['Tooling.use'],
+        explicit_selector_required: true,
+        selector_required: true
+      }
+    }),
+    action(baseAction, staleDb, {
+      action_id: 'db-rag-stale',
+      method: 'RAGSearch',
+      bindability: 'unavailable',
+      route_blockers: ['stale_provider'],
+      freshness: staleDb.freshness,
+      policy: { ...baseAction.policy, required_permissions: ['DB.use'] }
+    })
+  ]
+  return catalog
+}
+
+function provider(
+  base: CapabilityProviderInfo,
+  overrides: Partial<CapabilityProviderInfo>
+): CapabilityProviderInfo {
+  return {
+    ...base,
+    policy: { ...base.policy },
+    freshness: { ...base.freshness },
+    ...overrides
+  }
+}
+
+function action(
+  base: CapabilityActionInfo,
+  providerInfo: CapabilityProviderInfo,
+  overrides: Partial<CapabilityActionInfo>
+): CapabilityActionInfo {
+  const method = overrides.method ?? base.method
+  return {
+    ...base,
+    action_id: `${providerInfo.provider_id}:${method}`,
+    module: providerInfo.module,
+    method,
+    topic: `${providerInfo.module}.${method}`,
+    provider_id: providerInfo.provider_id,
+    peer_id: providerInfo.peer_id,
+    provider_kind: providerInfo.provider_kind,
+    service_instance_id: providerInfo.service_instance_id,
+    selector: { peer_id: providerInfo.peer_id, module: providerInfo.module },
+    route_blockers: providerInfo.eligible ? [] : [providerInfo.reason_code],
+    summary: providerInfo.reason,
+    policy: { ...providerInfo.policy },
+    freshness: { ...providerInfo.freshness },
+    ...overrides
+  }
+}


### PR DESCRIPTION
## Summary

- Drives shell navigation route state from the SDK capability graph instead of summary-only fixture matching.
- Adds feature details drawers with repair actions, blockers, provider candidates, selector/approval flags, evidence sources, and AdminAction requirements.
- Expands UI shell tests for degraded, denied, privacy-blocked, stale, SDK error, drawer, and repair-action states.

## Verification

- `pnpm --filter @aurora/ui typecheck`
- `pnpm --filter @aurora/ui test`
- `pnpm --filter @aurora/ui build`
- `pnpm --filter @aurora/web typecheck`
- `pnpm --filter @aurora/web test`
- `pnpm --filter @aurora/web build`

## Notes

- Production screen components still consume shell state through `AuroraClient`; no direct fetch/invoke paths were added.
- `assets/graph.png` was already modified in the working tree and is intentionally not included in this PR.
