### PR TITLE
BE-009: Add Orchestrator interrupt contract

### DIFF
--- a/app/services/orchestrator/service.py
+++ b/app/services/orchestrator/service.py
@@ -10,6 +10,7 @@ This service:
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -22,7 +23,8 @@ from app.messaging import (
 )
 from app.messaging.priority_helpers import get_interactive_priority
 from app.services.orchestrator.graph import GraphOrchestrator, set_orchestrator
-from app.shared.contracts.models.common import EmptyOutput
+from app.shared.config.interface import ConfigAPI
+from app.shared.contracts.models.common import EmptyInput, EmptyOutput
 from app.shared.contracts.models.orchestrator import (
     ModelRuntimeBenchmarkInfo,
     ModelRuntimeCatalogRequest,
@@ -35,6 +37,12 @@ from app.shared.contracts.models.orchestrator import (
     ModelRuntimeProviderInfo,
     ModelRuntimeRequest,
     ModelRuntimeResponse,
+    OrchestratorEvents,
+    OrchestratorInterruptedEvent,
+    OrchestratorInterruptRequest,
+    OrchestratorInterruptResponse,
+    OrchestratorInterruptScope,
+    OrchestratorInterruptScopeResult,
     OrchestratorMethods,
     OrchestratorModule,
     OrchestratorProcessRequest,
@@ -42,8 +50,8 @@ from app.shared.contracts.models.orchestrator import (
     OrchestratorToolResultRequest,
 )
 from app.shared.contracts.models.stt import STTMethods
+from app.shared.contracts.models.tts import TTSMethods, TTSRequest
 from app.shared.contracts.registry import method_contract
-from app.shared.config.interface import ConfigAPI
 from app.shared.messaging.models.stt_coordinator_models import STTUserSpeechCaptured
 from app.shared.services.base_service import BaseService
 
@@ -68,6 +76,8 @@ class OrchestratorService(BaseService):
         )
         self.orchestrator: GraphOrchestrator | None = None
         self._model_runtime_operations: dict[str, ModelRuntimeOperationResponse] = {}
+        self._generation_tasks: dict[asyncio.Task, str | None] = {}
+        self._generation_lock = asyncio.Lock()
 
     async def on_start(self) -> None:
         """Start the orchestrator service and subscribe to inputs."""
@@ -89,6 +99,7 @@ class OrchestratorService(BaseService):
         """Stop the orchestrator service."""
         log_info("Stopping Orchestrator service...")
         self.bus.unsubscribe(STTMethods.USER_SPEECH_CAPTURED, self._on_transcription)
+        await self._cancel_generation_tasks(session_id=None)
 
     async def reload(self, config_section: str | None = None) -> None:
         """Reload service configuration.
@@ -231,6 +242,128 @@ class OrchestratorService(BaseService):
         except Exception as e:
             log_error(f"Error processing tool result: {e}", exc_info=True)
             return EmptyOutput()
+
+    @method_contract(
+        method_id=OrchestratorMethods.INTERRUPT,
+        summary="Interrupt active assistant generation, tool work, TTS playback, or a session",
+        input_model=OrchestratorInterruptRequest,
+        output_model=OrchestratorInterruptResponse,
+        exposure="external",
+        method_type="use",
+        required_perms=["Orchestrator.use"],
+    )
+    async def interrupt_assistant(
+        self,
+        data: OrchestratorInterruptRequest,
+        envelope: Envelope | None = None,
+    ) -> OrchestratorInterruptResponse:
+        """Handle an idempotent assistant interrupt request."""
+        interrupt_id = f"interrupt-{uuid4().hex[:12]}"
+        scopes = _dedupe_scopes(data.scopes)
+        results: list[OrchestratorInterruptScopeResult] = []
+
+        generation_cancelled_by_session = False
+        for scope in scopes:
+            if scope == "generation":
+                cancelled = await self._cancel_generation_tasks(session_id=data.session_id)
+                generation_cancelled_by_session = generation_cancelled_by_session or cancelled > 0
+                results.append(
+                    OrchestratorInterruptScopeResult(
+                        scope=scope,
+                        status="cancelled" if cancelled else "no_active_work",
+                        cancelled_count=cancelled,
+                        message=(
+                            f"Cancelled {cancelled} active generation task(s)"
+                            if cancelled
+                            else "No active generation task matched the interrupt request"
+                        ),
+                    )
+                )
+            elif scope == "tool_call":
+                results.append(
+                    OrchestratorInterruptScopeResult(
+                        scope=scope,
+                        status="no_active_work",
+                        message=(
+                            "No separately cancellable tool call is active; graph-level "
+                            "generation cancellation covers current tool-bound runs"
+                        ),
+                    )
+                )
+            elif scope == "tts_playback":
+                await self.bus.publish(
+                    TTSMethods.STOP,
+                    EmptyInput(),
+                    event=False,
+                    priority=get_interactive_priority(),
+                    origin="internal",
+                    correlation_id=getattr(envelope, "correlation_id", None),
+                    principal_id=getattr(envelope, "principal_id", None),
+                )
+                results.append(
+                    OrchestratorInterruptScopeResult(
+                        scope=scope,
+                        status="cancelled",
+                        cancelled_count=1,
+                        message="TTS stop command sent",
+                    )
+                )
+            elif scope == "session":
+                cancelled = await self._cancel_generation_tasks(session_id=data.session_id)
+                generation_cancelled_by_session = generation_cancelled_by_session or cancelled > 0
+                results.append(
+                    OrchestratorInterruptScopeResult(
+                        scope=scope,
+                        status="cancelled" if cancelled else "no_active_work",
+                        cancelled_count=cancelled,
+                        message=(
+                            f"Cancelled {cancelled} active session task(s)"
+                            if cancelled
+                            else "No active session task matched the interrupt request"
+                        ),
+                    )
+                )
+
+        if generation_cancelled_by_session:
+            log_info(
+                f"Orchestrator interrupt {interrupt_id} cancelled generation "
+                f"for session={data.session_id or '*'}"
+            )
+
+        status = _interrupt_status(results)
+        response = OrchestratorInterruptResponse(
+            interrupt_id=interrupt_id,
+            status=status,
+            requested_scopes=scopes,
+            results=results,
+            session_id=data.session_id,
+            request_id=data.request_id,
+            audit_event="orchestrator.interrupt.requested",
+            idempotent=True,
+            secrets_redacted=True,
+        )
+        await self.bus.publish(
+            OrchestratorEvents.INTERRUPTED,
+            OrchestratorInterruptedEvent(
+                interrupt_id=response.interrupt_id,
+                status=response.status,
+                requested_scopes=response.requested_scopes,
+                results=response.results,
+                session_id=response.session_id,
+                request_id=response.request_id,
+                reason=data.reason,
+                principal_id=getattr(envelope, "principal_id", None),
+                audit_event=response.audit_event,
+                secrets_redacted=True,
+            ),
+            event=True,
+            mesh=True,
+            priority=get_interactive_priority(),
+            origin="internal",
+            correlation_id=getattr(envelope, "correlation_id", None),
+            principal_id=getattr(envelope, "principal_id", None),
+        )
+        return response
 
     @method_contract(
         method_id=OrchestratorMethods.GET_MODEL_RUNTIME,
@@ -378,6 +511,9 @@ class OrchestratorService(BaseService):
         Returns:
             Response text if return_response is True, else None
         """
+        current_task = asyncio.current_task()
+        if current_task is not None:
+            await self._track_generation_task(current_task, session_id)
         try:
             log_debug(f"Processing input from {source}: {text}")
 
@@ -412,9 +548,6 @@ class OrchestratorService(BaseService):
                 )
 
                 # Send TTS request to speak the response
-                from app.shared.contracts.models.tts import TTSMethods
-                from app.shared.messaging.models.tts_models import TTSRequest
-
                 await self.bus.publish(
                     TTSMethods.REQUEST,
                     TTSRequest(text=response_text, interrupt=True),
@@ -427,12 +560,49 @@ class OrchestratorService(BaseService):
             if return_response:
                 return response_text
 
+        except asyncio.CancelledError:
+            log_info(f"Orchestrator input processing interrupted for session={session_id}")
+            if return_response:
+                return "Interrupted"
         except Exception as e:
             log_error(f"Error processing input: {e}", exc_info=True)
             if return_response:
                 return f"Error: {e!s}"
+        finally:
+            if current_task is not None:
+                await self._untrack_generation_task(current_task)
 
         return None
+
+    async def _track_generation_task(
+        self,
+        task: asyncio.Task,
+        session_id: str | None,
+    ) -> None:
+        async with self._generation_lock:
+            self._generation_tasks[task] = session_id
+
+    async def _untrack_generation_task(self, task: asyncio.Task) -> None:
+        async with self._generation_lock:
+            self._generation_tasks.pop(task, None)
+
+    async def _cancel_generation_tasks(self, session_id: str | None) -> int:
+        current_task = asyncio.current_task()
+        async with self._generation_lock:
+            candidates = [
+                task
+                for task, task_session_id in self._generation_tasks.items()
+                if task is not current_task
+                and not task.done()
+                and (session_id is None or task_session_id == session_id)
+            ]
+
+        for task in candidates:
+            task.cancel()
+
+        if candidates:
+            await asyncio.gather(*candidates, return_exceptions=True)
+        return len(candidates)
 
     async def _build_model_runtime_catalog(
         self,
@@ -500,6 +670,31 @@ class OrchestratorService(BaseService):
 
 def _utc_now() -> str:
     return datetime.utcnow().isoformat()
+
+
+def _dedupe_scopes(
+    scopes: list[OrchestratorInterruptScope],
+) -> list[OrchestratorInterruptScope]:
+    seen: set[str] = set()
+    deduped: list[OrchestratorInterruptScope] = []
+    for scope in scopes:
+        if scope in seen:
+            continue
+        seen.add(scope)
+        deduped.append(scope)
+    return deduped
+
+
+def _interrupt_status(results: list[OrchestratorInterruptScopeResult]) -> str:
+    if not results:
+        return "no_op"
+    if any(result.status == "failed" for result in results):
+        return "partial" if any(result.status == "cancelled" for result in results) else "failed"
+    if any(result.status == "cancelled" for result in results):
+        return "interrupted"
+    if all(result.status == "no_active_work" for result in results):
+        return "no_active_work"
+    return "not_supported"
 
 
 def _configured_model_providers(

--- a/app/shared/contracts/models/orchestrator.py
+++ b/app/shared/contracts/models/orchestrator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import Field
 
@@ -21,6 +21,7 @@ class OrchestratorMethods:
     USER_INPUT = f"{OrchestratorModule.NAME}.UserInput"
     EXTERNAL_USER_INPUT = f"{OrchestratorModule.NAME}.ExternalUserInput"
     TOOL_RESULT = f"{OrchestratorModule.NAME}.ToolResult"
+    INTERRUPT = f"{OrchestratorModule.NAME}.Interrupt"
     RESPONSE = f"{OrchestratorModule.NAME}.Response"
     GET_MODEL_RUNTIME = f"{OrchestratorModule.NAME}.GetModelRuntime"
     GET_MODEL_CATALOG = f"{OrchestratorModule.NAME}.GetModelCatalog"
@@ -29,6 +30,21 @@ class OrchestratorMethods:
     DOWNLOAD_MODEL = f"{OrchestratorModule.NAME}.DownloadModel"
     BENCHMARK_MODEL = f"{OrchestratorModule.NAME}.BenchmarkModel"
     HEALTH_CHECK = f"{OrchestratorModule.NAME}.HealthCheck"
+
+
+class OrchestratorEvents:
+    """Broadcast event identifiers for Orchestrator service."""
+
+    INTERRUPTED = f"{OrchestratorModule.NAME}.Interrupted"
+
+
+OrchestratorInterruptScope = Literal["generation", "tool_call", "tts_playback", "session"]
+OrchestratorInterruptStatus = Literal[
+    "cancelled",
+    "no_active_work",
+    "not_supported",
+    "failed",
+]
 
 
 class OrchestratorProcessRequest(IOModel):
@@ -53,6 +69,63 @@ class OrchestratorToolResultRequest(IOModel):
     request_id: str
     result: Any
     error: str | None = None
+
+
+class OrchestratorInterruptRequest(IOModel):
+    """Request to interrupt active assistant work.
+
+    Scopes:
+    - ``generation``: cancel in-flight LLM/graph work tracked by Orchestrator.
+    - ``tool_call``: cancel active tool execution when a cancellable tool handle exists.
+    - ``tts_playback``: stop server-side TTS playback through the TTS service contract.
+    - ``session``: cancel all tracked work for a session and stop playback.
+    """
+
+    scopes: list[OrchestratorInterruptScope] = Field(
+        default_factory=lambda: ["generation", "tool_call", "tts_playback", "session"]
+    )
+    session_id: str | None = None
+    request_id: str | None = None
+    reason: str = "user_interrupt"
+
+
+class OrchestratorInterruptScopeResult(IOModel):
+    """Cancellation result for one requested scope."""
+
+    scope: OrchestratorInterruptScope
+    status: OrchestratorInterruptStatus
+    message: str = ""
+    cancelled_count: int = 0
+
+
+class OrchestratorInterruptResponse(IOModel):
+    """Idempotent response returned by Orchestrator.Interrupt."""
+
+    interrupt_id: str
+    status: str
+    requested_scopes: list[OrchestratorInterruptScope] = Field(default_factory=list)
+    results: list[OrchestratorInterruptScopeResult] = Field(default_factory=list)
+    session_id: str | None = None
+    request_id: str | None = None
+    event_topic: str = OrchestratorEvents.INTERRUPTED
+    audit_event: str = "orchestrator.interrupt.requested"
+    idempotent: bool = True
+    secrets_redacted: bool = True
+
+
+class OrchestratorInterruptedEvent(IOModel):
+    """Event emitted after an interrupt request is handled."""
+
+    interrupt_id: str
+    status: str
+    requested_scopes: list[OrchestratorInterruptScope] = Field(default_factory=list)
+    results: list[OrchestratorInterruptScopeResult] = Field(default_factory=list)
+    session_id: str | None = None
+    request_id: str | None = None
+    reason: str = "user_interrupt"
+    principal_id: str | None = None
+    audit_event: str = "orchestrator.interrupt.requested"
+    secrets_redacted: bool = True
 
 
 class ModelRuntimeFileInfo(IOModel):

--- a/tests/unit/orchestrator/test_model_runtime_contracts.py
+++ b/tests/unit/orchestrator/test_model_runtime_contracts.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import sys
-from types import ModuleType
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,14 +14,14 @@ graph_module.GraphOrchestrator = MagicMock()
 graph_module.set_orchestrator = MagicMock()
 sys.modules["app.services.orchestrator.graph"] = graph_module
 
-from app.services.orchestrator.service import OrchestratorService
-from app.shared.contracts.models.orchestrator import (
+from app.services.orchestrator.service import OrchestratorService  # noqa: E402
+from app.shared.contracts.models.orchestrator import (  # noqa: E402
     ModelRuntimeCatalogRequest,
     ModelRuntimeOperationRequest,
     ModelRuntimeOperationStatusRequest,
     OrchestratorMethods,
 )
-from app.shared.contracts.registry import all_contracts, clear_registry
+from app.shared.contracts.registry import all_contracts, clear_registry  # noqa: E402
 
 
 def _services_config(model_path: Path) -> dict:
@@ -75,6 +75,10 @@ def test_model_runtime_contracts_register_with_permissions():
     OrchestratorService()
 
     contracts = all_contracts()
+    assert contracts[OrchestratorMethods.INTERRUPT].exposure == "external"
+    assert contracts[OrchestratorMethods.INTERRUPT].method_type == "use"
+    assert contracts[OrchestratorMethods.INTERRUPT].required_perms == ["Orchestrator.use"]
+
     assert contracts[OrchestratorMethods.GET_MODEL_CATALOG].exposure == "external"
     assert contracts[OrchestratorMethods.GET_MODEL_CATALOG].method_type == "use"
     assert contracts[OrchestratorMethods.GET_MODEL_CATALOG].required_perms == [

--- a/tests/unit/orchestrator/test_service.py
+++ b/tests/unit/orchestrator/test_service.py
@@ -1,5 +1,6 @@
 """Unit tests for orchestrator service."""
 
+import asyncio
 import sys
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -286,6 +287,122 @@ class TestOrchestratorServiceToolHandling:
         with pytest.raises(ValidationError):
             request = OrchestratorToolResultRequest()  # Missing required fields
             await orchestrator_service.process_tool_result(request)
+
+
+class TestOrchestratorInterruptHandling:
+    """Test assistant interrupt/cancellation contract behavior."""
+
+    @pytest.mark.asyncio
+    async def test_interrupt_tts_playback_publishes_stop_and_event(
+        self, orchestrator_service, mock_bus
+    ):
+        from app.shared.contracts.models.common import EmptyInput
+        from app.shared.contracts.models.orchestrator import (
+            OrchestratorEvents,
+            OrchestratorInterruptedEvent,
+            OrchestratorInterruptRequest,
+            OrchestratorMethods,
+        )
+        from app.shared.contracts.models.tts import TTSMethods
+
+        envelope = Envelope(
+            type=OrchestratorMethods.INTERRUPT,
+            payload={},
+            correlation_id="corr-123",
+            principal_id="principal-123",
+        )
+
+        response = await orchestrator_service.interrupt_assistant(
+            OrchestratorInterruptRequest(scopes=["tts_playback"], session_id="session-1"),
+            envelope=envelope,
+        )
+
+        assert response.status == "interrupted"
+        assert response.idempotent is True
+        assert response.secrets_redacted is True
+        assert response.results[0].scope == "tts_playback"
+        assert response.results[0].status == "cancelled"
+
+        stop_call, event_call = mock_bus.publish.call_args_list
+        assert stop_call.args[0] == TTSMethods.STOP
+        assert isinstance(stop_call.args[1], EmptyInput)
+        assert stop_call.kwargs["event"] is False
+        assert stop_call.kwargs["correlation_id"] == "corr-123"
+        assert stop_call.kwargs["principal_id"] == "principal-123"
+
+        assert event_call.args[0] == OrchestratorEvents.INTERRUPTED
+        event = event_call.args[1]
+        assert isinstance(event, OrchestratorInterruptedEvent)
+        assert event.audit_event == "orchestrator.interrupt.requested"
+        assert event.secrets_redacted is True
+        assert event.principal_id == "principal-123"
+        assert event_call.kwargs["event"] is True
+        assert event_call.kwargs["mesh"] is True
+
+    @pytest.mark.asyncio
+    async def test_interrupt_generation_is_idempotent_when_no_task_matches(
+        self, orchestrator_service, mock_bus
+    ):
+        from app.shared.contracts.models.orchestrator import OrchestratorInterruptRequest
+
+        response = await orchestrator_service.interrupt_assistant(
+            OrchestratorInterruptRequest(scopes=["generation"], session_id="missing-session")
+        )
+
+        assert response.status == "no_active_work"
+        assert response.results[0].scope == "generation"
+        assert response.results[0].status == "no_active_work"
+        assert response.results[0].cancelled_count == 0
+        assert mock_bus.publish.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_interrupt_generation_cancels_matching_active_task(
+        self, orchestrator_service, mock_bus
+    ):
+        from app.shared.contracts.models.orchestrator import OrchestratorInterruptRequest
+
+        started = asyncio.Event()
+
+        async def slow_generation(text, tts_result=False):
+            started.set()
+            await asyncio.sleep(30)
+            return "should not publish"
+
+        orchestrator_service.orchestrator = MagicMock()
+        orchestrator_service.orchestrator.stream_graph_updates = AsyncMock(
+            side_effect=slow_generation
+        )
+
+        task = asyncio.create_task(
+            orchestrator_service._process_input(
+                "stop this", source="external", session_id="session-123", return_response=True
+            )
+        )
+        await started.wait()
+
+        response = await orchestrator_service.interrupt_assistant(
+            OrchestratorInterruptRequest(scopes=["generation"], session_id="session-123")
+        )
+
+        assert response.status == "interrupted"
+        assert response.results[0].status == "cancelled"
+        assert response.results[0].cancelled_count == 1
+        assert await task == "Interrupted"
+        assert mock_bus.publish.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_interrupt_tool_call_reports_no_separate_active_work(
+        self, orchestrator_service
+    ):
+        from app.shared.contracts.models.orchestrator import OrchestratorInterruptRequest
+
+        response = await orchestrator_service.interrupt_assistant(
+            OrchestratorInterruptRequest(scopes=["tool_call"])
+        )
+
+        assert response.status == "no_active_work"
+        assert response.results[0].scope == "tool_call"
+        assert response.results[0].status == "no_active_work"
 
 
 class TestOrchestratorServiceInputProcessing:


### PR DESCRIPTION
## Summary

- Adds the `Orchestrator.Interrupt` method contract and `Orchestrator.Interrupted` event models for assistant cancellation flows.
- Registers an external/use Orchestrator interrupt method guarded by `Orchestrator.use`.
- Tracks active generation tasks so generation/session interrupts can cancel matching work idempotently, and publishes TTS stop requests for playback interrupts.
- Adds targeted unit coverage for interrupt method registration, TTS stop/event publishing, idempotent no-op behavior, and active generation cancellation.

## Validation

- `/home/developer/projects/aurora/.venv/bin/ruff check app/shared/contracts/models/orchestrator.py app/services/orchestrator/service.py tests/unit/orchestrator/test_service.py tests/unit/orchestrator/test_model_runtime_contracts.py`
- `/home/developer/projects/aurora/.venv/bin/python -m pytest tests/unit/orchestrator/test_service.py tests/unit/orchestrator/test_model_runtime_contracts.py -q`
- `/home/developer/projects/aurora/.venv/bin/python -m pytest tests/unit/gateway/test_backend_inventory.py -q`

## Notes

- Opened as draft for QA review.
- `uv` is not installed in this runtime, so validation used the repository virtualenv directly.
