### PR TITLE
PER-205: Add scheduler admin management contracts

### DIFF
--- a/app/services/scheduler/service.py
+++ b/app/services/scheduler/service.py
@@ -20,6 +20,8 @@ from app.shared.contracts.models.auth import AuthMethods, StoreAuditEventRequest
 from app.shared.contracts.models.common import EmptyOutput
 from app.shared.contracts.models.mesh import MeshAddressSelector
 from app.shared.contracts.models.scheduler import (
+    SchedulerActionResponse,
+    SchedulerActionSupport,
     SchedulerCancelJobRequest,
     SchedulerJobCompletedEvent,
     SchedulerJobFiredEvent,
@@ -41,6 +43,8 @@ _scheduler_service_instance: SchedulerService | None = None
 DEFAULT_SCHEDULER_NAMESPACE = "local"
 DEFAULT_SCHEDULER_OWNER_PEER = "local"
 DEFAULT_SCHEDULER_OWNER_PRINCIPAL = "system"
+DEFAULT_SCHEDULER_PRIVACY_CLASS = "sensitive"
+PAUSE_RESUME_UNSUPPORTED_REASON = "scheduler_pause_resume_unsupported"
 DELEGATED_APPROVAL_REQUIRED_REASON = "delegated_approval_token_required"
 DELEGATED_ORCHESTRATOR_EXECUTION_UNSUPPORTED_REASON = (
     "delegated_orchestrator_execution_boundary_unsupported"
@@ -141,11 +145,20 @@ class SchedulerService(BaseService):
             "correlation_id": cmd.correlation_id,
             "caller_peer_id": cmd.caller_peer_id,
             "caller_principal_id": cmd.caller_principal_id,
+            "timezone": cmd.timezone,
+            "source": cmd.source or "scheduler",
+            "privacy_class": cmd.privacy_class or DEFAULT_SCHEDULER_PRIVACY_CLASS,
             "blocked_reason": None,
         }
 
     def _request_scope(
-        self, cmd: SchedulerCancelJobRequest | SchedulerListJobsRequest
+        self,
+        cmd: (
+            SchedulerCancelJobRequest
+            | SchedulerListJobsRequest
+            | SchedulerPauseJobRequest
+            | SchedulerResumeJobRequest
+        ),
     ) -> dict[str, Any]:
         return {
             "namespace": cmd.namespace,
@@ -173,6 +186,9 @@ class SchedulerService(BaseService):
             "correlation_id": context.get("correlation_id"),
             "caller_peer_id": context.get("caller_peer_id"),
             "caller_principal_id": context.get("caller_principal_id"),
+            "timezone": context.get("timezone"),
+            "source": context.get("source") or "scheduler",
+            "privacy_class": context.get("privacy_class") or DEFAULT_SCHEDULER_PRIVACY_CLASS,
             "blocked_reason": context.get("blocked_reason"),
         }
 
@@ -228,6 +244,9 @@ class SchedulerService(BaseService):
             "policy_decision_id": context.get("policy_decision_id"),
             "correlation_id": context.get("correlation_id"),
             "delegated_permissions": context.get("delegated_permissions") or [],
+            "timezone": context.get("timezone"),
+            "source": context.get("source"),
+            "privacy_class": context.get("privacy_class") or DEFAULT_SCHEDULER_PRIVACY_CLASS,
             "delegated_approval_token_present": bool(context.get("delegated_approval_token")),
             "reason": reason,
         }
@@ -243,6 +262,28 @@ class SchedulerService(BaseService):
             )
         except Exception as exc:
             log_warning(f"Failed to write scheduler audit event {event}: {exc}")
+
+    def _action_support(self, job: Any) -> list[SchedulerActionSupport]:
+        """Return UI-visible action capability states for a scheduler job."""
+        actions = [SchedulerActionSupport(action="cancel", supported=True)]
+        if getattr(job, "is_active", False):
+            actions.extend(
+                [
+                    SchedulerActionSupport(
+                        action="pause",
+                        supported=False,
+                        status="unsupported",
+                        reason=PAUSE_RESUME_UNSUPPORTED_REASON,
+                    ),
+                    SchedulerActionSupport(
+                        action="resume",
+                        supported=False,
+                        status="unsupported",
+                        reason=PAUSE_RESUME_UNSUPPORTED_REASON,
+                    ),
+                ]
+            )
+        return actions
 
     async def on_start(self) -> None:
         """Start the scheduler service."""
@@ -280,6 +321,7 @@ class SchedulerService(BaseService):
         output_model=EmptyOutput,
         exposure="both",
         method_type="manage",
+        required_perms=[SchedulerMethods.SCHEDULE],
     )
     async def schedule_job(self, cmd: SchedulerScheduleJobRequest) -> EmptyOutput:
         """Handle schedule job command."""
@@ -372,6 +414,7 @@ class SchedulerService(BaseService):
         output_model=EmptyOutput,
         exposure="both",
         method_type="manage",
+        required_perms=[SchedulerMethods.CANCEL],
     )
     async def cancel_job(self, cmd: SchedulerCancelJobRequest) -> EmptyOutput:
         """Handle cancel job command."""
@@ -436,81 +479,125 @@ class SchedulerService(BaseService):
         method_id=SchedulerMethods.PAUSE,
         summary="Pause a scheduled job",
         input_model=SchedulerPauseJobRequest,
-        output_model=EmptyOutput,
-        exposure="internal",
+        output_model=SchedulerActionResponse,
+        exposure="both",
         method_type="manage",
+        required_perms=[SchedulerMethods.PAUSE],
     )
-    async def pause_job(self, cmd: SchedulerPauseJobRequest) -> EmptyOutput:
-        """Handle pause job command."""
+    async def pause_job(self, cmd: SchedulerPauseJobRequest) -> SchedulerActionResponse:
+        """Return an audited unsupported response for pause semantics."""
+        job_id_str = str(cmd.job_id)
         try:
-            log_info(f"Pausing job: {cmd.job_id}")
+            log_info(f"Pause requested for job: {cmd.job_id}")
+            job = await self.cron_service.get_job(job_id_str)
+            context = self._job_context(job) if job else self._request_scope(cmd)
+            scope = self._request_scope(cmd)
+            if job and not self._scope_allows_job(context, scope):
+                await self._audit_scheduler_event(
+                    "scheduler.pause.denied",
+                    context,
+                    status="denied",
+                    job_id=job_id_str,
+                    reason="owner_scope_mismatch",
+                )
+                return SchedulerActionResponse(
+                    ok=False,
+                    status="denied",
+                    job_id=job_id_str,
+                    action="pause",
+                    reason="owner_scope_mismatch",
+                    audit_event="scheduler.pause.denied",
+                )
 
-            # Pause job via CronService
-            job_id_str = str(cmd.job_id)
-            success = await self.cron_service.pause_job(job_id_str)
-
-            if success:
-                log_debug(f"Job {cmd.job_id} paused successfully")
-            else:
-                log_warning(f"Failed to pause job {cmd.job_id}")
-
-            return EmptyOutput()
+            reason = "job_not_found" if job is None else PAUSE_RESUME_UNSUPPORTED_REASON
+            event = "scheduler.pause.denied" if job is None else "scheduler.pause.unsupported"
+            await self._audit_scheduler_event(
+                event,
+                context,
+                status="unsupported" if job else "denied",
+                job_id=job_id_str,
+                reason=reason,
+            )
+            return SchedulerActionResponse(
+                ok=False,
+                status="unsupported" if job else "not_found",
+                job_id=job_id_str,
+                action="pause",
+                reason=reason,
+                audit_event=event,
+            )
 
         except Exception as e:
             log_error(f"Error pausing job: {e}", exc_info=True)
-            return EmptyOutput()
+            return SchedulerActionResponse(
+                ok=False,
+                status="failed",
+                job_id=job_id_str,
+                action="pause",
+                reason=str(e),
+            )
 
     @method_contract(
         method_id=SchedulerMethods.RESUME,
         summary="Resume a paused job",
         input_model=SchedulerResumeJobRequest,
-        output_model=EmptyOutput,
-        exposure="internal",
+        output_model=SchedulerActionResponse,
+        exposure="both",
         method_type="manage",
+        required_perms=[SchedulerMethods.RESUME],
     )
-    async def resume_job(self, cmd: SchedulerResumeJobRequest) -> EmptyOutput:
-        """Handle resume job command."""
+    async def resume_job(self, cmd: SchedulerResumeJobRequest) -> SchedulerActionResponse:
+        """Return an audited unsupported response for resume semantics."""
+        job_id_str = str(cmd.job_id)
         try:
-            log_info(f"Resuming job: {cmd.job_id}")
-
-            # Resume job via CronService (unpause)
-            # Note: CronService doesn't have explicit resume, but we can
-            # cancel the paused job and reschedule it
-            job_id_str = str(cmd.job_id)
-
-            # Get the job from tracking
-            if job_id_str in self._jobs:
-                original_cmd = self._jobs[job_id_str]
-
-                # Cancel the paused job
-                await self.cron_service.cancel_job(job_id_str)
-
-                # Reschedule it (effectively resuming)
-                new_job_id = await self.cron_service.schedule_from_text(
-                    text=original_cmd.schedule,
-                    callback="app.scheduler.service.fire_scheduled_job",
-                    job_name=original_cmd.name,
-                    callback_args={
-                        "job_name": original_cmd.name,
-                        "action": original_cmd.action,
-                    },
+            log_info(f"Resume requested for job: {cmd.job_id}")
+            job = await self.cron_service.get_job(job_id_str)
+            context = self._job_context(job) if job else self._request_scope(cmd)
+            scope = self._request_scope(cmd)
+            if job and not self._scope_allows_job(context, scope):
+                await self._audit_scheduler_event(
+                    "scheduler.resume.denied",
+                    context,
+                    status="denied",
+                    job_id=job_id_str,
+                    reason="owner_scope_mismatch",
+                )
+                return SchedulerActionResponse(
+                    ok=False,
+                    status="denied",
+                    job_id=job_id_str,
+                    action="resume",
+                    reason="owner_scope_mismatch",
+                    audit_event="scheduler.resume.denied",
                 )
 
-                if new_job_id:
-                    # Update tracking with new job_id
-                    self._jobs.pop(job_id_str, None)
-                    self._jobs[new_job_id] = original_cmd
-                    log_debug(f"Job {cmd.job_id} resumed successfully with new ID: {new_job_id}")
-                else:
-                    log_warning(f"Failed to resume job {cmd.job_id}")
-            else:
-                log_warning(f"Job {cmd.job_id} not found in tracking")
-
-            return EmptyOutput()
+            reason = "job_not_found" if job is None else PAUSE_RESUME_UNSUPPORTED_REASON
+            event = "scheduler.resume.denied" if job is None else "scheduler.resume.unsupported"
+            await self._audit_scheduler_event(
+                event,
+                context,
+                status="unsupported" if job else "denied",
+                job_id=job_id_str,
+                reason=reason,
+            )
+            return SchedulerActionResponse(
+                ok=False,
+                status="unsupported" if job else "not_found",
+                job_id=job_id_str,
+                action="resume",
+                reason=reason,
+                audit_event=event,
+            )
 
         except Exception as e:
             log_error(f"Error resuming job: {e}", exc_info=True)
-            return EmptyOutput()
+            return SchedulerActionResponse(
+                ok=False,
+                status="failed",
+                job_id=job_id_str,
+                action="resume",
+                reason=str(e),
+            )
 
     @method_contract(
         method_id=SchedulerMethods.LIST_JOBS,
@@ -519,6 +606,7 @@ class SchedulerService(BaseService):
         output_model=SchedulerListJobsResponse,
         exposure="both",
         method_type="use",
+        required_perms=[SchedulerMethods.LIST_JOBS],
     )
     async def list_jobs(self, query: SchedulerListJobsRequest) -> SchedulerListJobsResponse:
         """List all scheduled jobs.
@@ -573,6 +661,19 @@ class SchedulerService(BaseService):
                     delegated_approval_token_present=bool(context.get("delegated_approval_token")),
                     correlation_id=context["correlation_id"],
                     blocked_reason=context.get("blocked_reason"),
+                    timezone=context.get("timezone"),
+                    source=context.get("source") or job.callback_module or "scheduler",
+                    failure_count=getattr(job, "retry_count", 0) or 0,
+                    privacy_class=context.get("privacy_class") or DEFAULT_SCHEDULER_PRIVACY_CLASS,
+                    last_error=(
+                        job.last_run_result
+                        if (
+                            (hasattr(job.status, "value") and job.status.value == "failed")
+                            or str(job.status) == "failed"
+                        )
+                        else None
+                    ),
+                    action_support=self._action_support(job),
                 )
                 job_infos.append(job_info)
 

--- a/app/shared/contracts/models/scheduler.py
+++ b/app/shared/contracts/models/scheduler.py
@@ -34,6 +34,9 @@ class SchedulerScheduleJobRequest(IOModel):
     schedule: str  # Cron expression
     action: str
     enabled: bool = True
+    timezone: str | None = None
+    source: str | None = None
+    privacy_class: str | None = None
     namespace: str | None = None
     owner_peer_id: str | None = None
     owner_principal_id: str | None = None
@@ -61,12 +64,22 @@ class SchedulerPauseJobRequest(IOModel):
     """Request to pause a scheduled job."""
 
     job_id: int | str
+    namespace: str | None = None
+    owner_peer_id: str | None = None
+    owner_principal_id: str | None = None
+    caller_peer_id: str | None = None
+    caller_principal_id: str | None = None
 
 
 class SchedulerResumeJobRequest(IOModel):
     """Request to resume a paused job."""
 
     job_id: int | str
+    namespace: str | None = None
+    owner_peer_id: str | None = None
+    owner_principal_id: str | None = None
+    caller_peer_id: str | None = None
+    caller_principal_id: str | None = None
 
 
 class SchedulerListJobsRequest(IOModel):
@@ -80,6 +93,26 @@ class SchedulerListJobsRequest(IOModel):
     owner_principal_id: str | None = None
     caller_peer_id: str | None = None
     caller_principal_id: str | None = None
+
+
+class SchedulerActionSupport(IOModel):
+    """Capability state for one scheduler job action."""
+
+    action: str
+    supported: bool
+    status: str = "supported"
+    reason: str | None = None
+
+
+class SchedulerActionResponse(IOModel):
+    """Response for scheduler job management actions."""
+
+    ok: bool
+    status: str
+    job_id: str
+    action: str
+    reason: str | None = None
+    audit_event: str | None = None
 
 
 class SchedulerJobInfo(IOModel):
@@ -103,6 +136,12 @@ class SchedulerJobInfo(IOModel):
     delegated_approval_token_present: bool = False
     correlation_id: str | None = None
     blocked_reason: str | None = None
+    timezone: str | None = None
+    source: str = "scheduler"
+    failure_count: int = 0
+    privacy_class: str = "sensitive"
+    last_error: str | None = None
+    action_support: list[SchedulerActionSupport] = Field(default_factory=list)
 
 
 class SchedulerListJobsResponse(IOModel):

--- a/docs/SERVICE_METHODS_REFERENCE.md
+++ b/docs/SERVICE_METHODS_REFERENCE.md
@@ -330,11 +330,11 @@ Job scheduling using cron expressions.
 
 | Method ID | Summary | Input | Output | Exposure |
 |-----------|---------|-------|--------|----------|
-| `Scheduler.Schedule` | Schedule a new job | `SchedulerScheduleJobRequest` | `EmptyOutput` | **both** |
-| `Scheduler.Cancel` | Cancel a job | `SchedulerCancelJobRequest` | `EmptyOutput` | **both** |
-| `Scheduler.Pause` | Pause a job | `SchedulerPauseJobRequest` | `EmptyOutput` | **internal** |
-| `Scheduler.Resume` | Resume a paused job | `SchedulerResumeJobRequest` | `EmptyOutput` | **internal** |
-| `Scheduler.ListJobs` | List all scheduled jobs | `SchedulerListJobsRequest` | `SchedulerListJobsResponse` | **both** |
+| `Scheduler.Schedule` | Schedule a new job | `SchedulerScheduleJobRequest` | `EmptyOutput` | **both, manage** |
+| `Scheduler.Cancel` | Cancel a job | `SchedulerCancelJobRequest` | `EmptyOutput` | **both, manage** |
+| `Scheduler.Pause` | Pause a job | `SchedulerPauseJobRequest` | `SchedulerActionResponse` | **both, manage, degraded** |
+| `Scheduler.Resume` | Resume a paused job | `SchedulerResumeJobRequest` | `SchedulerActionResponse` | **both, manage, degraded** |
+| `Scheduler.ListJobs` | List all scheduled jobs | `SchedulerListJobsRequest` | `SchedulerListJobsResponse` | **both, use** |
 
 ### Method Details
 
@@ -346,6 +346,9 @@ SchedulerScheduleJobRequest(
     schedule: str,                     # Cron expression (e.g., "0 9 * * *")
     action: str,                       # Action to execute
     enabled: bool = True,              # Whether job is active
+    timezone: str | None = None,       # UI/operator timezone when known
+    source: str | None = None,         # Originating surface, e.g. admin-ui
+    privacy_class: str | None = None,  # Defaults to sensitive when omitted
     namespace: str | None = None,      # Owner/resource namespace, defaults to local
     owner_peer_id: str | None = None,  # Peer that owns the job
     owner_principal_id: str | None = None,  # Principal that owns the job
@@ -380,11 +383,28 @@ SchedulerListJobsResponse(
 ```
 
 Remote scheduler calls are ownership-scoped. Mesh callers may only list or
-cancel jobs owned by their injected `caller_peer_id`/`caller_principal_id`;
-local callers can still list local jobs and may apply explicit filters.
-Scheduler jobs carry namespace, owner, target selector, delegated permissions,
-policy decision ID, and correlation ID through creation, listing, job-fired
-events, completion events, and audit records.
+cancel/pause/resume jobs owned by their injected `caller_peer_id`/
+`caller_principal_id`; local callers can still list local jobs and may apply
+explicit filters. Scheduler jobs carry namespace, owner, target selector,
+delegated permissions, policy decision ID, correlation ID, timezone, source,
+failure count, and privacy class where available through creation, listing,
+job-fired events, completion events, and audit records.
+
+`Scheduler.Schedule`, `Scheduler.Cancel`, `Scheduler.Pause`, and
+`Scheduler.Resume` are `method_type="manage"` contracts with specific
+permissions matching their method IDs. Generated Gateway routes require the
+AdminAction draft/confirm/audit envelope before forwarding these mutations.
+The Scheduler service also writes scheduler-specific Auth audit events for
+allowed, denied, blocked, unsupported, and failed management decisions.
+
+Pause/resume are intentionally exposed as degraded capability states until the
+CronService can guarantee safe pause and resume semantics without losing
+scheduler context. `Scheduler.ListJobs` returns `action_support` entries that
+mark `pause` and `resume` as `supported=False`, `status="unsupported"`, and
+`reason="scheduler_pause_resume_unsupported"`. Direct calls to
+`Scheduler.Pause` or `Scheduler.Resume` return `SchedulerActionResponse` with
+`ok=False` and audit `scheduler.pause.unsupported` or
+`scheduler.resume.unsupported` rather than silently mutating or recreating jobs.
 
 ---
 
@@ -710,6 +730,8 @@ These methods are exposed via HTTP POST at `/api/{service}/{method}`:
 | Orchestrator | ExternalUserInput | `POST /api/orchestrator/externaluserinput` |
 | Scheduler | Schedule | `POST /api/scheduler/schedule` |
 | Scheduler | Cancel | `POST /api/scheduler/cancel` |
+| Scheduler | Pause | `POST /api/scheduler/pause` |
+| Scheduler | Resume | `POST /api/scheduler/resume` |
 | Scheduler | ListJobs | `POST /api/scheduler/listjobs` |
 | DB | GetMessages | `POST /api/db/getmessages` |
 | DB | GetMessagesForDate | `POST /api/db/getmessagesfordate` |

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -14,6 +14,7 @@ import { describeRegistry, GATEWAY_METHODS, TOOLING_METHODS, routePath } from '.
 import { buildAdminOverviewManifest, buildCapabilityGraph, summarizeCapabilities } from './capabilities.js'
 import { buildPermissionCatalog, checkAccess, hasPermission, resolveEffectivePermissions } from './permissions.js'
 import { evaluateRoutePolicy } from './policy.js'
+import { SchedulerClient } from './scheduler.js'
 import type {
   AdminOverviewManifest,
   AdminOverviewManifestInput,
@@ -57,6 +58,7 @@ export class AuroraClient {
   readonly permissions: PermissionClient
   readonly routes: RouteClient
   readonly tools: ToolClient
+  readonly scheduler: SchedulerClient
   readonly admin: AdminActionClient
   readonly approvals: ApprovalClient
   readonly native: NativeClient
@@ -73,6 +75,7 @@ export class AuroraClient {
     this.permissions = new PermissionClient(this)
     this.routes = new RouteClient(this)
     this.tools = new ToolClient(this)
+    this.scheduler = new SchedulerClient(this)
     this.admin = new AdminActionClient(this)
     this.approvals = new ApprovalClient(this)
     this.native = new NativeClient(this)

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -1,5 +1,11 @@
 export { AuroraClient } from './client.js'
 export { AdminActionClient, ApprovalClient, adminActionAudit } from './admin.js'
+export {
+  SCHEDULER_METHODS,
+  SchedulerClient,
+  normalizeSchedulerActionSupport,
+  normalizeSchedulerJob
+} from './scheduler.js'
 export { HttpGatewayTransport } from './http.js'
 export { MeshP2PTransport } from './mesh.js'
 export { MockAuroraTransport } from './mock.js'
@@ -75,6 +81,7 @@ export {
 } from './fixtures.js'
 export type * from './types.js'
 export type * from './admin.js'
+export type * from './scheduler.js'
 export type * from './transport.js'
 export type {
   AuroraEventStreamKind,

--- a/packages/aurora-sdk/src/scheduler.ts
+++ b/packages/aurora-sdk/src/scheduler.ts
@@ -1,0 +1,183 @@
+import type { AuroraClient } from './client.js'
+import { routePath } from './descriptors.js'
+
+export const SCHEDULER_METHODS = {
+  listJobs: 'Scheduler.ListJobs',
+  schedule: 'Scheduler.Schedule',
+  cancel: 'Scheduler.Cancel',
+  pause: 'Scheduler.Pause',
+  resume: 'Scheduler.Resume'
+} as const
+
+export interface SchedulerScheduleJobRequest {
+  name: string
+  schedule: string
+  action: string
+  enabled?: boolean
+  timezone?: string | null
+  source?: string | null
+  privacy_class?: string | null
+  namespace?: string | null
+  owner_peer_id?: string | null
+  owner_principal_id?: string | null
+  target_selector?: Record<string, unknown> | null
+  delegated_permissions?: string[]
+  policy_decision_id?: string | null
+  delegated_approval_token?: string | null
+  correlation_id?: string | null
+  caller_peer_id?: string | null
+  caller_principal_id?: string | null
+}
+
+export interface SchedulerScopedJobRequest {
+  job_id: string | number
+  namespace?: string | null
+  owner_peer_id?: string | null
+  owner_principal_id?: string | null
+  caller_peer_id?: string | null
+  caller_principal_id?: string | null
+}
+
+export interface SchedulerListJobsRequest {
+  enabled_only?: boolean
+  limit?: number
+  offset?: number
+  namespace?: string | null
+  owner_peer_id?: string | null
+  owner_principal_id?: string | null
+  caller_peer_id?: string | null
+  caller_principal_id?: string | null
+}
+
+export interface SchedulerActionSupport {
+  action: string
+  supported: boolean
+  status: string
+  reason: string | null
+}
+
+export interface SchedulerActionResponse {
+  ok: boolean
+  status: string
+  job_id: string
+  action: string
+  reason: string | null
+  audit_event: string | null
+}
+
+export interface SchedulerJobInfo {
+  job_id: string
+  name: string
+  schedule: string
+  action: string
+  enabled: boolean
+  next_run: string | null
+  last_run: string | null
+  status: string | null
+  namespace: string
+  owner_peer_id: string
+  owner_principal_id: string
+  target_peer_id: string | null
+  target_resource_namespace: string | null
+  delegated_permissions: string[]
+  policy_decision_id: string | null
+  delegated_approval_token_present: boolean
+  correlation_id: string | null
+  blocked_reason: string | null
+  timezone: string | null
+  source: string
+  failure_count: number
+  privacy_class: string
+  last_error: string | null
+  action_support: SchedulerActionSupport[]
+}
+
+export interface SchedulerListJobsResponse {
+  jobs: SchedulerJobInfo[]
+  total: number
+}
+
+export interface NormalizedSchedulerAction {
+  action: string
+  supported: boolean
+  status: string
+  reason: string | null
+  disabled: boolean
+}
+
+export interface NormalizedSchedulerJob extends SchedulerJobInfo {
+  actions: Record<string, NormalizedSchedulerAction>
+}
+
+export function normalizeSchedulerActionSupport(
+  action: SchedulerActionSupport
+): NormalizedSchedulerAction {
+  return {
+    action: action.action,
+    supported: action.supported,
+    status: action.status,
+    reason: action.reason,
+    disabled: !action.supported || action.status !== 'supported'
+  }
+}
+
+export function normalizeSchedulerJob(job: SchedulerJobInfo): NormalizedSchedulerJob {
+  return {
+    ...job,
+    actions: Object.fromEntries(
+      job.action_support.map((action) => [
+        action.action,
+        normalizeSchedulerActionSupport(action)
+      ])
+    )
+  }
+}
+
+export class SchedulerClient {
+  constructor(private readonly client: AuroraClient) {}
+
+  listJobs(request: SchedulerListJobsRequest = {}): Promise<SchedulerListJobsResponse> {
+    return this.client.request<SchedulerListJobsResponse, SchedulerListJobsRequest>(
+      SCHEDULER_METHODS.listJobs,
+      request,
+      { path: routePath('Scheduler', 'ListJobs') }
+    )
+  }
+
+  async listNormalizedJobs(request: SchedulerListJobsRequest = {}): Promise<NormalizedSchedulerJob[]> {
+    const response = await this.listJobs(request)
+    return response.jobs.map(normalizeSchedulerJob)
+  }
+
+  schedule(payload: SchedulerScheduleJobRequest): Promise<unknown> {
+    return this.client.request<unknown, SchedulerScheduleJobRequest>(
+      SCHEDULER_METHODS.schedule,
+      payload,
+      { path: routePath('Scheduler', 'Schedule') }
+    )
+  }
+
+  cancel(payload: SchedulerScopedJobRequest): Promise<unknown> {
+    return this.client.request<unknown, SchedulerScopedJobRequest>(
+      SCHEDULER_METHODS.cancel,
+      payload,
+      { path: routePath('Scheduler', 'Cancel') }
+    )
+  }
+
+  pause(payload: SchedulerScopedJobRequest): Promise<SchedulerActionResponse> {
+    return this.client.request<SchedulerActionResponse, SchedulerScopedJobRequest>(
+      SCHEDULER_METHODS.pause,
+      payload,
+      { path: routePath('Scheduler', 'Pause') }
+    )
+  }
+
+  resume(payload: SchedulerScopedJobRequest): Promise<SchedulerActionResponse> {
+    return this.client.request<SchedulerActionResponse, SchedulerScopedJobRequest>(
+      SCHEDULER_METHODS.resume,
+      payload,
+      { path: routePath('Scheduler', 'Resume') }
+    )
+  }
+}

--- a/packages/aurora-sdk/tests/scheduler.test.ts
+++ b/packages/aurora-sdk/tests/scheduler.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AuroraClient,
+  MockAuroraTransport,
+  SCHEDULER_METHODS,
+  normalizeSchedulerActionSupport,
+  normalizeSchedulerJob,
+  type SchedulerJobInfo
+} from '../src/index.js'
+import type { AuroraTransportRequest } from '../src/transport.js'
+
+const schedulerJob: SchedulerJobInfo = {
+  job_id: 'job-1',
+  name: 'Morning summary',
+  schedule: '0 8 * * *',
+  action: 'Orchestrator.ProcessUserInput',
+  enabled: true,
+  next_run: '2026-06-22T08:00:00Z',
+  last_run: null,
+  status: 'scheduled',
+  namespace: 'home',
+  owner_peer_id: 'peer-local',
+  owner_principal_id: 'principal-admin',
+  target_peer_id: null,
+  target_resource_namespace: null,
+  delegated_permissions: ['Scheduler.use'],
+  policy_decision_id: 'policy-1',
+  delegated_approval_token_present: false,
+  correlation_id: 'corr-1',
+  blocked_reason: null,
+  timezone: 'America/New_York',
+  source: 'admin',
+  failure_count: 2,
+  privacy_class: 'sensitive',
+  last_error: 'last failure',
+  action_support: [
+    {
+      action: 'cancel',
+      supported: true,
+      status: 'supported',
+      reason: null
+    },
+    {
+      action: 'pause',
+      supported: false,
+      status: 'unsupported',
+      reason: 'scheduler_pause_resume_unsupported'
+    },
+    {
+      action: 'resume',
+      supported: false,
+      status: 'unsupported',
+      reason: 'scheduler_pause_resume_unsupported'
+    }
+  ]
+}
+
+describe('SchedulerClient', () => {
+  it('normalizes scheduler jobs and disabled admin actions', () => {
+    const normalized = normalizeSchedulerJob(schedulerJob)
+
+    expect(normalized.timezone).toBe('America/New_York')
+    expect(normalized.source).toBe('admin')
+    expect(normalized.failure_count).toBe(2)
+    expect(normalized.privacy_class).toBe('sensitive')
+    expect(normalized.last_error).toBe('last failure')
+    expect(normalized.actions.cancel).toEqual(
+      expect.objectContaining({
+        supported: true,
+        disabled: false
+      })
+    )
+    expect(normalized.actions.pause).toEqual(
+      expect.objectContaining({
+        supported: false,
+        disabled: true,
+        status: 'unsupported',
+        reason: 'scheduler_pause_resume_unsupported'
+      })
+    )
+  })
+
+  it('marks non-supported action status as disabled even when supported is true', () => {
+    expect(
+      normalizeSchedulerActionSupport({
+        action: 'pause',
+        supported: true,
+        status: 'degraded',
+        reason: 'pending_backend_support'
+      })
+    ).toEqual({
+      action: 'pause',
+      supported: true,
+      status: 'degraded',
+      reason: 'pending_backend_support',
+      disabled: true
+    })
+  })
+
+  it('lists normalized jobs through the Scheduler.ListJobs contract route', async () => {
+    const requests: AuroraTransportRequest[] = []
+    const transport = MockAuroraTransport.empty().register('Scheduler.ListJobs', (request) => {
+      requests.push(request)
+      return {
+        jobs: [schedulerJob],
+        total: 1
+      }
+    })
+    const client = new AuroraClient({ transport })
+
+    const jobs = await client.scheduler.listNormalizedJobs({
+      namespace: 'home',
+      caller_peer_id: 'peer-local',
+      caller_principal_id: 'principal-admin'
+    })
+
+    expect(requests).toEqual([
+      expect.objectContaining({
+        method: SCHEDULER_METHODS.listJobs,
+        busTopic: SCHEDULER_METHODS.listJobs,
+        path: '/api/Scheduler/ListJobs',
+        payload: expect.objectContaining({
+          namespace: 'home',
+          caller_peer_id: 'peer-local',
+          caller_principal_id: 'principal-admin'
+        })
+      })
+    ])
+    expect(jobs).toHaveLength(1)
+    expect(jobs[0]?.actions.pause).toEqual(
+      expect.objectContaining({
+        disabled: true
+      })
+    )
+    expect(jobs[0]?.actions.resume).toEqual(
+      expect.objectContaining({
+        reason: 'scheduler_pause_resume_unsupported'
+      })
+    )
+  })
+
+  it('calls degraded pause and resume management routes without hiding response status', async () => {
+    const requests: AuroraTransportRequest[] = []
+    const transport = MockAuroraTransport.empty()
+      .register('Scheduler.Pause', (request) => {
+        requests.push(request)
+        return {
+          ok: false,
+          status: 'unsupported',
+          job_id: 'job-1',
+          action: 'pause',
+          reason: 'scheduler_pause_resume_unsupported',
+          audit_event: 'scheduler.pause.unsupported'
+        }
+      })
+      .register('Scheduler.Resume', (request) => {
+        requests.push(request)
+        return {
+          ok: false,
+          status: 'unsupported',
+          job_id: 'job-1',
+          action: 'resume',
+          reason: 'scheduler_pause_resume_unsupported',
+          audit_event: 'scheduler.resume.unsupported'
+        }
+      })
+    const client = new AuroraClient({ transport })
+
+    await expect(
+      client.scheduler.pause({
+        job_id: 'job-1',
+        namespace: 'home',
+        caller_peer_id: 'peer-local',
+        caller_principal_id: 'principal-admin'
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        ok: false,
+        status: 'unsupported',
+        action: 'pause',
+        audit_event: 'scheduler.pause.unsupported'
+      })
+    )
+    await expect(
+      client.scheduler.resume({
+        job_id: 'job-1',
+        namespace: 'home',
+        caller_peer_id: 'peer-local',
+        caller_principal_id: 'principal-admin'
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        ok: false,
+        status: 'unsupported',
+        action: 'resume',
+        audit_event: 'scheduler.resume.unsupported'
+      })
+    )
+
+    expect(requests).toEqual([
+      expect.objectContaining({
+        method: SCHEDULER_METHODS.pause,
+        path: '/api/Scheduler/Pause',
+        payload: expect.objectContaining({ job_id: 'job-1', namespace: 'home' })
+      }),
+      expect.objectContaining({
+        method: SCHEDULER_METHODS.resume,
+        path: '/api/Scheduler/Resume',
+        payload: expect.objectContaining({ job_id: 'job-1', namespace: 'home' })
+      })
+    ])
+  })
+})

--- a/tests/unit/app/scheduler/test_scheduler_admin_contracts.py
+++ b/tests/unit/app/scheduler/test_scheduler_admin_contracts.py
@@ -1,0 +1,189 @@
+"""Scheduler admin contract and degraded-action tests."""
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.scheduler.service import (
+    PAUSE_RESUME_UNSUPPORTED_REASON,
+    SchedulerService,
+)
+from app.shared.contracts.models.scheduler import (
+    SchedulerActionResponse,
+    SchedulerCancelJobRequest,
+    SchedulerListJobsRequest,
+    SchedulerListJobsResponse,
+    SchedulerMethods,
+    SchedulerPauseJobRequest,
+    SchedulerResumeJobRequest,
+    SchedulerScheduleJobRequest,
+)
+from app.shared.messaging.bus_init import set_bus
+from app.shared.models.db import CronJob, JobStatus, ScheduleType
+
+
+def make_service() -> SchedulerService:
+    bus = AsyncMock()
+    bus.request = AsyncMock()
+    bus.publish = AsyncMock()
+    set_bus(bus)
+    service = SchedulerService()
+    service.cron_service = MagicMock()
+    return service
+
+
+def make_job(job_id: str = "job-1", *, status: JobStatus = JobStatus.PENDING) -> CronJob:
+    now = datetime.now()
+    return CronJob(
+        id=job_id,
+        name="nightly report",
+        schedule_type=ScheduleType.CRON,
+        schedule_value="0 2 * * *",
+        next_run_time=now + timedelta(hours=2),
+        last_run_time=now - timedelta(days=1),
+        last_run_result="previous failure" if status == JobStatus.FAILED else "ok",
+        callback_module="app.services.scheduler.service",
+        callback_function="fire_scheduled_job",
+        callback_args={
+            "action": "orchestrator:report",
+            "scheduler_context": {
+                "namespace": "ops",
+                "owner_peer_id": "local",
+                "owner_principal_id": "admin-1",
+                "timezone": "UTC",
+                "source": "admin-ui",
+                "privacy_class": "private",
+            },
+        },
+        status=status,
+        retry_count=2,
+        created_at=now - timedelta(days=2),
+        updated_at=now,
+    )
+
+
+def test_scheduler_admin_method_contracts_are_explicit():
+    assert SchedulerService.schedule_job._contract_metadata["required_perms"] == [
+        SchedulerMethods.SCHEDULE
+    ]
+    assert SchedulerService.cancel_job._contract_metadata["required_perms"] == [
+        SchedulerMethods.CANCEL
+    ]
+    assert SchedulerService.list_jobs._contract_metadata["required_perms"] == [
+        SchedulerMethods.LIST_JOBS
+    ]
+
+    pause_contract = SchedulerService.pause_job._contract_metadata
+    assert pause_contract["exposure"] == "both"
+    assert pause_contract["method_type"] == "manage"
+    assert pause_contract["required_perms"] == [SchedulerMethods.PAUSE]
+    assert pause_contract["output_model"] is SchedulerActionResponse
+
+    resume_contract = SchedulerService.resume_job._contract_metadata
+    assert resume_contract["exposure"] == "both"
+    assert resume_contract["method_type"] == "manage"
+    assert resume_contract["required_perms"] == [SchedulerMethods.RESUME]
+    assert resume_contract["output_model"] is SchedulerActionResponse
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_includes_admin_metadata_and_degraded_action_support():
+    service = make_service()
+    service.cron_service.get_all_jobs = AsyncMock(return_value=[make_job(status=JobStatus.FAILED)])
+
+    response = await service.list_jobs(SchedulerListJobsRequest(namespace="ops"))
+
+    assert isinstance(response, SchedulerListJobsResponse)
+    assert response.total == 1
+    job = response.jobs[0]
+    assert job.owner_principal_id == "admin-1"
+    assert job.timezone == "UTC"
+    assert job.source == "admin-ui"
+    assert job.privacy_class == "private"
+    assert job.failure_count == 2
+    assert job.last_error == "previous failure"
+
+    actions = {action.action: action for action in job.action_support}
+    assert actions["cancel"].supported is True
+    assert actions["pause"].supported is False
+    assert actions["pause"].status == "unsupported"
+    assert actions["pause"].reason == PAUSE_RESUME_UNSUPPORTED_REASON
+    assert actions["resume"].supported is False
+    assert actions["resume"].reason == PAUSE_RESUME_UNSUPPORTED_REASON
+
+
+@pytest.mark.asyncio
+async def test_pause_job_returns_unsupported_and_audits_without_mutating():
+    service = make_service()
+    service.cron_service.get_job = AsyncMock(return_value=make_job())
+    service.cron_service.pause_job = AsyncMock(return_value=True)
+
+    response = await service.pause_job(SchedulerPauseJobRequest(job_id="job-1"))
+
+    assert response.ok is False
+    assert response.status == "unsupported"
+    assert response.reason == PAUSE_RESUME_UNSUPPORTED_REASON
+    assert response.audit_event == "scheduler.pause.unsupported"
+    service.cron_service.pause_job.assert_not_called()
+
+    audit_request = service.bus.request.await_args.args[1]
+    details = json.loads(audit_request.details)
+    assert audit_request.event == "scheduler.pause.unsupported"
+    assert details["reason"] == PAUSE_RESUME_UNSUPPORTED_REASON
+    assert details["privacy_class"] == "private"
+
+
+@pytest.mark.asyncio
+async def test_resume_job_returns_unsupported_and_does_not_recreate_job():
+    service = make_service()
+    service.cron_service.get_job = AsyncMock(return_value=make_job())
+    service.cron_service.cancel_job = AsyncMock(return_value=True)
+    service.cron_service.schedule_from_text = AsyncMock(return_value="job-2")
+
+    response = await service.resume_job(SchedulerResumeJobRequest(job_id="job-1"))
+
+    assert response.ok is False
+    assert response.status == "unsupported"
+    assert response.reason == PAUSE_RESUME_UNSUPPORTED_REASON
+    assert response.audit_event == "scheduler.resume.unsupported"
+    service.cron_service.cancel_job.assert_not_called()
+    service.cron_service.schedule_from_text.assert_not_called()
+
+    audit_request = service.bus.request.await_args.args[1]
+    assert audit_request.event == "scheduler.resume.unsupported"
+
+
+@pytest.mark.asyncio
+async def test_pause_denies_remote_scope_mismatch_before_unsupported_state():
+    service = make_service()
+    service.cron_service.get_job = AsyncMock(return_value=make_job())
+
+    response = await service.pause_job(
+        SchedulerPauseJobRequest(job_id="job-1", caller_peer_id="other-peer")
+    )
+
+    assert response.ok is False
+    assert response.status == "denied"
+    assert response.reason == "owner_scope_mismatch"
+    assert response.audit_event == "scheduler.pause.denied"
+
+
+def test_scheduler_manage_requests_accept_admin_context_fields():
+    schedule = SchedulerScheduleJobRequest(
+        name="job",
+        schedule="0 2 * * *",
+        action="orchestrator:report",
+        timezone="UTC",
+        source="admin-ui",
+        privacy_class="private",
+    )
+    cancel = SchedulerCancelJobRequest(job_id="job-1", owner_principal_id="admin-1")
+    pause = SchedulerPauseJobRequest(job_id="job-1", owner_principal_id="admin-1")
+    resume = SchedulerResumeJobRequest(job_id="job-1", owner_principal_id="admin-1")
+
+    assert schedule.timezone == "UTC"
+    assert schedule.source == "admin-ui"
+    assert schedule.privacy_class == "private"
+    assert cancel.owner_principal_id == pause.owner_principal_id == resume.owner_principal_id


### PR DESCRIPTION
## Summary

- Exposes scheduler schedule/cancel/pause/resume/list contracts with explicit permissions, method types, and AdminAction-compatible manage metadata.
- Adds scheduler action status models so pause/resume are surfaced as audited unsupported/degraded actions instead of silently mutating jobs.
- Extends scheduler job metadata with timezone, source, failure count, privacy class, and last error fields for admin UI/SDK use.
- Adds `SchedulerClient`, scheduler SDK types, normalized action helpers, and focused Python/TypeScript tests.

## Validation

- `/home/developer/projects/aurora/.venv/bin/pytest --no-cov tests/unit/app/scheduler/test_scheduler_remote_policy.py tests/unit/app/scheduler/test_scheduler_admin_contracts.py -q` in clean PR worktree: 13 passed, 3 existing warnings.
- `/home/developer/projects/aurora/.venv/bin/pytest --no-cov tests/unit/gateway/test_route_generator_adminaction.py -q` in clean PR worktree: 9 passed, 3 existing warnings.
- `/home/developer/projects/aurora/.venv/bin/ruff check app/shared/contracts/models/scheduler.py app/services/scheduler/service.py tests/unit/app/scheduler/test_scheduler_admin_contracts.py` in clean PR worktree: passed.
- `pnpm --filter @aurora/client test -- scheduler.test.ts` in clean PR worktree: 3 files passed, 65 tests passed.
- `pnpm --filter @aurora/client typecheck` in clean PR worktree: passed.
- `pnpm --filter @aurora/client build` in clean PR worktree: passed.
- `git diff --check` in clean PR worktree: passed.

## Notes

Pause/resume remain intentionally unsupported until CronService can preserve scheduler context safely. Calls now return `SchedulerActionResponse` with explicit unsupported status and audit event names.
