### PR TITLE
BE-008: Add attachment context ingestion contracts

### DIFF
--- a/.omx/plans/PER-195-BE-008-attachment-context-ingestion-contracts.md
+++ b/.omx/plans/PER-195-BE-008-attachment-context-ingestion-contracts.md
@@ -1,0 +1,35 @@
+# PER-195 / BE-008 Attachment Context Ingestion Contracts
+
+## Scope
+
+Implement the backend contract slice for assistant attachment and shared-context ingestion. The issue scope is limited to typed request/response models, an external Orchestrator method surface, privacy-first policy handling, audit/RAG bus integration points, and focused tests.
+
+## Source Context
+
+- Multica issue PER-195 / BE-008.
+- `.omx/specs/ui-production-tasks/tasks/BE-008-add-attachment-context-ingestion-contracts.md`.
+- `.omx/specs/ui-refinement/aurora-ui-sdk-contract.md`.
+- `.omx/specs/ui-production-tasks/backend-gap-crosswalk.md`.
+- Root and subsystem `AGENTS.md` files for services, contracts, messaging, and tests.
+
+## Invariants
+
+- Services communicate through the message bus only.
+- Externally exposed methods use `@method_contract`, typed IO models, and explicit permissions.
+- Privacy-sensitive classes are rejected by default.
+- Raw context content is not echoed in responses or audit details.
+- RAG persistence is opt-in through an explicit storage policy.
+
+## Plan
+
+1. Add typed attachment/context ingestion models to Orchestrator contracts.
+2. Register `Orchestrator.IngestContext` as an external `use` method requiring `Orchestrator.use`.
+3. Implement ingestion in Orchestrator with size limits, privacy-class rejection, secret redaction, optional DB RAG storage, and Auth audit logging over the bus.
+4. Add unit tests for registry metadata, redaction and RAG storage, oversized rejection, and blocked privacy classes.
+5. Verify with targeted unit and registry/inventory tests plus Ruff on changed files.
+
+## Verification
+
+- `.venv/bin/pytest tests/unit/orchestrator/test_context_ingestion_contracts.py -q`
+- `.venv/bin/ruff check app/shared/contracts/models/orchestrator.py app/services/orchestrator/service.py tests/unit/orchestrator/test_context_ingestion_contracts.py`
+- `.venv/bin/pytest tests/unit/orchestrator/test_model_runtime_contracts.py tests/unit/gateway/test_backend_inventory.py -q`

--- a/app/services/backup/service.py
+++ b/app/services/backup/service.py
@@ -484,7 +484,7 @@ class BackupService(BaseService):
         return value
 
     def _audit_receipt(self, operation: str, target_id: str) -> str:
-        digest = hashlib.sha256(f"{operation}:{target_id}:{uuid4()}".encode("utf-8")).hexdigest()
+        digest = hashlib.sha256(f"{operation}:{target_id}:{uuid4()}".encode()).hexdigest()
         return f"bar_{digest[:24]}"
 
     def _result_data(self, result: Any) -> Any:

--- a/app/services/config/config_manager.py
+++ b/app/services/config/config_manager.py
@@ -616,8 +616,7 @@ class ConfigManager:
         if restart_required:
             return f"{key_path} changes startup or transport behavior for {service_text}"
         return (
-            f"{key_path} can be applied through Config.Updated reload handling "
-            f"for {service_text}"
+            f"{key_path} can be applied through Config.Updated reload handling for {service_text}"
         )
 
     def _resolve_env_fallbacks(self, config: dict[str, Any]) -> dict[str, Any]:

--- a/app/services/config/service.py
+++ b/app/services/config/service.py
@@ -206,9 +206,7 @@ class ConfigService(BaseService):
         self, query: ConfigDiffPreviewRequest
     ) -> ConfigDiffPreviewResponse:
         """Handle dry-run config diff preview."""
-        result = self.config_manager.preview_diff(
-            [change.model_dump() for change in query.changes]
-        )
+        result = self.config_manager.preview_diff([change.model_dump() for change in query.changes])
         return ConfigDiffPreviewResponse(**result)
 
     @method_contract(

--- a/app/services/gateway/fastapi_app.py
+++ b/app/services/gateway/fastapi_app.py
@@ -235,6 +235,11 @@ def create_gateway_app(
 
         return GetServicesResponse(services=services, mode=mode)
 
+    stream_events_auth = Security(
+        create_scoped_auth_check(method_type="manage"),
+        scopes=["Gateway.manage"],
+    )
+
     @app.get(
         "/api/events/stream",
         tags=["Gateway"],
@@ -248,10 +253,7 @@ def create_gateway_app(
         },
     )
     async def stream_events(
-        _auth: Any = Security(  # noqa: B008
-            create_scoped_auth_check(method_type="manage"),
-            scopes=["Gateway.manage"],
-        ),
+        _auth: Any = stream_events_auth,
     ) -> StreamingResponse:
         """Stream normalized event envelopes as Server-Sent Events."""
         queue: asyncio.Queue[AuroraEventStreamEvent] = asyncio.Queue(maxsize=100)

--- a/app/services/gateway/mesh/capability_catalog.py
+++ b/app/services/gateway/mesh/capability_catalog.py
@@ -361,7 +361,9 @@ def _local_candidate(
         max_concurrent=service.max_concurrent if service else 0,
         available_capacity=service.available_capacity if service else None,
         policy=policy,
-        freshness=_freshness(service) if service else CapabilityFreshnessInfo(source="local_registry"),
+        freshness=_freshness(service)
+        if service
+        else CapabilityFreshnessInfo(source="local_registry"),
         auth_rbac_state=_auth_rbac_state(policy=policy, blockers=[], included=True),
         transport="local_bus",
         privacy_class=_privacy_class(policy),

--- a/app/services/gateway/mesh/peer_bridge.py
+++ b/app/services/gateway/mesh/peer_bridge.py
@@ -115,8 +115,7 @@ class PeerBridge:
                 )
 
             log_debug(
-                f"PeerBridge: Sent call {req_id} to {peer_id} topic={topic} "
-                f"correlation_id={req_id}"
+                f"PeerBridge: Sent call {req_id} to {peer_id} topic={topic} correlation_id={req_id}"
             )
 
             # Wait for response with timeout

--- a/app/services/gateway/mesh/routing_table.py
+++ b/app/services/gateway/mesh/routing_table.py
@@ -411,13 +411,15 @@ def _selector_target(
     if len(peer_ids) > 1:
         return None, f"selector names multiple peer/provider targets: {', '.join(peer_ids)}", None
     if len(provider_kinds) > 1:
-        return None, (
-            f"selector names multiple provider kinds: {', '.join(provider_kinds)}"
-        ), None
-    return (peer_ids[0], None, provider_kinds[0] if provider_kinds else None) if peer_ids else (
-        None,
-        None,
-        None,
+        return None, (f"selector names multiple provider kinds: {', '.join(provider_kinds)}"), None
+    return (
+        (peer_ids[0], None, provider_kinds[0] if provider_kinds else None)
+        if peer_ids
+        else (
+            None,
+            None,
+            None,
+        )
     )
 
 
@@ -439,9 +441,7 @@ def _parse_selector_target(
         peer_id, service_module = value.split(":", 1)
 
     if service_module and service_module != module:
-        return None, (
-            f"{field_name} '{value}' targets {service_module}, not {module}"
-        ), None
+        return None, (f"{field_name} '{value}' targets {service_module}, not {module}"), None
     return peer_id, None, provider_kind
 
 

--- a/app/services/gateway/webrtc/rpc.py
+++ b/app/services/gateway/webrtc/rpc.py
@@ -120,8 +120,7 @@ class RPCHandler:
             return
 
         log_debug(
-            f"RPCHandler: Received forwarded event {topic} "
-            f"correlation_id={correlation_id or 'n/a'}"
+            f"RPCHandler: Received forwarded event {topic} correlation_id={correlation_id or 'n/a'}"
         )
         try:
             payload: Any = params
@@ -307,16 +306,18 @@ class RPCHandler:
                     module_for_capacity, max_concurrent - active, max_concurrent
                 )
         try:
-            log_debug(
-                f"RPCHandler: Executing {topic} via bus correlation_id={correlation_id}"
-            )
+            log_debug(f"RPCHandler: Executing {topic} via bus correlation_id={correlation_id}")
             typed_params = params
             if isinstance(params, dict):
-                if topic in {
-                    AudioSessionMethods.PREPARE,
-                    TranscriptionMethods.PROCESS_AUDIO,
-                    WakeWordMethods.PROCESS_AUDIO,
-                } or topic == ToolingMethods.EXECUTE_TOOL:
+                if (
+                    topic
+                    in {
+                        AudioSessionMethods.PREPARE,
+                        TranscriptionMethods.PROCESS_AUDIO,
+                        WakeWordMethods.PROCESS_AUDIO,
+                    }
+                    or topic == ToolingMethods.EXECUTE_TOOL
+                ):
                     params = {
                         **params,
                         "caller_peer_id": self._peer_id,

--- a/app/services/gateway/webrtc/rtc_client.py
+++ b/app/services/gateway/webrtc/rtc_client.py
@@ -927,9 +927,7 @@ class RTCClient:
         )
         remote_node_name = msg.get("node_name") or msg.get("mesh_node_name") or ""
         if remote_stable_peer_id == self._local_mesh_peer_id():
-            log_debug(
-                f"RTCClient: Ignoring stale self-presence from signaling peer {remote_peer}"
-            )
+            log_debug(f"RTCClient: Ignoring stale self-presence from signaling peer {remote_peer}")
             return
         if remote_stable_peer_id:
             self._remember_stable_peer_id(remote_peer, remote_stable_peer_id, remote_node_name)

--- a/app/services/orchestrator/service.py
+++ b/app/services/orchestrator/service.py
@@ -560,7 +560,11 @@ class OrchestratorService(BaseService):
         provider = None
         if data.provider_id:
             provider = next(
-                (candidate for candidate in catalog.providers if candidate.provider_id == data.provider_id),
+                (
+                    candidate
+                    for candidate in catalog.providers
+                    if candidate.provider_id == data.provider_id
+                ),
                 None,
             )
         elif catalog.selected_provider_id:
@@ -1035,10 +1039,10 @@ def _configured_model_providers(
 ) -> list[ModelRuntimeProviderInfo]:
     third_party = llm_config.get("third_party") or {}
     local = llm_config.get("local") or {}
-    openai_options = ((third_party.get("openai") or {}).get("options") or {})
-    hf_endpoint_options = ((third_party.get("huggingface_endpoint") or {}).get("options") or {})
-    hf_pipeline_options = ((local.get("huggingface_pipeline") or {}).get("options") or {})
-    llama_options = ((local.get("llama_cpp") or {}).get("options") or {})
+    openai_options = (third_party.get("openai") or {}).get("options") or {}
+    hf_endpoint_options = (third_party.get("huggingface_endpoint") or {}).get("options") or {}
+    hf_pipeline_options = (local.get("huggingface_pipeline") or {}).get("options") or {}
+    llama_options = (local.get("llama_cpp") or {}).get("options") or {}
 
     return [
         _provider_info(
@@ -1095,9 +1099,7 @@ def _configured_model_providers(
             },
             capabilities=["chat", "local_execution"],
             health="available" if hf_pipeline_options.get("model") else "misconfigured",
-            health_reason=None
-            if hf_pipeline_options.get("model")
-            else "model is not configured",
+            health_reason=None if hf_pipeline_options.get("model") else "model is not configured",
             operations=operations,
         ),
         _provider_info(
@@ -1174,8 +1176,12 @@ def _provider_info(
 def _provider_index(providers: list[ModelRuntimeProviderInfo]) -> dict[str, list[str]]:
     return {
         "all": [provider.provider_id for provider in providers],
-        "local": [provider.provider_id for provider in providers if provider.provider_type == "local"],
-        "cloud": [provider.provider_id for provider in providers if provider.provider_type == "cloud"],
+        "local": [
+            provider.provider_id for provider in providers if provider.provider_type == "local"
+        ],
+        "cloud": [
+            provider.provider_id for provider in providers if provider.provider_type == "cloud"
+        ],
         "selected": [provider.provider_id for provider in providers if provider.selected],
     }
 
@@ -1237,7 +1243,11 @@ def _operation_progress(
     operations: list[ModelRuntimeOperationResponse],
 ) -> ModelRuntimeProgressInfo:
     operation = next(
-        (candidate for candidate in reversed(operations) if candidate.operation_type == operation_type),
+        (
+            candidate
+            for candidate in reversed(operations)
+            if candidate.operation_type == operation_type
+        ),
         None,
     )
     if operation is None:
@@ -1260,7 +1270,11 @@ def _benchmark_progress(
     operations: list[ModelRuntimeOperationResponse],
 ) -> ModelRuntimeBenchmarkInfo:
     operation = next(
-        (candidate for candidate in reversed(operations) if candidate.operation_type == "benchmark"),
+        (
+            candidate
+            for candidate in reversed(operations)
+            if candidate.operation_type == "benchmark"
+        ),
         None,
     )
     if operation is None:

--- a/app/services/orchestrator/service.py
+++ b/app/services/orchestrator/service.py
@@ -11,6 +11,8 @@ This service:
 from __future__ import annotations
 
 import asyncio
+import json
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -24,8 +26,17 @@ from app.messaging import (
 from app.messaging.priority_helpers import get_interactive_priority
 from app.services.orchestrator.graph import GraphOrchestrator, set_orchestrator
 from app.shared.config.interface import ConfigAPI
+from app.shared.contracts.models.auth import AuthMethods, StoreAuditEventRequest
 from app.shared.contracts.models.common import EmptyInput, EmptyOutput
+from app.shared.contracts.models.db import DBMethods, DBRAGStoreRequest
 from app.shared.contracts.models.orchestrator import (
+    AttachmentContextIngestRequest,
+    AttachmentContextIngestResponse,
+    AttachmentContextItem,
+    AttachmentContextItemResult,
+    AttachmentContextPrivacyClass,
+    AttachmentContextStatus,
+    AttachmentContextStoragePolicy,
     ModelRuntimeBenchmarkInfo,
     ModelRuntimeCatalogRequest,
     ModelRuntimeCatalogResponse,
@@ -54,6 +65,12 @@ from app.shared.contracts.models.tts import TTSMethods, TTSRequest
 from app.shared.contracts.registry import method_contract
 from app.shared.messaging.models.stt_coordinator_models import STTUserSpeechCaptured
 from app.shared.services.base_service import BaseService
+
+_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*['\"]?[^'\"\s]+"), "credential"),
+    (re.compile(r"(?i)bearer\s+[a-z0-9._~+/=-]{16,}"), "bearer_token"),
+    (re.compile(r"\b(?:sk|pk)-[A-Za-z0-9_-]{16,}\b"), "api_key"),
+)
 
 
 # Service implementation
@@ -218,6 +235,166 @@ class OrchestratorService(BaseService):
                 session_id=cmd.session_id,
                 metadata={"source": "external", "error": True},
             )
+
+    @method_contract(
+        method_id=OrchestratorMethods.INGEST_CONTEXT,
+        summary="Ingest assistant attachment and shared context metadata",
+        input_model=AttachmentContextIngestRequest,
+        output_model=AttachmentContextIngestResponse,
+        exposure="external",
+        method_type="use",
+        required_perms=["Orchestrator.use"],
+    )
+    async def ingest_context(
+        self, data: AttachmentContextIngestRequest
+    ) -> AttachmentContextIngestResponse:
+        """Accept redacted text context for assistant use with policy and audit metadata."""
+        correlation_id = data.correlation_id or f"context-{uuid4().hex[:12]}"
+        accepted_items: list[AttachmentContextItemResult] = []
+        rejected_items: list[AttachmentContextItemResult] = []
+        total_bytes = 0
+
+        if len(data.items) > data.limits.max_items:
+            response = self._context_response(
+                data=data,
+                accepted_items=[],
+                rejected_items=[
+                    self._context_result(
+                        item=AttachmentContextItem(kind="text"),
+                        index=0,
+                        status="rejected",
+                        storage_policy=data.storage_policy,
+                        privacy_class=data.privacy_class,
+                        reason_code="too_many_items",
+                        message=f"Context item count exceeds limit {data.limits.max_items}",
+                    )
+                ],
+                total_bytes=0,
+                correlation_id=correlation_id,
+            )
+            await self._audit_context_ingestion(data, response)
+            return response
+
+        for index, item in enumerate(data.items):
+            item_bytes = self._context_item_size(item)
+            total_bytes += item_bytes
+
+            if data.storage_policy == "reject":
+                rejected_items.append(
+                    self._context_result(
+                        item=item,
+                        index=index,
+                        status="rejected",
+                        storage_policy=data.storage_policy,
+                        privacy_class=data.privacy_class,
+                        reason_code="storage_policy_reject",
+                        message="Storage policy rejects attachment/context ingestion",
+                    )
+                )
+                continue
+
+            if data.privacy_class in {"secret", "credential", "raw-audio"}:
+                rejected_items.append(
+                    self._context_result(
+                        item=item,
+                        index=index,
+                        status="rejected",
+                        storage_policy=data.storage_policy,
+                        privacy_class=data.privacy_class,
+                        accepted_bytes=item_bytes,
+                        reason_code="privacy_class_blocked",
+                        message="Privacy class is not accepted for assistant context ingestion",
+                    )
+                )
+                continue
+
+            if item_bytes > data.limits.max_item_bytes:
+                rejected_items.append(
+                    self._context_result(
+                        item=item,
+                        index=index,
+                        status="rejected",
+                        storage_policy=data.storage_policy,
+                        privacy_class=data.privacy_class,
+                        accepted_bytes=item_bytes,
+                        reason_code="item_too_large",
+                        message=f"Context item exceeds limit {data.limits.max_item_bytes} bytes",
+                    )
+                )
+                continue
+
+            if total_bytes > data.limits.max_total_bytes:
+                rejected_items.append(
+                    self._context_result(
+                        item=item,
+                        index=index,
+                        status="rejected",
+                        storage_policy=data.storage_policy,
+                        privacy_class=data.privacy_class,
+                        accepted_bytes=item_bytes,
+                        reason_code="total_too_large",
+                        message=f"Context batch exceeds limit {data.limits.max_total_bytes} bytes",
+                    )
+                )
+                continue
+
+            text = self._context_item_text(item)
+            if not text:
+                rejected_items.append(
+                    self._context_result(
+                        item=item,
+                        index=index,
+                        status="unsupported",
+                        storage_policy=data.storage_policy,
+                        privacy_class=data.privacy_class,
+                        reason_code="no_text_context",
+                        message="Only text-like attachment/context content is supported",
+                    )
+                )
+                continue
+
+            sanitized_text, redaction_reasons = self._sanitize_context_text(
+                text,
+                max_chars=data.limits.max_text_chars,
+            )
+            status: AttachmentContextStatus = "redacted" if redaction_reasons else "accepted"
+            result = self._context_result(
+                item=item,
+                index=index,
+                status=status,
+                storage_policy=data.storage_policy,
+                privacy_class=data.privacy_class,
+                accepted_bytes=item_bytes,
+                redacted=bool(redaction_reasons),
+                redaction_reasons=redaction_reasons,
+                message="Context accepted for assistant use",
+            )
+
+            if data.storage_policy == "rag":
+                stored_key = await self._store_context_in_rag(
+                    data=data,
+                    item=item,
+                    item_id=result.item_id,
+                    text=sanitized_text,
+                    redacted=bool(redaction_reasons),
+                    redaction_reasons=redaction_reasons,
+                    correlation_id=correlation_id,
+                )
+                result.status = "stored"
+                result.stored_namespace = data.namespace
+                result.stored_key = stored_key
+
+            accepted_items.append(result)
+
+        response = self._context_response(
+            data=data,
+            accepted_items=accepted_items,
+            rejected_items=rejected_items,
+            total_bytes=total_bytes,
+            correlation_id=correlation_id,
+        )
+        await self._audit_context_ingestion(data, response)
+        return response
 
     @method_contract(
         method_id=OrchestratorMethods.TOOL_RESULT,
@@ -666,6 +843,158 @@ class OrchestratorService(BaseService):
         )
         self._model_runtime_operations[operation.operation_id] = operation
         return operation
+
+    def _context_item_size(self, item: AttachmentContextItem) -> int:
+        if item.size_bytes is not None:
+            return max(0, item.size_bytes)
+        text = self._context_item_text(item)
+        return len(text.encode("utf-8"))
+
+    def _context_item_text(self, item: AttachmentContextItem) -> str:
+        if item.content_text:
+            return item.content_text
+        if item.kind == "url" and item.url:
+            return f"{item.title or item.url}\n{item.url}"
+        return ""
+
+    def _sanitize_context_text(self, text: str, *, max_chars: int) -> tuple[str, list[str]]:
+        reasons: list[str] = []
+        sanitized = text[:max_chars]
+        if len(text) > max_chars:
+            reasons.append("truncated")
+        for pattern, reason in _SECRET_PATTERNS:
+            sanitized, count = pattern.subn("[REDACTED]", sanitized)
+            if count:
+                reasons.append(reason)
+        return sanitized, sorted(set(reasons))
+
+    def _context_result(
+        self,
+        *,
+        item: AttachmentContextItem,
+        index: int,
+        status: AttachmentContextStatus,
+        storage_policy: AttachmentContextStoragePolicy,
+        privacy_class: AttachmentContextPrivacyClass,
+        accepted_bytes: int = 0,
+        redacted: bool = False,
+        redaction_reasons: list[str] | None = None,
+        reason_code: str | None = None,
+        message: str = "",
+    ) -> AttachmentContextItemResult:
+        return AttachmentContextItemResult(
+            item_id=f"context-{index}-{uuid4().hex[:12]}",
+            kind=item.kind,
+            status=status,
+            storage_policy=storage_policy,
+            privacy_class=privacy_class,
+            accepted_bytes=accepted_bytes,
+            redacted=redacted,
+            redaction_reasons=redaction_reasons or [],
+            reason_code=reason_code,
+            message=message,
+        )
+
+    def _context_response(
+        self,
+        *,
+        data: AttachmentContextIngestRequest,
+        accepted_items: list[AttachmentContextItemResult],
+        rejected_items: list[AttachmentContextItemResult],
+        total_bytes: int,
+        correlation_id: str,
+    ) -> AttachmentContextIngestResponse:
+        return AttachmentContextIngestResponse(
+            accepted=bool(accepted_items),
+            rejected=bool(rejected_items),
+            total_items=len(data.items),
+            accepted_items=accepted_items,
+            rejected_items=rejected_items,
+            total_bytes=total_bytes,
+            storage_policy=data.storage_policy,
+            privacy_class=data.privacy_class,
+            correlation_id=correlation_id,
+            secrets_redacted=True,
+        )
+
+    async def _store_context_in_rag(
+        self,
+        *,
+        data: AttachmentContextIngestRequest,
+        item: AttachmentContextItem,
+        item_id: str,
+        text: str,
+        redacted: bool,
+        redaction_reasons: list[str],
+        correlation_id: str,
+    ) -> str:
+        stored_key = item_id
+        value = {
+            "text": text,
+            "kind": item.kind,
+            "title": item.title,
+            "filename": item.filename,
+            "url": item.url,
+            "mime_type": item.mime_type,
+            "privacy_class": data.privacy_class,
+            "source": item.source.model_dump(exclude_none=True),
+            "metadata": item.metadata,
+            "redacted": redacted,
+            "redaction_reasons": redaction_reasons,
+            "policy_decision_id": data.policy_decision_id,
+            "correlation_id": correlation_id,
+            "schema_version": "assistant-context.v1",
+        }
+        await self.bus.request(
+            DBMethods.RAG_STORE,
+            DBRAGStoreRequest(
+                key=stored_key,
+                value=json.dumps(value, sort_keys=True),
+                namespace=data.namespace,
+            ),
+            timeout=10.0,
+            origin="internal",
+            principal_id=data.caller_principal_id,
+            correlation_id=correlation_id,
+        )
+        return stored_key
+
+    async def _audit_context_ingestion(
+        self,
+        data: AttachmentContextIngestRequest,
+        response: AttachmentContextIngestResponse,
+    ) -> None:
+        details = {
+            "session_id": data.session_id,
+            "namespace": data.namespace,
+            "storage_policy": data.storage_policy,
+            "privacy_class": data.privacy_class,
+            "policy_decision_id": data.policy_decision_id,
+            "correlation_id": response.correlation_id,
+            "total_items": response.total_items,
+            "accepted_count": len(response.accepted_items),
+            "rejected_count": len(response.rejected_items),
+            "total_bytes": response.total_bytes,
+            "redacted_count": sum(1 for item in response.accepted_items if item.redacted),
+            "rejection_codes": [
+                item.reason_code for item in response.rejected_items if item.reason_code
+            ],
+        }
+        try:
+            await self.bus.request(
+                AuthMethods.STORE_AUDIT_EVENT,
+                StoreAuditEventRequest(
+                    event=response.audit_event,
+                    principal_id=data.caller_principal_id,
+                    details=json.dumps(details, sort_keys=True),
+                ),
+                timeout=5.0,
+                origin="internal",
+                principal_id=data.caller_principal_id,
+                correlation_id=response.correlation_id,
+            )
+        except Exception as e:
+            log_error(f"Failed to audit context ingestion: {e}", exc_info=True)
 
 
 def _utc_now() -> str:

--- a/app/services/orchestrator/service.py
+++ b/app/services/orchestrator/service.py
@@ -16,6 +16,7 @@ import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 from uuid import uuid4
 
 from app.helpers.aurora_logger import log_debug, log_error, log_info
@@ -71,6 +72,10 @@ _SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"(?i)bearer\s+[a-z0-9._~+/=-]{16,}"), "bearer_token"),
     (re.compile(r"\b(?:sk|pk)-[A-Za-z0-9_-]{16,}\b"), "api_key"),
 )
+_SENSITIVE_METADATA_KEY_PATTERN = re.compile(
+    r"(?i)(api[_-]?key|auth|authorization|bearer|cookie|credential|password|secret|signature|token)"
+)
+_URI_IN_TEXT_PATTERN = re.compile(r"\b[a-z][a-z0-9+.-]*://[^\s'\"]+", re.IGNORECASE)
 
 
 # Service implementation
@@ -371,7 +376,7 @@ class OrchestratorService(BaseService):
             )
 
             if data.storage_policy == "rag":
-                stored_key = await self._store_context_in_rag(
+                stored_key, final_redaction_reasons = await self._store_context_in_rag(
                     data=data,
                     item=item,
                     item_id=result.item_id,
@@ -383,6 +388,8 @@ class OrchestratorService(BaseService):
                 result.status = "stored"
                 result.stored_namespace = data.namespace
                 result.stored_key = stored_key
+                result.redaction_reasons = final_redaction_reasons
+                result.redacted = bool(final_redaction_reasons)
 
             accepted_items.append(result)
 
@@ -870,7 +877,128 @@ class OrchestratorService(BaseService):
             sanitized, count = pattern.subn("[REDACTED]", sanitized)
             if count:
                 reasons.append(reason)
+        uri_reasons: list[str] = []
+
+        def sanitize_uri_match(match: re.Match[str]) -> str:
+            sanitized_uri, match_reasons = self._sanitize_context_uri(match.group(0))
+            uri_reasons.extend(f"embedded_{reason}" for reason in match_reasons)
+            return sanitized_uri or "[REDACTED]"
+
+        sanitized = _URI_IN_TEXT_PATTERN.sub(sanitize_uri_match, sanitized)
+        reasons.extend(uri_reasons)
         return sanitized, sorted(set(reasons))
+
+    def _sanitize_context_scalar(self, value: str | None) -> tuple[str | None, list[str]]:
+        if value is None:
+            return None, []
+        sanitized, reasons = self._sanitize_context_text(value, max_chars=len(value))
+        return sanitized, reasons
+
+    def _sanitize_context_uri(self, uri: str | None) -> tuple[str | None, list[str]]:
+        if not uri:
+            return uri, []
+
+        reasons: list[str] = []
+        parsed = urlsplit(uri)
+        if parsed.scheme in {"http", "https"} and parsed.netloc:
+            netloc = parsed.hostname or ""
+            if parsed.port is not None:
+                netloc = f"{netloc}:{parsed.port}"
+            origin = urlunsplit((parsed.scheme, netloc, "", "", ""))
+            if parsed.username or parsed.password:
+                reasons.append("uri_credentials")
+            if parsed.query:
+                reasons.append("uri_query")
+            if parsed.fragment:
+                reasons.append("uri_fragment")
+            path_reasons = self._sanitize_context_text(
+                parsed.path,
+                max_chars=len(parsed.path),
+            )[1]
+            if path_reasons:
+                reasons.extend(f"uri_{reason}" for reason in path_reasons)
+            if reasons:
+                return f"{origin}/[REDACTED]", sorted(set(reasons))
+            return urlunsplit((parsed.scheme, netloc, parsed.path, "", "")), []
+
+        if parsed.scheme == "file" or uri.startswith(("/", "~")) or "\\" in uri:
+            return "[REDACTED_PATH]", ["local_path"]
+
+        if parsed.scheme:
+            return f"{parsed.scheme}://[REDACTED]", ["uri_provenance"]
+
+        sanitized, scalar_reasons = self._sanitize_context_scalar(uri)
+        return sanitized, scalar_reasons
+
+    def _sanitize_context_metadata(self, value: Any) -> tuple[Any, list[str]]:
+        reasons: list[str] = []
+        if isinstance(value, dict):
+            sanitized: dict[str, Any] = {}
+            for raw_key, raw_value in value.items():
+                key = str(raw_key)
+                if _SENSITIVE_METADATA_KEY_PATTERN.search(key):
+                    reasons.append("metadata_key")
+                    continue
+                sanitized_value, value_reasons = self._sanitize_context_metadata(raw_value)
+                reasons.extend(value_reasons)
+                sanitized[key] = sanitized_value
+            return sanitized, sorted(set(reasons))
+        if isinstance(value, list):
+            sanitized_items: list[Any] = []
+            for item in value:
+                sanitized_item, item_reasons = self._sanitize_context_metadata(item)
+                reasons.extend(item_reasons)
+                sanitized_items.append(sanitized_item)
+            return sanitized_items, sorted(set(reasons))
+        if isinstance(value, str):
+            if "://" in value or value.startswith(("/", "~")) or "\\" in value:
+                sanitized_uri, uri_reasons = self._sanitize_context_uri(value)
+                return sanitized_uri, uri_reasons
+            sanitized_scalar, scalar_reasons = self._sanitize_context_scalar(value)
+            return sanitized_scalar, scalar_reasons
+        return value, []
+
+    def _context_rag_value(
+        self,
+        *,
+        data: AttachmentContextIngestRequest,
+        item: AttachmentContextItem,
+        text: str,
+        redacted: bool,
+        redaction_reasons: list[str],
+        correlation_id: str,
+    ) -> tuple[dict[str, Any], list[str]]:
+        storage_reasons: list[str] = []
+        title, title_reasons = self._sanitize_context_scalar(item.title)
+        filename, filename_reasons = self._sanitize_context_uri(item.filename)
+        url, url_reasons = self._sanitize_context_uri(item.url)
+        source, source_reasons = self._sanitize_context_metadata(
+            item.source.model_dump(exclude_none=True)
+        )
+        metadata, metadata_reasons = self._sanitize_context_metadata(item.metadata)
+        storage_reasons.extend(f"title_{reason}" for reason in title_reasons)
+        storage_reasons.extend(f"filename_{reason}" for reason in filename_reasons)
+        storage_reasons.extend(f"url_{reason}" for reason in url_reasons)
+        storage_reasons.extend(f"source_{reason}" for reason in source_reasons)
+        storage_reasons.extend(f"metadata_{reason}" for reason in metadata_reasons)
+        final_reasons = sorted(set(redaction_reasons + storage_reasons))
+        value = {
+            "text": text,
+            "kind": item.kind,
+            "title": title,
+            "filename": filename,
+            "url": url,
+            "mime_type": item.mime_type,
+            "privacy_class": data.privacy_class,
+            "source": source,
+            "metadata": metadata,
+            "redacted": redacted or bool(storage_reasons),
+            "redaction_reasons": final_reasons,
+            "policy_decision_id": data.policy_decision_id,
+            "correlation_id": correlation_id,
+            "schema_version": "assistant-context.v1",
+        }
+        return value, final_reasons
 
     def _context_result(
         self,
@@ -931,24 +1059,16 @@ class OrchestratorService(BaseService):
         redacted: bool,
         redaction_reasons: list[str],
         correlation_id: str,
-    ) -> str:
+    ) -> tuple[str, list[str]]:
         stored_key = item_id
-        value = {
-            "text": text,
-            "kind": item.kind,
-            "title": item.title,
-            "filename": item.filename,
-            "url": item.url,
-            "mime_type": item.mime_type,
-            "privacy_class": data.privacy_class,
-            "source": item.source.model_dump(exclude_none=True),
-            "metadata": item.metadata,
-            "redacted": redacted,
-            "redaction_reasons": redaction_reasons,
-            "policy_decision_id": data.policy_decision_id,
-            "correlation_id": correlation_id,
-            "schema_version": "assistant-context.v1",
-        }
+        value, final_redaction_reasons = self._context_rag_value(
+            data=data,
+            item=item,
+            text=text,
+            redacted=redacted,
+            redaction_reasons=redaction_reasons,
+            correlation_id=correlation_id,
+        )
         await self.bus.request(
             DBMethods.RAG_STORE,
             DBRAGStoreRequest(
@@ -961,7 +1081,7 @@ class OrchestratorService(BaseService):
             principal_id=data.caller_principal_id,
             correlation_id=correlation_id,
         )
-        return stored_key
+        return stored_key, final_redaction_reasons
 
     async def _audit_context_ingestion(
         self,

--- a/app/services/orchestrator/tool_bindings.py
+++ b/app/services/orchestrator/tool_bindings.py
@@ -31,9 +31,7 @@ def build_tool_bindings(
             continue
 
         try:
-            bindable_name = _unique_tool_name(
-                str(schema.get("name") or "unknown_tool"), bindings
-            )
+            bindable_name = _unique_tool_name(str(schema.get("name") or "unknown_tool"), bindings)
             tool = _structured_tool_from_schema(schema, bindable_name)
             tools.append(tool)
             bindings[bindable_name] = _execution_binding(schema, bindable_name)
@@ -82,29 +80,30 @@ def _is_safe_to_bind(schema: dict[str, Any]) -> bool:
     return safety_class == "standard" and not confirmation_required
 
 
-def _requires_approval_interrupt(
-    schema: dict[str, Any], blocked_metadata: dict[str, Any]
-) -> bool:
+def _requires_approval_interrupt(schema: dict[str, Any], blocked_metadata: dict[str, Any]) -> bool:
     """Return whether a blocked catalog tool should surface as an approval card."""
 
     safety_class = schema.get("safety_class") or "standard"
     reason_code = blocked_metadata.get("reason_code")
-    return bool(schema.get("confirmation_required")) or safety_class in {
-        "sensitive",
-        "dangerous",
-    } or reason_code in {
-        "confirmation_required",
-        "safety_class_sensitive",
-        "safety_class_dangerous",
-        "approval_required",
-    }
+    return (
+        bool(schema.get("confirmation_required"))
+        or safety_class
+        in {
+            "sensitive",
+            "dangerous",
+        }
+        or reason_code
+        in {
+            "confirmation_required",
+            "safety_class_sensitive",
+            "safety_class_dangerous",
+            "approval_required",
+        }
+    )
 
 
 def _is_remote_tool(schema: dict[str, Any]) -> bool:
-    return (
-        schema.get("execution_location") == "remote"
-        or schema.get("source_type") == "mesh_peer"
-    )
+    return schema.get("execution_location") == "remote" or schema.get("source_type") == "mesh_peer"
 
 
 def _unique_tool_name(candidate: str, existing: dict[str, ToolBinding]) -> str:
@@ -119,9 +118,7 @@ def _unique_tool_name(candidate: str, existing: dict[str, ToolBinding]) -> str:
     return f"{candidate}_{suffix}"
 
 
-def _structured_tool_from_schema(
-    schema: dict[str, Any], bindable_name: str
-) -> StructuredTool:
+def _structured_tool_from_schema(schema: dict[str, Any], bindable_name: str) -> StructuredTool:
     args_schema = _args_model_from_json_schema(
         bindable_name, schema.get("args_schema") or schema.get("schema") or {}
     )
@@ -161,16 +158,10 @@ def _args_model_from_json_schema(bindable_name: str, args_schema: dict[str, Any]
         field_description = field_info.get("description", "")
 
         if field_name in required_fields:
-            field_default = (
-                Field(..., description=field_description)
-                if field_description
-                else ...
-            )
+            field_default = Field(..., description=field_description) if field_description else ...
         else:
             field_default = (
-                Field(default=None, description=field_description)
-                if field_description
-                else None
+                Field(default=None, description=field_description) if field_description else None
             )
         field_defs[field_name] = (field_type, field_default)
 

--- a/app/services/stt_transcription/service.py
+++ b/app/services/stt_transcription/service.py
@@ -748,7 +748,9 @@ class TranscriptionService(BaseService):
                 status="denied",
                 payload={"reason": "consent_token_required"},
             )
-            raise PermissionError("Transcription.ProcessAudio requires an audio session consent token")
+            raise PermissionError(
+                "Transcription.ProcessAudio requires an audio session consent token"
+            )
 
         self._validate_streaming_audio_sample(chunk)
         result = await self.bus.request(

--- a/app/services/tooling/service.py
+++ b/app/services/tooling/service.py
@@ -433,9 +433,7 @@ class ToolingService(BaseService):
             "mesh_data_scope": mesh_selector.get("data_scope"),
             "mesh_tool_id": mesh_selector.get("tool_id"),
         }
-        serialized = json.dumps(
-            selector_fields, sort_keys=True, default=str, separators=(",", ":")
-        )
+        serialized = json.dumps(selector_fields, sort_keys=True, default=str, separators=(",", ":"))
         return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
     @classmethod
@@ -748,7 +746,7 @@ class ToolingService(BaseService):
                         reason_code=block_reason[0],
                         reason=block_reason[1],
                     )
-            )
+                )
             return
         tools.append(tool)
 
@@ -812,9 +810,7 @@ class ToolingService(BaseService):
     def _tool_admin(tool: Any, operation_class: str) -> bool:
         return bool(getattr(tool, "admin", False)) or operation_class == "admin"
 
-    def _tool_privacy_hints(
-        self, tool: Any, safety_class: str, operation_class: str
-    ) -> list[str]:
+    def _tool_privacy_hints(self, tool: Any, safety_class: str, operation_class: str) -> list[str]:
         raw_hints = getattr(tool, "privacy_hints", None)
         hints: list[str] = []
         if isinstance(raw_hints, (list, tuple, set)):
@@ -918,9 +914,7 @@ class ToolingService(BaseService):
 
     @staticmethod
     def _policy_rule_matches(rule: ToolingSharingPolicyRule, context: dict[str, Any]) -> bool:
-        rule_fields = rule.model_dump(
-            exclude={"share", "approval_mode", "token_ttl_seconds"}
-        )
+        rule_fields = rule.model_dump(exclude={"share", "approval_mode", "token_ttl_seconds"})
         for field_name, rule_value in rule_fields.items():
             if field_name == "rule_id" or rule_value is None:
                 continue

--- a/app/shared/contracts/models/gateway.py
+++ b/app/shared/contracts/models/gateway.py
@@ -541,9 +541,7 @@ class GatewaySupportBundleResponse(IOModel):
     services: list[ServiceInfo] = Field(default_factory=list)
     service_health: list[GetServiceHealthResponse] = Field(default_factory=list)
     mesh_status: GetMeshStatusResponse = Field(default_factory=GetMeshStatusResponse)
-    webrtc_diagnostics: WebRTCDiagnosticsResponse = Field(
-        default_factory=WebRTCDiagnosticsResponse
-    )
+    webrtc_diagnostics: WebRTCDiagnosticsResponse = Field(default_factory=WebRTCDiagnosticsResponse)
     route_diagnostics: list[MeshRouteDiagnostic] = Field(default_factory=list)
     capability_catalog_summary: CapabilityCatalogSummary = Field(
         default_factory=CapabilityCatalogSummary

--- a/app/shared/contracts/models/orchestrator.py
+++ b/app/shared/contracts/models/orchestrator.py
@@ -20,6 +20,7 @@ class OrchestratorMethods:
 
     USER_INPUT = f"{OrchestratorModule.NAME}.UserInput"
     EXTERNAL_USER_INPUT = f"{OrchestratorModule.NAME}.ExternalUserInput"
+    INGEST_CONTEXT = f"{OrchestratorModule.NAME}.IngestContext"
     TOOL_RESULT = f"{OrchestratorModule.NAME}.ToolResult"
     INTERRUPT = f"{OrchestratorModule.NAME}.Interrupt"
     RESPONSE = f"{OrchestratorModule.NAME}.Response"
@@ -61,6 +62,118 @@ class OrchestratorResponse(IOModel):
     text: str
     session_id: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+AttachmentContextKind = Literal["text", "url", "file", "image"]
+AttachmentContextPrivacyClass = Literal[
+    "public",
+    "personal",
+    "sensitive",
+    "secret",
+    "credential",
+    "raw-audio",
+]
+AttachmentContextSourceChannel = Literal[
+    "chat",
+    "api",
+    "desktop",
+    "mobile_share_sheet",
+    "deep_link",
+    "browser_extension",
+]
+AttachmentContextStoragePolicy = Literal["ephemeral", "rag", "reject"]
+AttachmentContextStatus = Literal[
+    "accepted",
+    "stored",
+    "rejected",
+    "redacted",
+    "unsupported",
+]
+
+
+class AttachmentContextLimits(IOModel):
+    """Client-visible limits for assistant attachment/context ingestion."""
+
+    max_items: int = 8
+    max_item_bytes: int = 262_144
+    max_total_bytes: int = 1_048_576
+    max_text_chars: int = 120_000
+
+
+class AttachmentContextSource(IOModel):
+    """Redacted provenance for context shared into an assistant session."""
+
+    channel: AttachmentContextSourceChannel = "api"
+    display_name: str | None = None
+    uri: str | None = None
+    mime_type: str | None = None
+    platform: str | None = None
+    originating_app: str | None = None
+    shared_at: str | None = None
+    principal_id: str | None = None
+    device_id: str | None = None
+    peer_id: str | None = None
+
+
+class AttachmentContextItem(IOModel):
+    """One text-like attachment or shared context item for assistant ingestion."""
+
+    kind: AttachmentContextKind
+    content_text: str | None = None
+    url: str | None = None
+    title: str | None = None
+    filename: str | None = None
+    mime_type: str | None = None
+    size_bytes: int | None = None
+    source: AttachmentContextSource = Field(default_factory=AttachmentContextSource)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AttachmentContextIngestRequest(IOModel):
+    """Request to ingest redacted attachment/context metadata for assistant use."""
+
+    items: list[AttachmentContextItem] = Field(default_factory=list)
+    session_id: str | None = None
+    namespace: str = "assistant.attachments"
+    storage_policy: AttachmentContextStoragePolicy = "ephemeral"
+    privacy_class: AttachmentContextPrivacyClass = "personal"
+    caller_principal_id: str | None = None
+    correlation_id: str | None = None
+    policy_decision_id: str | None = None
+    limits: AttachmentContextLimits = Field(default_factory=AttachmentContextLimits)
+
+
+class AttachmentContextItemResult(IOModel):
+    """Per-item ingestion outcome without echoing raw attachment content."""
+
+    item_id: str
+    kind: AttachmentContextKind
+    status: AttachmentContextStatus
+    storage_policy: AttachmentContextStoragePolicy
+    privacy_class: AttachmentContextPrivacyClass
+    accepted_bytes: int = 0
+    stored_namespace: str | None = None
+    stored_key: str | None = None
+    redacted: bool = False
+    redaction_reasons: list[str] = Field(default_factory=list)
+    reason_code: str | None = None
+    message: str = ""
+
+
+class AttachmentContextIngestResponse(IOModel):
+    """Summary returned after context ingestion and audit recording."""
+
+    accepted: bool
+    rejected: bool
+    total_items: int
+    accepted_items: list[AttachmentContextItemResult] = Field(default_factory=list)
+    rejected_items: list[AttachmentContextItemResult] = Field(default_factory=list)
+    total_bytes: int = 0
+    storage_policy: AttachmentContextStoragePolicy
+    privacy_class: AttachmentContextPrivacyClass
+    audit_event: str = "assistant.context.ingested"
+    correlation_id: str | None = None
+    secrets_redacted: bool = True
 
 
 class OrchestratorToolResultRequest(IOModel):

--- a/app/shared/mesh/tracing.py
+++ b/app/shared/mesh/tracing.py
@@ -51,10 +51,7 @@ def redacted_copy(value: Any) -> Any:
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="json")
     if isinstance(value, dict):
-        return {
-            str(key): _redact_value(str(key), nested)
-            for key, nested in value.items()
-        }
+        return {str(key): _redact_value(str(key), nested) for key, nested in value.items()}
     if isinstance(value, list | tuple):
         return [redacted_copy(item) for item in value]
     return value

--- a/scripts/generate_backend_inventory.py
+++ b/scripts/generate_backend_inventory.py
@@ -45,8 +45,7 @@ SERVICE_CLASSES: tuple[tuple[str, str, str], ...] = (
 )
 
 SERVICE_SOURCES: tuple[Path, ...] = tuple(
-    REPO_ROOT / (module_path.replace(".", "/") + ".py")
-    for _, module_path, _ in SERVICE_CLASSES
+    REPO_ROOT / (module_path.replace(".", "/") + ".py") for _, module_path, _ in SERVICE_CLASSES
 )
 
 STATIC_ONLY_SERVICES = {"Config"}

--- a/tests/e2e/test_mesh_gap_e2e_harness.py
+++ b/tests/e2e/test_mesh_gap_e2e_harness.py
@@ -165,7 +165,9 @@ def test_mesh_gap_harness_uses_executable_component_paths(tmp_path):
             mode_id="process_bullmq_redis",
             status="pass",
             assertion=scenario.assertion,
-            evidence={"transport_path": "BullMQBus.request->Redis->BullMQBus.worker->BullMQBus.reply"},
+            evidence={
+                "transport_path": "BullMQBus.request->Redis->BullMQBus.worker->BullMQBus.reply"
+            },
             correlation_id=f"process_bullmq_redis-{scenario.scenario_id}",
         )
         for scenario in SCENARIOS

--- a/tests/integration/test_mesh_chaos_failure_modes.py
+++ b/tests/integration/test_mesh_chaos_failure_modes.py
@@ -147,9 +147,7 @@ class TestMeshChaosFallbacks:
         mesh_config: MeshConfig,
     ) -> None:
         await _register_peer(peer_registry, "orchestrator-peer", ["Orchestrator"])
-        bridge = ScriptedPeerBridge(
-            {"orchestrator-peer": [ConnectionError("data channel closed")]}
-        )
+        bridge = ScriptedPeerBridge({"orchestrator-peer": [ConnectionError("data channel closed")]})
         mesh_bus = MeshBus(inner_bus, routing_table, bridge, mesh_config)
 
         result = await mesh_bus.request(OrchestratorMethods.USER_INPUT, ChaosPayload())

--- a/tests/unit/gateway/test_auth_service.py
+++ b/tests/unit/gateway/test_auth_service.py
@@ -448,8 +448,7 @@ async def test_pairing_approve_deny_and_exchange_publish_lifecycle_events(auth_s
     assert denied_entry["denied_reason"] == "not recognized"
 
     audit_events = [
-        call.args[1].event
-        for call in _bus_calls(auth_service.bus, AuthMethods.STORE_AUDIT_EVENT)
+        call.args[1].event for call in _bus_calls(auth_service.bus, AuthMethods.STORE_AUDIT_EVENT)
     ]
     assert "auth.pairing.approved" in audit_events
     assert "auth.pairing.denied" in audit_events

--- a/tests/unit/gateway/test_capability_catalog.py
+++ b/tests/unit/gateway/test_capability_catalog.py
@@ -520,9 +520,7 @@ def test_gateway_service_registers_capability_catalog_and_explain_contracts():
     assert AudioSessionMethods.LIST_EVENTS in audio_methods
     assert methods[GatewayMethods.GET_CAPABILITY_CATALOG].exposure == "external"
     assert methods[GatewayMethods.GET_CAPABILITY_CATALOG].method_type == "manage"
-    assert audio_methods[AudioSessionMethods.PREPARE].required_perms == [
-        "AudioSession.manage"
-    ]
+    assert audio_methods[AudioSessionMethods.PREPARE].required_perms == ["AudioSession.manage"]
     assert methods[GatewayMethods.EXPLAIN_ROUTE].required_perms == ["Gateway.manage"]
     clear_registry()
 

--- a/tests/unit/gateway/test_capability_graph.py
+++ b/tests/unit/gateway/test_capability_graph.py
@@ -243,11 +243,7 @@ def test_capability_graph_classifies_audio_boundaries():
         local_peer_id="local-peer",
     )
 
-    methods = {
-        method.bus_topic: method
-        for service in graph.services
-        for method in service.methods
-    }
+    methods = {method.bus_topic: method for service in graph.services for method in service.methods}
 
     synthesize = methods[TTSMethods.SYNTHESIZE]
     assert synthesize.policy.safety_class == "standard"

--- a/tests/unit/gateway/test_mesh_observability.py
+++ b/tests/unit/gateway/test_mesh_observability.py
@@ -57,9 +57,7 @@ def test_gateway_observability_contracts_are_registered():
     assert methods[GatewayMethods.GET_REGISTRY].required_perms == ["Gateway.manage"]
     assert methods[GatewayMethods.GET_DEPLOYMENT_TOPOLOGY].required_perms == ["Gateway.manage"]
     assert methods[GatewayMethods.GET_WEBRTC_DIAGNOSTICS].method_type == "manage"
-    assert methods[GatewayMethods.GET_WEBRTC_DIAGNOSTICS].required_perms == [
-        "Gateway.manage"
-    ]
+    assert methods[GatewayMethods.GET_WEBRTC_DIAGNOSTICS].required_perms == ["Gateway.manage"]
     clear_registry()
 
 
@@ -159,7 +157,9 @@ async def test_deployment_topology_reports_process_mode_and_redacts_redis_url():
     assert "bullmq_queue_lag_unknown" in response.mode_capability_degradations
     assert "process_registry_stale" in response.mode_capability_degradations
     assert response.container_topology_hints.gateway_service == "gateway-service"
-    auth_topology = next(item for item in response.service_process_topology if item.module == "Auth")
+    auth_topology = next(
+        item for item in response.service_process_topology if item.module == "Auth"
+    )
     assert auth_topology.container_hint == "auth-service"
     assert auth_topology.stale is True
 

--- a/tests/unit/gateway/test_mesh_observability.py
+++ b/tests/unit/gateway/test_mesh_observability.py
@@ -349,7 +349,7 @@ def test_pairing_lifecycle_event_stream_omits_raw_pairing_code():
     assert event.category == "pairing"
     assert "code_sha256" in event.redacted_payload
     assert raw_code not in dumped
-    assert "code\": " not in dumped
+    assert 'code": ' not in dumped
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gateway/test_peer_registry.py
+++ b/tests/unit/gateway/test_peer_registry.py
@@ -477,8 +477,8 @@ class TestStaleDetection:
         await registry.register_peer("peer-1")
         await registry.update_manifest("peer-1", _make_manifest("peer-1", ["TTS"]))
         state = registry.get_peer("peer-1")
-        # Set last_ping far in the past
-        state.last_ping = time.monotonic() - 200
+        # Set last_ping beyond this registry's stale threshold.
+        state.last_ping = time.monotonic() - registry._config.stale_peer_timeout_s - 1.0
 
         await registry._check_stale_peers()
         assert registry.get_peer("peer-1").status == "stale"

--- a/tests/unit/gateway/test_route_generator_adminaction.py
+++ b/tests/unit/gateway/test_route_generator_adminaction.py
@@ -27,7 +27,11 @@ from app.shared.contracts.models.auth import (
     PasswordChangeRequest,
     PasswordChangeResponse,
 )
-from app.shared.contracts.models.backup import BackupCreateRequest, BackupCreateResponse, BackupMethods
+from app.shared.contracts.models.backup import (
+    BackupCreateRequest,
+    BackupCreateResponse,
+    BackupMethods,
+)
 from app.shared.contracts.models.common import EmptyInput
 from app.shared.contracts.models.config import (
     ConfigMethods,

--- a/tests/unit/gateway/test_route_generator_adminaction.py
+++ b/tests/unit/gateway/test_route_generator_adminaction.py
@@ -229,9 +229,7 @@ async def test_generated_config_set_requires_admin_action_headers(generated_rout
 
 @pytest.mark.asyncio
 async def test_generated_config_rollback_requires_admin_action_headers(generated_route_app):
-    app, router, generator, bus, _manager = generated_route_app(
-        "Config", _config_rollback_method()
-    )
+    app, router, generator, bus, _manager = generated_route_app("Config", _config_rollback_method())
     await _start_app(app, router, generator)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/tests/unit/gateway/test_rtc_client_auth.py
+++ b/tests/unit/gateway/test_rtc_client_auth.py
@@ -267,7 +267,6 @@ async def test_rtc_client_default_token_not_used_when_peer_tokens_exist(mock_dep
         assert "unknown-session-peer" in client._pairing_tasks
 
 
-
 @pytest.mark.asyncio
 async def test_rtc_client_manifest_uses_stable_local_identity(mock_deps):
     """Manifest exchange exposes stable local mesh identity."""

--- a/tests/unit/orchestrator/test_context_ingestion_contracts.py
+++ b/tests/unit/orchestrator/test_context_ingestion_contracts.py
@@ -67,7 +67,9 @@ async def test_ingest_context_redacts_and_stores_text_in_rag():
     assert response.accepted_items[0].redacted is True
     assert "credential" in response.accepted_items[0].redaction_reasons
 
-    rag_call = next(call for call in bus.request.await_args_list if call.args[0] == DBMethods.RAG_STORE)
+    rag_call = next(
+        call for call in bus.request.await_args_list if call.args[0] == DBMethods.RAG_STORE
+    )
     rag_request = rag_call.args[1]
     stored = json.loads(rag_request.value)
     assert rag_request.namespace == "assistant.attachments"
@@ -76,7 +78,9 @@ async def test_ingest_context_redacts_and_stores_text_in_rag():
     assert stored["source"]["channel"] == "api"
 
     audit_call = next(
-        call for call in bus.request.await_args_list if call.args[0] == AuthMethods.STORE_AUDIT_EVENT
+        call
+        for call in bus.request.await_args_list
+        if call.args[0] == AuthMethods.STORE_AUDIT_EVENT
     )
     audit_request = audit_call.args[1]
     audit_details = json.loads(audit_request.details)
@@ -106,7 +110,9 @@ async def test_ingest_context_rejects_oversized_item_without_rag_store():
     assert response.rejected is True
     assert response.rejected_items[0].reason_code == "item_too_large"
     assert all(call.args[0] != DBMethods.RAG_STORE for call in bus.request.await_args_list)
-    assert any(call.args[0] == AuthMethods.STORE_AUDIT_EVENT for call in bus.request.await_args_list)
+    assert any(
+        call.args[0] == AuthMethods.STORE_AUDIT_EVENT for call in bus.request.await_args_list
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_context_ingestion_contracts.py
+++ b/tests/unit/orchestrator/test_context_ingestion_contracts.py
@@ -3,31 +3,23 @@
 from __future__ import annotations
 
 import json
-import sys
-from types import ModuleType
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-graph_module = ModuleType("app.services.orchestrator.graph")
-graph_module.GraphOrchestrator = MagicMock()
-graph_module.set_orchestrator = MagicMock()
-sys.modules["app.services.orchestrator.graph"] = graph_module
-
-from app.services.orchestrator.service import OrchestratorService  # noqa: E402
-from app.shared.contracts.models.auth import AuthMethods  # noqa: E402
-from app.shared.contracts.models.db import DBMethods  # noqa: E402
-from app.shared.contracts.models.orchestrator import (  # noqa: E402
+from app.services.orchestrator.service import OrchestratorService
+from app.shared.contracts.models.auth import AuthMethods
+from app.shared.contracts.models.db import DBMethods
+from app.shared.contracts.models.orchestrator import (
     AttachmentContextIngestRequest,
     AttachmentContextItem,
     OrchestratorMethods,
 )
-from app.shared.contracts.registry import all_contracts, clear_registry  # noqa: E402
+from app.shared.contracts.registry import all_contracts, clear_registry
 
 
 def _service_with_bus(bus: AsyncMock) -> OrchestratorService:
-    with patch("app.shared.services.base_service.get_bus_singleton", return_value=bus):
-        service = OrchestratorService()
+    service = OrchestratorService()
     service._bus = bus
     return service
 
@@ -49,23 +41,24 @@ async def test_ingest_context_redacts_and_stores_text_in_rag():
     bus.request = AsyncMock(return_value=None)
     service = _service_with_bus(bus)
 
-    response = await service.ingest_context(
-        AttachmentContextIngestRequest(
-            storage_policy="rag",
-            privacy_class="personal",
-            caller_principal_id="user-1",
-            correlation_id="corr-1",
-            policy_decision_id="policy-1",
-            items=[
-                AttachmentContextItem(
-                    kind="text",
-                    title="Notes",
-                    content_text="Keep this. api_key=sk-secret-value",
-                    metadata={"source": "unit"},
-                )
-            ],
+    with patch("app.shared.services.base_service.get_bus_singleton", return_value=bus):
+        response = await service.ingest_context(
+            AttachmentContextIngestRequest(
+                storage_policy="rag",
+                privacy_class="personal",
+                caller_principal_id="user-1",
+                correlation_id="corr-1",
+                policy_decision_id="policy-1",
+                items=[
+                    AttachmentContextItem(
+                        kind="text",
+                        title="Notes",
+                        content_text="Keep this. api_key=sk-secret-value",
+                        metadata={"source": "unit"},
+                    )
+                ],
+            )
         )
-    )
 
     assert response.accepted is True
     assert response.rejected is False
@@ -100,13 +93,14 @@ async def test_ingest_context_rejects_oversized_item_without_rag_store():
     bus.request = AsyncMock(return_value=None)
     service = _service_with_bus(bus)
 
-    response = await service.ingest_context(
-        AttachmentContextIngestRequest(
-            storage_policy="rag",
-            limits={"max_item_bytes": 4},
-            items=[AttachmentContextItem(kind="text", content_text="too large")],
+    with patch("app.shared.services.base_service.get_bus_singleton", return_value=bus):
+        response = await service.ingest_context(
+            AttachmentContextIngestRequest(
+                storage_policy="rag",
+                limits={"max_item_bytes": 4},
+                items=[AttachmentContextItem(kind="text", content_text="too large")],
+            )
         )
-    )
 
     assert response.accepted is False
     assert response.rejected is True
@@ -121,13 +115,14 @@ async def test_ingest_context_blocks_secret_privacy_class():
     bus.request = AsyncMock(return_value=None)
     service = _service_with_bus(bus)
 
-    response = await service.ingest_context(
-        AttachmentContextIngestRequest(
-            storage_policy="ephemeral",
-            privacy_class="credential",
-            items=[AttachmentContextItem(kind="text", content_text="password=secret")],
+    with patch("app.shared.services.base_service.get_bus_singleton", return_value=bus):
+        response = await service.ingest_context(
+            AttachmentContextIngestRequest(
+                storage_policy="ephemeral",
+                privacy_class="credential",
+                items=[AttachmentContextItem(kind="text", content_text="password=secret")],
+            )
         )
-    )
 
     assert response.accepted is False
     assert response.rejected_items[0].reason_code == "privacy_class_blocked"

--- a/tests/unit/orchestrator/test_context_ingestion_contracts.py
+++ b/tests/unit/orchestrator/test_context_ingestion_contracts.py
@@ -1,0 +1,134 @@
+"""Assistant attachment/context ingestion contract tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+graph_module = ModuleType("app.services.orchestrator.graph")
+graph_module.GraphOrchestrator = MagicMock()
+graph_module.set_orchestrator = MagicMock()
+sys.modules["app.services.orchestrator.graph"] = graph_module
+
+from app.services.orchestrator.service import OrchestratorService  # noqa: E402
+from app.shared.contracts.models.auth import AuthMethods  # noqa: E402
+from app.shared.contracts.models.db import DBMethods  # noqa: E402
+from app.shared.contracts.models.orchestrator import (  # noqa: E402
+    AttachmentContextIngestRequest,
+    AttachmentContextItem,
+    OrchestratorMethods,
+)
+from app.shared.contracts.registry import all_contracts, clear_registry  # noqa: E402
+
+
+def _service_with_bus(bus: AsyncMock) -> OrchestratorService:
+    with patch("app.shared.services.base_service.get_bus_singleton", return_value=bus):
+        service = OrchestratorService()
+    service._bus = bus
+    return service
+
+
+def test_ingest_context_contract_registers_external_use_permission():
+    clear_registry()
+    OrchestratorService()
+
+    contract = all_contracts()[OrchestratorMethods.INGEST_CONTEXT]
+    assert contract.exposure == "external"
+    assert contract.method_type == "use"
+    assert contract.required_perms == ["Orchestrator.use"]
+    assert contract.input_model is AttachmentContextIngestRequest
+
+
+@pytest.mark.asyncio
+async def test_ingest_context_redacts_and_stores_text_in_rag():
+    bus = AsyncMock()
+    bus.request = AsyncMock(return_value=None)
+    service = _service_with_bus(bus)
+
+    response = await service.ingest_context(
+        AttachmentContextIngestRequest(
+            storage_policy="rag",
+            privacy_class="personal",
+            caller_principal_id="user-1",
+            correlation_id="corr-1",
+            policy_decision_id="policy-1",
+            items=[
+                AttachmentContextItem(
+                    kind="text",
+                    title="Notes",
+                    content_text="Keep this. api_key=sk-secret-value",
+                    metadata={"source": "unit"},
+                )
+            ],
+        )
+    )
+
+    assert response.accepted is True
+    assert response.rejected is False
+    assert response.correlation_id == "corr-1"
+    assert response.accepted_items[0].status == "stored"
+    assert response.accepted_items[0].redacted is True
+    assert "credential" in response.accepted_items[0].redaction_reasons
+
+    rag_call = next(call for call in bus.request.await_args_list if call.args[0] == DBMethods.RAG_STORE)
+    rag_request = rag_call.args[1]
+    stored = json.loads(rag_request.value)
+    assert rag_request.namespace == "assistant.attachments"
+    assert stored["text"] == "Keep this. [REDACTED]"
+    assert stored["policy_decision_id"] == "policy-1"
+    assert stored["source"]["channel"] == "api"
+
+    audit_call = next(
+        call for call in bus.request.await_args_list if call.args[0] == AuthMethods.STORE_AUDIT_EVENT
+    )
+    audit_request = audit_call.args[1]
+    audit_details = json.loads(audit_request.details)
+    assert audit_request.event == "assistant.context.ingested"
+    assert audit_request.principal_id == "user-1"
+    assert audit_details["accepted_count"] == 1
+    assert audit_details["redacted_count"] == 1
+    assert "sk-secret-value" not in audit_request.details
+
+
+@pytest.mark.asyncio
+async def test_ingest_context_rejects_oversized_item_without_rag_store():
+    bus = AsyncMock()
+    bus.request = AsyncMock(return_value=None)
+    service = _service_with_bus(bus)
+
+    response = await service.ingest_context(
+        AttachmentContextIngestRequest(
+            storage_policy="rag",
+            limits={"max_item_bytes": 4},
+            items=[AttachmentContextItem(kind="text", content_text="too large")],
+        )
+    )
+
+    assert response.accepted is False
+    assert response.rejected is True
+    assert response.rejected_items[0].reason_code == "item_too_large"
+    assert all(call.args[0] != DBMethods.RAG_STORE for call in bus.request.await_args_list)
+    assert any(call.args[0] == AuthMethods.STORE_AUDIT_EVENT for call in bus.request.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_ingest_context_blocks_secret_privacy_class():
+    bus = AsyncMock()
+    bus.request = AsyncMock(return_value=None)
+    service = _service_with_bus(bus)
+
+    response = await service.ingest_context(
+        AttachmentContextIngestRequest(
+            storage_policy="ephemeral",
+            privacy_class="credential",
+            items=[AttachmentContextItem(kind="text", content_text="password=secret")],
+        )
+    )
+
+    assert response.accepted is False
+    assert response.rejected_items[0].reason_code == "privacy_class_blocked"
+    assert all(call.args[0] != DBMethods.RAG_STORE for call in bus.request.await_args_list)

--- a/tests/unit/orchestrator/test_context_ingestion_contracts.py
+++ b/tests/unit/orchestrator/test_context_ingestion_contracts.py
@@ -13,6 +13,7 @@ from app.shared.contracts.models.db import DBMethods
 from app.shared.contracts.models.orchestrator import (
     AttachmentContextIngestRequest,
     AttachmentContextItem,
+    AttachmentContextSource,
     OrchestratorMethods,
 )
 from app.shared.contracts.registry import all_contracts, clear_registry
@@ -89,6 +90,83 @@ async def test_ingest_context_redacts_and_stores_text_in_rag():
     assert audit_details["accepted_count"] == 1
     assert audit_details["redacted_count"] == 1
     assert "sk-secret-value" not in audit_request.details
+
+
+@pytest.mark.asyncio
+async def test_ingest_context_redacts_persisted_provenance_and_metadata():
+    bus = AsyncMock()
+    bus.request = AsyncMock(return_value=None)
+    service = _service_with_bus(bus)
+
+    with patch("app.shared.services.base_service.get_bus_singleton", return_value=bus):
+        response = await service.ingest_context(
+            AttachmentContextIngestRequest(
+                storage_policy="rag",
+                privacy_class="sensitive",
+                caller_principal_id="user-1",
+                correlation_id="corr-2",
+                items=[
+                    AttachmentContextItem(
+                        kind="url",
+                        title="Shared password=title-secret",
+                        filename="/Users/alice/private/token-file.txt",
+                        url=(
+                            "https://user:pass@example.com/shared/doc"
+                            "?access_token=url-secret&expires=never#frag"
+                        ),
+                        source=AttachmentContextSource(
+                            channel="mobile_share_sheet",
+                            uri="myapp://share/open?token=source-secret",
+                            display_name="Display token=display-secret",
+                            originating_app="Bearer abcdefghijklmnop",
+                        ),
+                        metadata={
+                            "safe_label": "kept",
+                            "api_key": "metadata-key-secret",
+                            "callback_url": "https://callback.example/cb?token=metadata-url-secret",
+                            "notes": ["password=list-secret"],
+                            "nested": {"safe": "secret=nested-secret"},
+                        },
+                    )
+                ],
+            )
+        )
+
+    assert response.accepted is True
+    assert response.accepted_items[0].redacted is True
+    assert "url_uri_credentials" in response.accepted_items[0].redaction_reasons
+    assert "metadata_metadata_key" in response.accepted_items[0].redaction_reasons
+
+    rag_call = next(
+        call for call in bus.request.await_args_list if call.args[0] == DBMethods.RAG_STORE
+    )
+    stored = json.loads(rag_call.args[1].value)
+    stored_json = json.dumps(stored, sort_keys=True)
+
+    assert stored["url"] == "https://example.com/[REDACTED]"
+    assert stored["source"]["channel"] == "mobile_share_sheet"
+    assert stored["source"]["uri"] == "myapp://[REDACTED]"
+    assert stored["metadata"]["safe_label"] == "kept"
+    assert "api_key" not in stored["metadata"]
+    assert stored["metadata"]["callback_url"] == "https://callback.example/[REDACTED]"
+    assert stored["metadata"]["notes"] == ["[REDACTED]"]
+    assert stored["metadata"]["nested"]["safe"] == "[REDACTED]"
+
+    for raw_secret in (
+        "title-secret",
+        "token-file",
+        "url-secret",
+        "source-secret",
+        "display-secret",
+        "abcdefghijklmnop",
+        "metadata-key-secret",
+        "metadata-url-secret",
+        "list-secret",
+        "nested-secret",
+        "user:pass",
+        "/Users/alice",
+    ):
+        assert raw_secret not in stored_json
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_model_runtime_contracts.py
+++ b/tests/unit/orchestrator/test_model_runtime_contracts.py
@@ -74,15 +74,11 @@ def test_model_runtime_contracts_register_with_permissions():
 
     assert contracts[OrchestratorMethods.GET_MODEL_CATALOG].exposure == "external"
     assert contracts[OrchestratorMethods.GET_MODEL_CATALOG].method_type == "use"
-    assert contracts[OrchestratorMethods.GET_MODEL_CATALOG].required_perms == [
-        "Orchestrator.use"
-    ]
+    assert contracts[OrchestratorMethods.GET_MODEL_CATALOG].required_perms == ["Orchestrator.use"]
 
     assert contracts[OrchestratorMethods.IMPORT_MODEL].exposure == "external"
     assert contracts[OrchestratorMethods.IMPORT_MODEL].method_type == "manage"
-    assert contracts[OrchestratorMethods.IMPORT_MODEL].required_perms == [
-        "Orchestrator.manage"
-    ]
+    assert contracts[OrchestratorMethods.IMPORT_MODEL].required_perms == ["Orchestrator.manage"]
     assert contracts[OrchestratorMethods.DOWNLOAD_MODEL].method_type == "manage"
     assert contracts[OrchestratorMethods.BENCHMARK_MODEL].method_type == "manage"
 

--- a/tests/unit/orchestrator/test_model_runtime_contracts.py
+++ b/tests/unit/orchestrator/test_model_runtime_contracts.py
@@ -2,20 +2,13 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-from types import ModuleType
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-graph_module = ModuleType("app.services.orchestrator.graph")
-graph_module.GraphOrchestrator = MagicMock()
-graph_module.set_orchestrator = MagicMock()
-sys.modules["app.services.orchestrator.graph"] = graph_module
-
-from app.services.orchestrator.service import OrchestratorService  # noqa: E402
-from app.shared.contracts.models.orchestrator import (  # noqa: E402
+from app.services.orchestrator.service import OrchestratorService
+from app.shared.contracts.models.orchestrator import (
     ModelRuntimeCatalogRequest,
     ModelRuntimeOperationRequest,
     ModelRuntimeOperationStatusRequest,

--- a/tests/unit/orchestrator/test_service.py
+++ b/tests/unit/orchestrator/test_service.py
@@ -391,9 +391,7 @@ class TestOrchestratorInterruptHandling:
         assert mock_bus.publish.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_interrupt_tool_call_reports_no_separate_active_work(
-        self, orchestrator_service
-    ):
+    async def test_interrupt_tool_call_reports_no_separate_active_work(self, orchestrator_service):
         from app.shared.contracts.models.orchestrator import OrchestratorInterruptRequest
 
         response = await orchestrator_service.interrupt_assistant(

--- a/tests/unit/services/test_backup_service.py
+++ b/tests/unit/services/test_backup_service.py
@@ -9,7 +9,6 @@ import pytest
 from app.messaging.bus import QueryResult
 from app.services.backup import BackupService
 from app.services.config.messages import GetConfigQuery
-from app.shared.contracts.registry import list_modules
 from app.shared.contracts.models.backup import (
     BackupCreateRequest,
     BackupListRequest,
@@ -22,6 +21,7 @@ from app.shared.contracts.models.backup import (
 )
 from app.shared.contracts.models.config import ConfigMethods
 from app.shared.contracts.models.db import DBMethods, DBRAGListNamespacesResponse
+from app.shared.contracts.registry import list_modules
 from app.shared.messaging.bus_init import set_bus
 
 

--- a/tests/unit/tooling/test_service.py
+++ b/tests/unit/tooling/test_service.py
@@ -1099,9 +1099,7 @@ class TestToolingSharingPolicyAndApproval:
         mock_tool.ainvoke.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_raw_confirmed_does_not_bypass_approval_token(
-        self, tooling_service, mock_bus
-    ):
+    async def test_raw_confirmed_does_not_bypass_approval_token(self, tooling_service, mock_bus):
         """Raw confirmed=true is denied for approval-required remote tools."""
         from app.shared.contracts.models.tooling import (
             ToolingExecuteToolRequest,
@@ -1230,9 +1228,7 @@ class TestToolingSharingPolicyAndApproval:
         assert response.error_code == expected_error
 
     @pytest.mark.asyncio
-    async def test_token_resource_mismatch_and_expiry_are_denied(
-        self, tooling_service, mock_bus
-    ):
+    async def test_token_resource_mismatch_and_expiry_are_denied(self, tooling_service, mock_bus):
         """Resource selector changes and expired tokens fail closed."""
         from app.shared.contracts.models.tooling import (
             ToolingRequestApprovalRequest,
@@ -1373,9 +1369,7 @@ class TestToolingSharingPolicyAndApproval:
         assert "tooling.execute" in event_names
 
     @pytest.mark.asyncio
-    async def test_config_loaded_policy_enforces_peer_scoped_rule(
-        self, tooling_service, mock_bus
-    ):
+    async def test_config_loaded_policy_enforces_peer_scoped_rule(self, tooling_service, mock_bus):
         """Schema-backed approval_policy loads into runtime sharing enforcement."""
         from app.shared.contracts.models.tooling import ToolingExecuteToolRequest
 


### PR DESCRIPTION
## Summary

- Add typed Orchestrator attachment/shared-context ingestion request and response models.
- Register `Orchestrator.IngestContext` as an external `use` contract requiring `Orchestrator.use`.
- Implement privacy-first ingestion with size limits, blocked sensitive classes, secret redaction, optional RAG storage through `DB.RAGStore`, and audit recording through `Auth.StoreAuditEvent`.
- Add focused contract/service tests and a PER-195 planning artifact.

## Validation

- `/home/developer/projects/aurora/.venv/bin/pytest tests/unit/orchestrator/test_context_ingestion_contracts.py -q` — 4 passed, 4 warnings
- `/home/developer/projects/aurora/.venv/bin/ruff check app/shared/contracts/models/orchestrator.py app/services/orchestrator/service.py tests/unit/orchestrator/test_context_ingestion_contracts.py` — passed
- `/home/developer/projects/aurora/.venv/bin/pytest tests/unit/orchestrator/test_model_runtime_contracts.py tests/unit/gateway/test_backend_inventory.py -q` — 10 passed, 25 warnings

## Notes

- Verification used the existing repository virtualenv at `/home/developer/projects/aurora/.venv` from an isolated BE-008 worktree.
- Test warnings are existing deprecations/user warnings unrelated to this change.
