### PR TITLE
UIA-002 assistant streaming, cancellation, and retry states

### DIFF
--- a/apps/aurora-web/app/assistant-client.tsx
+++ b/apps/aurora-web/app/assistant-client.tsx
@@ -3,6 +3,12 @@
 import { AssistantView, type RouteAvailability } from '@aurora/ui'
 import { createAuroraBrowserClient } from './aurora-client'
 
-export function AssistantClientPage({ route }: { route: RouteAvailability }) {
-  return <AssistantView client={createAuroraBrowserClient()} route={route} />
+export function AssistantClientPage({
+  route,
+  cancellationRoute
+}: {
+  route: RouteAvailability
+  cancellationRoute?: RouteAvailability | undefined
+}) {
+  return <AssistantView client={createAuroraBrowserClient()} route={route} cancellationRoute={cancellationRoute} />
 }

--- a/apps/aurora-web/app/page.tsx
+++ b/apps/aurora-web/app/page.tsx
@@ -7,7 +7,7 @@ export default async function Page() {
   const route = snapshot.routes.find((candidate) => candidate.item.id === 'assistant')
   return (
     <>
-      {route ? <AssistantClientPage route={route} /> : null}
+      {route ? <AssistantClientPage route={route} cancellationRoute={snapshot.assistantCancellationRoute ?? undefined} /> : null}
       {!route ? (
         <AuroraRoutePage
           routeId="assistant"

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -468,6 +468,7 @@ export class AssistantClient {
     } catch (error) {
       const normalized = normalizeError(error)
       this.client.auth.applyError(normalized)
+      if (input.signal?.aborted) return
       if (sawEvent) {
         yield streamFailure(normalized, this.client.transport.kind, 'transport_lost')
         return

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -32,6 +32,9 @@ import type {
   AuthWhoAmIResponse,
   AssistantSendMessageRequest,
   AssistantSendMessageResult,
+  AssistantCancelRequest,
+  AssistantStreamMessageRequest,
+  AssistantStreamUpdate,
   CapabilityCatalogRequest,
   CapabilityCatalogResponse,
   CapabilityExplanation,
@@ -45,6 +48,8 @@ import type {
   NativeCapabilityManifest,
   OrchestratorProcessRequest,
   OrchestratorResponse,
+  OrchestratorInterruptRequest,
+  OrchestratorInterruptResponse,
   PeerSummary,
   ContractMethodType,
   RouteExplainRequest,
@@ -421,6 +426,85 @@ export class AssistantClient {
       }
     }
   }
+
+  async *streamMessage(input: AssistantStreamMessageRequest): AsyncIterable<AssistantStreamUpdate> {
+    const text = input.text.trim()
+    if (!text) {
+      yield streamFailure(
+        new AuroraError({
+          code: 'validation',
+          message: 'Assistant message text is required.',
+          method: ORCHESTRATOR_METHODS.externalUserInput,
+          busTopic: ORCHESTRATOR_METHODS.externalUserInput
+        }),
+        this.client.transport.kind
+      )
+      return
+    }
+
+    const payload: OrchestratorProcessRequest = {
+      text,
+      source: 'external'
+    }
+    if (input.sessionId !== undefined) payload.session_id = input.sessionId
+
+    let sawEvent = false
+    try {
+      const stream = this.client.events.streamAssistant<Record<string, unknown>, OrchestratorProcessRequest>(payload, {
+        signal: input.signal,
+        lastEventId: input.lastEventId ?? null,
+        replayFrom: input.replayFrom ?? input.lastEventId ?? null,
+        reconnect: { maxAttempts: 1, initialDelayMs: 250, maxDelayMs: 1_000 },
+        audit: {
+          method: ORCHESTRATOR_METHODS.externalUserInput,
+          busTopic: ORCHESTRATOR_METHODS.externalUserInput,
+          transport: this.client.transport.kind
+        }
+      })
+      for await (const event of stream) {
+        sawEvent = true
+        yield assistantStreamUpdateFromEvent(event)
+      }
+    } catch (error) {
+      const normalized = normalizeError(error)
+      this.client.auth.applyError(normalized)
+      if (sawEvent) {
+        yield streamFailure(normalized, this.client.transport.kind, 'transport_lost')
+        return
+      }
+
+      const fallback = await this.sendMessage(input)
+      if (fallback.ok) {
+        yield {
+          kind: 'fallback',
+          eventId: fallback.data.response.id,
+          sessionId: fallback.data.sessionId,
+          text: fallback.data.response.text,
+          textDelta: fallback.data.response.text,
+          modelLabel: fallback.data.modelLabel,
+          error: null,
+          audit: fallback.audit,
+          metadata: fallback.data.metadata
+        }
+        return
+      }
+      yield streamFailure(fallback.error, this.client.transport.kind, 'fallback')
+    }
+  }
+
+  cancel(input: AssistantCancelRequest = {}): Promise<AuroraResponse<OrchestratorInterruptResponse>> {
+    const payload: OrchestratorInterruptRequest = {
+      scopes: input.scopes ?? ['generation', 'tool_call', 'tts_playback', 'session'],
+      reason: input.reason ?? 'user_interrupt'
+    }
+    if (input.sessionId !== undefined) payload.session_id = input.sessionId
+    if (input.requestId !== undefined) payload.request_id = input.requestId
+    return this.client.requestResult<OrchestratorInterruptResponse, OrchestratorInterruptRequest>(
+      ORCHESTRATOR_METHODS.interrupt,
+      payload,
+      { path: routePath('Orchestrator', 'Interrupt') }
+    )
+  }
 }
 
 export interface AdminOverviewManifestOptions {
@@ -433,6 +517,114 @@ export interface AdminOverviewManifestOptions {
 function metadataString(metadata: OrchestratorResponse['metadata'] | undefined, key: string): string | null {
   const value = metadata?.[key]
   return typeof value === 'string' && value.trim() ? value : null
+}
+
+function assistantStreamUpdateFromEvent(event: import('./types.js').AuroraEvent<Record<string, unknown>>): AssistantStreamUpdate {
+  const payload = event.payload ?? {}
+  const text = streamText(payload)
+  const metadata = streamMetadata(payload)
+  const sessionId = streamString(payload, 'session_id', 'sessionId') ?? null
+  const modelLabel = metadataString(metadata, 'model') ?? metadataString(metadata, 'provider')
+  if (event.kind === 'assistant.completed') {
+    return {
+      kind: 'completed',
+      eventId: event.id,
+      sessionId,
+      text,
+      textDelta: text,
+      modelLabel,
+      error: null,
+      audit: event.audit,
+      metadata
+    }
+  }
+  if (event.kind === 'assistant.failed') {
+    return {
+      kind: 'failed',
+      eventId: event.id,
+      sessionId,
+      text,
+      textDelta: '',
+      modelLabel,
+      error: new AuroraError({
+        code: 'unavailable_service',
+        message: text || 'Assistant stream failed.',
+        detail: payload,
+        correlationId: event.audit.correlationId ?? undefined,
+        method: event.method ?? ORCHESTRATOR_METHODS.externalUserInput,
+        busTopic: event.busTopic ?? ORCHESTRATOR_METHODS.externalUserInput
+      }),
+      audit: event.audit,
+      metadata
+    }
+  }
+  if (event.kind.startsWith('tool.')) {
+    return {
+      kind: 'tool',
+      eventId: event.id,
+      sessionId,
+      text,
+      textDelta: '',
+      modelLabel,
+      error: null,
+      audit: event.audit,
+      metadata
+    }
+  }
+  return {
+    kind: 'delta',
+    eventId: event.id,
+    sessionId,
+    text,
+    textDelta: streamString(payload, 'delta', 'text_delta', 'textDelta') ?? text,
+    modelLabel,
+    error: null,
+    audit: event.audit,
+    metadata
+  }
+}
+
+function streamFailure(
+  error: AuroraError,
+  transport: string,
+  kind: 'failed' | 'transport_lost' | 'fallback' = 'failed'
+): AssistantStreamUpdate {
+  return {
+    kind,
+    eventId: null,
+    sessionId: null,
+    text: error.message,
+    textDelta: '',
+    modelLabel: null,
+    error,
+    audit: createAuditReceipt(error.detail, {
+      correlationId: error.correlationId ?? null,
+      method: error.method ?? ORCHESTRATOR_METHODS.externalUserInput,
+      busTopic: error.busTopic ?? ORCHESTRATOR_METHODS.externalUserInput,
+      status: error.code,
+      transport
+    }),
+    metadata: {}
+  }
+}
+
+function streamText(payload: Record<string, unknown>): string {
+  return streamString(payload, 'text', 'content', 'message', 'delta', 'text_delta', 'textDelta') ?? ''
+}
+
+function streamMetadata(payload: Record<string, unknown>): Record<string, import('./types.js').JsonValue | undefined> {
+  const metadata = payload.metadata
+  return typeof metadata === 'object' && metadata !== null && !Array.isArray(metadata)
+    ? metadata as Record<string, import('./types.js').JsonValue | undefined>
+    : {}
+}
+
+function streamString(payload: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = payload[key]
+    if (typeof value === 'string' && value.trim()) return value
+  }
+  return null
 }
 
 function stableSessionId(): string {

--- a/packages/aurora-sdk/src/descriptors.ts
+++ b/packages/aurora-sdk/src/descriptors.ts
@@ -47,6 +47,7 @@ export const TOOLING_METHODS = {
 export const ORCHESTRATOR_METHODS = {
   userInput: 'Orchestrator.UserInput',
   externalUserInput: 'Orchestrator.ExternalUserInput',
+  interrupt: 'Orchestrator.Interrupt',
   toolResult: 'Orchestrator.ToolResult',
   response: 'Orchestrator.Response'
 } as const

--- a/packages/aurora-sdk/src/events.ts
+++ b/packages/aurora-sdk/src/events.ts
@@ -248,10 +248,19 @@ function subscribeWithReconnect<TEventPayload, TPayload>(
   if (!isEventStreamTransport(transport)) throw eventStreamUnsupported(transport.kind)
   const reconnect = normalizeReconnect(request.reconnect)
   const controller = new AbortController()
+  const abortFromCaller = () => controller.abort()
+  if (request.signal?.aborted) {
+    controller.abort()
+  } else {
+    request.signal?.addEventListener('abort', abortFromCaller, { once: true })
+  }
   const source = reconnect.maxAttempts === 0
     ? singleStream<TEventPayload, TPayload>(transport, request, controller.signal)
     : reconnectingStream<TEventPayload, TPayload>(transport, request, reconnect, controller.signal)
-  return createEventSubscription(source, () => controller.abort())
+  return createEventSubscription(source, () => {
+    request.signal?.removeEventListener('abort', abortFromCaller)
+    controller.abort()
+  })
 }
 
 async function* singleStream<TEventPayload, TPayload>(

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -106,6 +106,12 @@ export interface AssistantSendMessageRequest {
   timeoutMs?: number
 }
 
+export interface AssistantStreamMessageRequest extends AssistantSendMessageRequest {
+  signal?: AbortSignal
+  lastEventId?: string | null
+  replayFrom?: string | null
+}
+
 export interface AssistantMessage {
   id: string
   role: 'user' | 'assistant'
@@ -120,6 +126,57 @@ export interface AssistantSendMessageResult {
   modelLabel: string | null
   privacyClass: PrivacyClass
   metadata: JsonObject
+}
+
+export type AssistantStreamUpdateKind = 'delta' | 'completed' | 'failed' | 'tool' | 'transport_lost' | 'fallback'
+
+export interface AssistantStreamUpdate {
+  kind: AssistantStreamUpdateKind
+  eventId: string | null
+  sessionId: string | null
+  text: string
+  textDelta: string
+  modelLabel: string | null
+  error: AuroraError | null
+  audit: AuditReceipt
+  metadata: JsonObject
+}
+
+export type OrchestratorInterruptScope = 'generation' | 'tool_call' | 'tts_playback' | 'session'
+export type OrchestratorInterruptStatus = 'cancelled' | 'no_active_work' | 'not_supported' | 'failed'
+
+export interface OrchestratorInterruptRequest {
+  scopes?: OrchestratorInterruptScope[]
+  session_id?: string | null
+  request_id?: string | null
+  reason?: string
+}
+
+export interface OrchestratorInterruptScopeResult {
+  scope: OrchestratorInterruptScope
+  status: OrchestratorInterruptStatus
+  message: string
+  cancelled_count: number
+}
+
+export interface OrchestratorInterruptResponse {
+  interrupt_id: string
+  status: string
+  requested_scopes: OrchestratorInterruptScope[]
+  results: OrchestratorInterruptScopeResult[]
+  session_id: string | null
+  request_id: string | null
+  event_topic: string
+  audit_event: string
+  idempotent: boolean
+  secrets_redacted: boolean
+}
+
+export interface AssistantCancelRequest {
+  sessionId?: string | null
+  requestId?: string | null
+  scopes?: OrchestratorInterruptScope[]
+  reason?: string
 }
 
 export type ContractExposure = 'internal' | 'external' | 'both' | 'gateway_builtin' | string

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -2108,6 +2108,105 @@ describe('AuroraClient', () => {
 })
 
 describe('AuroraClient assistant namespace', () => {
+  it('streams assistant deltas, final event evidence, and model metadata', async () => {
+    const transport = new MockAuroraTransport().stream('assistant', [
+      { id: 's1', kind: 'assistant.delta', payload: { textDelta: 'Hel' }, correlation_id: 'corr-stream' },
+      { id: 's2', kind: 'assistant.delta', payload: { delta: 'lo' }, correlation_id: 'corr-stream' },
+      {
+        id: 's3',
+        kind: 'assistant.completed',
+        payload: { text: 'Hello', session_id: 'session-stream', metadata: { model: 'mock-stream' } },
+        correlation_id: 'corr-stream'
+      }
+    ])
+    const client = new AuroraClient({ transport })
+
+    const events = await collectEvents(client.assistant.streamMessage({ text: 'hello' }), 3)
+
+    expect(events.map((event) => event.kind)).toEqual(['delta', 'delta', 'completed'])
+    expect(events[0]?.textDelta).toBe('Hel')
+    expect(events[1]?.textDelta).toBe('lo')
+    expect(events[2]).toEqual(
+      expect.objectContaining({
+        eventId: 's3',
+        sessionId: 'session-stream',
+        text: 'Hello',
+        modelLabel: 'mock-stream',
+        audit: expect.objectContaining({ correlationId: 'corr-stream' })
+      })
+    )
+  })
+
+  it('falls back to non-streaming assistant response when stream transport is unavailable before data', async () => {
+    const client = new AuroraClient({ transport: new MockAuroraTransport() })
+
+    const events = await collectEvents(client.assistant.streamMessage({ text: 'fallback please' }), 1)
+
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        kind: 'fallback',
+        sessionId: 'mock-assistant-session',
+        text: 'Mock Aurora response to "fallback please"',
+        modelLabel: 'mock-local'
+      })
+    )
+  })
+
+  it('reports transport loss after the last streamed event instead of inventing completion', async () => {
+    const transport = new MockAuroraTransport().stream('assistant', async function* () {
+      yield { id: 's1', kind: 'assistant.delta', payload: { text: 'partial' } }
+      throw new TypeError('stream disconnected')
+    })
+    const client = new AuroraClient({ transport })
+
+    const events = await collectEvents(client.assistant.streamMessage({ text: 'hello' }), 2)
+
+    expect(events[0]?.kind).toBe('delta')
+    expect(events[1]).toEqual(
+      expect.objectContaining({
+        kind: 'transport_lost',
+        error: expect.objectContaining({ code: 'transport_loss' })
+      })
+    )
+  })
+
+  it('calls the Orchestrator.Interrupt contract for cancellation through the SDK', async () => {
+    let capturedPayload: unknown
+    const transport = new MockAuroraTransport()
+    transport.register(ORCHESTRATOR_METHODS.interrupt, (request) => {
+      capturedPayload = request.payload
+      return {
+        interrupt_id: 'interrupt-1',
+        status: 'interrupted',
+        requested_scopes: ['generation', 'session'],
+        results: [],
+        session_id: 'session-123',
+        request_id: 'request-123',
+        event_topic: 'Orchestrator.Interrupted',
+        audit_event: 'orchestrator.interrupt.requested',
+        idempotent: true,
+        secrets_redacted: true
+      }
+    })
+    const client = new AuroraClient({ transport })
+
+    const result = await client.assistant.cancel({
+      sessionId: 'session-123',
+      requestId: 'request-123',
+      scopes: ['generation', 'session']
+    })
+
+    expect(capturedPayload).toEqual({
+      scopes: ['generation', 'session'],
+      reason: 'user_interrupt',
+      session_id: 'session-123',
+      request_id: 'request-123'
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected interrupt success')
+    expect(result.data.status).toBe('interrupted')
+  })
+
   it('sends text prompts through Orchestrator.ExternalUserInput and normalizes final responses', async () => {
     let capturedPayload: unknown
     const transport = new MockAuroraTransport()

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -2170,6 +2170,36 @@ describe('AuroraClient assistant namespace', () => {
     )
   })
 
+  it('closes assistant stream on external abort without falling back to sendMessage', async () => {
+    let sendCalls = 0
+    const transport = new MockAuroraTransport().stream('assistant', async function* () {
+      yield { id: 's1', kind: 'assistant.delta', payload: { text: 'partial' } }
+      await new Promise(() => undefined)
+    })
+    transport.register(ORCHESTRATOR_METHODS.externalUserInput, () => {
+      sendCalls += 1
+      return {
+        text: 'fallback should not run',
+        session_id: 'session-fallback',
+        metadata: { model: 'fallback-model' }
+      }
+    })
+    const client = new AuroraClient({ transport })
+    const controller = new AbortController()
+    const iterator = client.assistant.streamMessage({ text: 'hello', signal: controller.signal })[Symbol.asyncIterator]()
+
+    await expect(iterator.next()).resolves.toEqual(
+      expect.objectContaining({
+        done: false,
+        value: expect.objectContaining({ kind: 'delta', text: 'partial' })
+      })
+    )
+    controller.abort()
+
+    await expect(raceWithTimeout(iterator.next(), 100)).resolves.toEqual({ done: true, value: undefined })
+    expect(sendCalls).toBe(0)
+  })
+
   it('calls the Orchestrator.Interrupt contract for cancellation through the SDK', async () => {
     let capturedPayload: unknown
     const transport = new MockAuroraTransport()

--- a/packages/aurora-ui/src/assistant-view.tsx
+++ b/packages/aurora-ui/src/assistant-view.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
-import { SendHorizontal } from 'lucide-react'
+import { RotateCcw, SendHorizontal, StopCircle, WifiOff } from 'lucide-react'
 import type {
   AssistantMessage as SdkAssistantMessage,
   AssistantRoutePolicy,
+  AssistantStreamUpdate,
   AuroraClient,
   AuroraError,
   AuroraResponse
@@ -15,10 +16,11 @@ import { EvidenceBadge, PrivacyBadge, StatusBadge } from './status-badges'
 export interface AssistantViewProps {
   client: AuroraClient
   route: RouteAvailability
+  cancellationRoute?: RouteAvailability | undefined
   storageKey?: string
 }
 
-export type AssistantUiMessageStatus = 'sent' | 'sending' | 'failed'
+export type AssistantUiMessageStatus = 'sent' | 'sending' | 'streaming' | 'failed' | 'cancelled'
 
 export interface AssistantUiMessage {
   id: string
@@ -34,18 +36,37 @@ export interface AssistantSessionSnapshot {
   messages: AssistantUiMessage[]
 }
 
+export type AssistantStreamStatus = 'idle' | 'streaming' | 'fallback' | 'lost' | 'cancelled'
+
+export interface AssistantStreamState {
+  status: AssistantStreamStatus
+  lastEventId: string | null
+  message: string | null
+}
+
+export interface AssistantControlState {
+  canSend: boolean
+  canCancel: boolean
+  cancelReason: string
+}
+
 const defaultStorageKey = 'aurora.assistant.session.v1'
 
-export function AssistantView({ client, route, storageKey = defaultStorageKey }: AssistantViewProps) {
+export function AssistantView({ client, route, cancellationRoute, storageKey = defaultStorageKey }: AssistantViewProps) {
   const [session, setSession] = useState<AssistantSessionSnapshot>(() => emptyAssistantSession())
   const [text, setText] = useState('')
   const [lastResult, setLastResult] = useState<SdkAssistantMessage | null>(null)
   const [modelLabel, setModelLabel] = useState<string | null>(null)
   const [lastError, setLastError] = useState<string | null>(null)
+  const [lastPrompt, setLastPrompt] = useState<string | null>(null)
+  const [streamState, setStreamState] = useState<AssistantStreamState>(() => idleAssistantStreamState())
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
   const routePolicy = useMemo(() => routePolicyFromRoute(route), [route])
   const isSending = session.messages.some((message) => message.status === 'sending')
-  const canSend = !route.disabled && !isSending
+  const isStreaming = session.messages.some((message) => message.status === 'streaming')
+  const controls = assistantControlsForRoute(route, cancellationRoute, isSending || isStreaming)
+  const canSend = controls.canSend
 
   useEffect(() => {
     setSession(loadAssistantSession(storageKey))
@@ -55,11 +76,16 @@ export function AssistantView({ client, route, storageKey = defaultStorageKey }:
     persistAssistantSession(storageKey, session)
   }, [session, storageKey])
 
+  useEffect(() => () => abortRef.current?.abort(), [])
+
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const prompt = text.trim()
     if (!prompt || !canSend) return
+    await startAssistantTurn(prompt)
+  }
 
+  async function startAssistantTurn(prompt: string, replayFrom: string | null = null) {
     const now = new Date().toISOString()
     const userMessage: AssistantUiMessage = {
       id: `user-${Date.now()}`,
@@ -71,24 +97,35 @@ export function AssistantView({ client, route, storageKey = defaultStorageKey }:
     const pendingMessage: AssistantUiMessage = {
       id: `assistant-pending-${Date.now()}`,
       role: 'assistant',
-      text: 'Waiting for Aurora response...',
+      text: replayFrom ? 'Replaying stream from last backend event...' : 'Waiting for Aurora stream...',
       createdAt: now,
-      status: 'sending'
+      status: 'streaming'
     }
 
     setText('')
+    setLastPrompt(prompt)
     setLastError(null)
+    setStreamState({ status: 'streaming', lastEventId: replayFrom, message: replayFrom ? 'Replaying from last known event.' : null })
     setSession((current) => ({
       ...current,
       messages: [...current.messages, userMessage, pendingMessage]
     }))
 
-    const result = await client.assistant.sendMessage({
+    const abort = new AbortController()
+    abortRef.current = abort
+    for await (const update of client.assistant.streamMessage({
       text: prompt,
       sessionId: session.sessionId,
-      routePolicy
-    })
-    applyAssistantResult(result, pendingMessage.id)
+      routePolicy,
+      signal: abort.signal,
+      replayFrom
+    })) {
+      applyAssistantStreamUpdate(update, pendingMessage.id)
+      if (update.kind === 'completed' || update.kind === 'failed' || update.kind === 'fallback' || update.kind === 'transport_lost') {
+        break
+      }
+    }
+    if (abortRef.current === abort) abortRef.current = null
   }
 
   function applyAssistantResult(result: AuroraResponse<import('@aurora/client').AssistantSendMessageResult>, pendingId: string) {
@@ -129,6 +166,123 @@ export function AssistantView({ client, route, storageKey = defaultStorageKey }:
     }))
   }
 
+  function applyAssistantStreamUpdate(update: AssistantStreamUpdate, pendingId: string) {
+    if (update.eventId) {
+      setStreamState((current) => ({ ...current, lastEventId: update.eventId }))
+    }
+    if (update.modelLabel) setModelLabel(update.modelLabel)
+    if (update.kind === 'transport_lost') {
+      const error = assistantErrorMessage(update.error ?? new Error('Assistant stream disconnected.'))
+      setLastError(error)
+      setStreamState((current) => ({
+        status: 'lost',
+        lastEventId: current.lastEventId,
+        message: 'Stream disconnected. Replay will request events after the last backend event when the transport supports it.'
+      }))
+      setSession((current) => ({
+        ...current,
+        messages: current.messages.map((message) =>
+          message.id === pendingId
+            ? {
+                ...message,
+                text: message.text.trim() ? message.text : error,
+                status: 'failed',
+                error
+              }
+            : message
+        )
+      }))
+      return
+    }
+    if (update.kind === 'failed') {
+      const error = assistantErrorMessage(update.error ?? new Error(update.text))
+      setLastError(error)
+      setStreamState((current) => ({ ...current, status: 'lost', message: error }))
+      setSession((current) => ({
+        ...current,
+        messages: current.messages.map((message) =>
+          message.id === pendingId
+            ? {
+                ...message,
+                text: error,
+                status: 'failed',
+                error
+              }
+            : message
+        )
+      }))
+      return
+    }
+    if (update.kind === 'fallback') {
+      setStreamState((current) => ({
+        status: 'fallback',
+        lastEventId: update.eventId ?? current.lastEventId,
+        message: 'Streaming was unavailable; Aurora returned a final non-streaming response.'
+      }))
+    }
+    if (update.kind === 'completed' || update.kind === 'fallback') {
+      setLastResult({
+        id: update.eventId ?? `assistant-${Date.now()}`,
+        role: 'assistant',
+        text: update.text,
+        createdAt: new Date().toISOString()
+      })
+      setSession((current) => ({
+        sessionId: update.sessionId ?? current.sessionId ?? session.sessionId,
+        messages: current.messages.map((message) =>
+          message.id === pendingId
+            ? {
+                id: update.eventId ?? message.id,
+                role: 'assistant',
+                text: update.text,
+                createdAt: message.createdAt,
+                status: 'sent'
+              }
+            : message
+        )
+      }))
+      if (update.kind === 'completed') {
+        setStreamState((current) => ({ ...current, status: 'idle', message: 'Final assistant event received.' }))
+      }
+      return
+    }
+    if (update.kind === 'delta') {
+      setSession((current) => ({
+        ...current,
+        messages: current.messages.map((message) =>
+          message.id === pendingId ? applyAssistantStreamDelta(message, update) : message
+        )
+      }))
+    }
+  }
+
+  async function onCancel() {
+    if (!controls.canCancel) return
+    abortRef.current?.abort()
+    const result = await client.assistant.cancel({
+      sessionId: session.sessionId,
+      reason: 'user_interrupt'
+    })
+    if (result.ok) {
+      setStreamState((current) => ({ ...current, status: 'cancelled', message: `Interrupt ${result.data.status}` }))
+      setSession((current) => ({
+        ...current,
+        messages: current.messages.map((message) =>
+          message.status === 'streaming' || message.status === 'sending'
+            ? { ...message, status: 'cancelled', text: message.text.trim() ? message.text : 'Stopped by user.' }
+            : message
+        )
+      }))
+      return
+    }
+    setLastError(assistantErrorMessage(result.error))
+  }
+
+  async function retryLastPrompt(replay = false) {
+    if (!lastPrompt || !canSend) return
+    await startAssistantTurn(replay ? lastPrompt : lastPrompt, replay ? streamState.lastEventId : null)
+  }
+
   return (
     <section className="aui-assistant" aria-labelledby="assistant-title">
       <header className="aui-assistant-header">
@@ -142,9 +296,21 @@ export function AssistantView({ client, route, storageKey = defaultStorageKey }:
           <EvidenceBadge label={route.providerLabel} />
           <EvidenceBadge label={modelLabel ? `model ${modelLabel}` : 'model pending'} />
           <EvidenceBadge label={client.transport.kind} />
+          <EvidenceBadge label={streamState.status === 'idle' ? 'stream ready' : `stream ${streamState.status}`} />
           {session.sessionId ? <EvidenceBadge label={`session ${session.sessionId}`} /> : null}
         </div>
       </header>
+
+      {streamState.status === 'lost' || streamState.status === 'fallback' ? (
+        <div className="aui-stream-banner" role="status" aria-live="polite">
+          <WifiOff size={17} aria-hidden />
+          <span>{streamState.message}</span>
+          <button type="button" onClick={() => void retryLastPrompt(true)} disabled={!lastPrompt || !canSend}>
+            <RotateCcw size={15} aria-hidden />
+            <span>Replay</span>
+          </button>
+        </div>
+      ) : null}
 
       <div className="aui-assistant-grid">
         <div className="aui-chat-panel" aria-live="polite">
@@ -166,6 +332,8 @@ export function AssistantView({ client, route, storageKey = defaultStorageKey }:
             <div><dt>Privacy</dt><dd>{route.item.privacyClass}</dd></div>
             <div><dt>Selector</dt><dd>{route.selectorRequired ? 'required' : 'not required'}</dd></div>
             <div><dt>Approval</dt><dd>{route.approvalRequired ? 'required' : 'not required'}</dd></div>
+            <div><dt>Cancellation</dt><dd>{controls.canCancel ? 'supported' : controls.cancelReason}</dd></div>
+            <div><dt>Last stream event</dt><dd>{streamState.lastEventId ?? 'none'}</dd></div>
             <div><dt>Model</dt><dd>{modelLabel ?? (lastResult ? 'not reported' : 'pending backend response')}</dd></div>
           </dl>
           <p>{route.explanation}</p>
@@ -185,6 +353,14 @@ export function AssistantView({ client, route, storageKey = defaultStorageKey }:
           placeholder={route.disabled ? 'Assistant capability is unavailable' : 'Ask Aurora...'}
           rows={3}
         />
+        <button type="button" className="aui-secondary-button" onClick={onCancel} disabled={!controls.canCancel} aria-label="Stop assistant generation">
+          <StopCircle size={17} aria-hidden />
+          <span>Stop</span>
+        </button>
+        <button type="button" className="aui-secondary-button" onClick={() => void retryLastPrompt(false)} disabled={!lastPrompt || !canSend} aria-label="Retry last assistant prompt">
+          <RotateCcw size={17} aria-hidden />
+          <span>Retry</span>
+        </button>
         <button type="submit" disabled={!canSend || text.trim().length === 0} aria-label="Send assistant prompt">
           <SendHorizontal size={17} aria-hidden />
           <span>Send</span>
@@ -196,6 +372,10 @@ export function AssistantView({ client, route, storageKey = defaultStorageKey }:
 
 export function emptyAssistantSession(): AssistantSessionSnapshot {
   return { sessionId: null, messages: [] }
+}
+
+export function idleAssistantStreamState(): AssistantStreamState {
+  return { status: 'idle', lastEventId: null, message: null }
 }
 
 export function loadAssistantSession(storageKey: string): AssistantSessionSnapshot {
@@ -232,12 +412,58 @@ export function routePolicyFromRoute(route: RouteAvailability): AssistantRoutePo
   }
 }
 
-export function assistantErrorMessage(error: AuroraError): string {
-  if (error.code === 'timeout') return 'Aurora timed out before returning a final assistant response.'
-  if (error.code === 'auth' || error.code === 'permission') return 'Assistant request denied by authentication or permissions.'
-  if (error.code === 'unavailable_service' || error.code === 'unsupported_feature') return 'Assistant service is unavailable in this backend or deployment mode.'
-  if (error.code === 'privacy_blocked') return 'Assistant route is blocked by privacy policy until required consent or selector evidence exists.'
+export function assistantErrorMessage(error: AuroraError | Error): string {
+  if ('code' in error && error.code === 'timeout') return 'Aurora timed out before returning a final assistant response.'
+  if ('code' in error && (error.code === 'auth' || error.code === 'permission')) return 'Assistant request denied by authentication or permissions.'
+  if ('code' in error && (error.code === 'unavailable_service' || error.code === 'unsupported_feature')) return 'Assistant service is unavailable in this backend or deployment mode.'
+  if ('code' in error && error.code === 'privacy_blocked') return 'Assistant route is blocked by privacy policy until required consent or selector evidence exists.'
+  if ('code' in error && error.code === 'transport_loss') return 'Assistant stream disconnected before Aurora sent a final event.'
   return error.message || 'Assistant request failed.'
+}
+
+export function assistantControlsForRoute(
+  route: RouteAvailability,
+  cancellationRoute: RouteAvailability | undefined,
+  busy: boolean
+): AssistantControlState {
+  const canSend = !route.disabled && !busy
+  if (!busy) {
+    return {
+      canSend,
+      canCancel: false,
+      cancelReason: 'no active response'
+    }
+  }
+  if (!cancellationRoute) {
+    return {
+      canSend,
+      canCancel: false,
+      cancelReason: 'unsupported: missing Orchestrator.Interrupt capability evidence'
+    }
+  }
+  if (cancellationRoute.disabled) {
+    return {
+      canSend,
+      canCancel: false,
+      cancelReason: cancellationRoute.blockers.join(', ') || 'unsupported by backend capability state'
+    }
+  }
+  return {
+    canSend,
+    canCancel: true,
+    cancelReason: 'supported by Orchestrator.Interrupt'
+  }
+}
+
+export function applyAssistantStreamDelta(message: AssistantUiMessage, update: AssistantStreamUpdate): AssistantUiMessage {
+  const currentText = message.text === 'Waiting for Aurora stream...' || message.text === 'Replaying stream from last backend event...'
+    ? ''
+    : message.text
+  return {
+    ...message,
+    text: `${currentText}${update.textDelta}`,
+    status: 'streaming'
+  }
 }
 
 function ChatBubble({ message }: { message: AssistantUiMessage }) {
@@ -260,6 +486,10 @@ function isAssistantUiMessage(value: unknown): value is AssistantUiMessage {
     (message.role === 'user' || message.role === 'assistant') &&
     typeof message.text === 'string' &&
     typeof message.createdAt === 'string' &&
-    (message.status === 'sent' || message.status === 'sending' || message.status === 'failed')
+    (message.status === 'sent' ||
+      message.status === 'sending' ||
+      message.status === 'streaming' ||
+      message.status === 'failed' ||
+      message.status === 'cancelled')
   )
 }

--- a/packages/aurora-ui/src/assistant-view.tsx
+++ b/packages/aurora-ui/src/assistant-view.tsx
@@ -62,6 +62,8 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
   const [streamState, setStreamState] = useState<AssistantStreamState>(() => idleAssistantStreamState())
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
   const abortRef = useRef<AbortController | null>(null)
+  const activePendingIdRef = useRef<string | null>(null)
+  const cancelledPendingIdsRef = useRef<Set<string>>(new Set())
   const routePolicy = useMemo(() => routePolicyFromRoute(route), [route])
   const isSending = session.messages.some((message) => message.status === 'sending')
   const isStreaming = session.messages.some((message) => message.status === 'streaming')
@@ -113,6 +115,8 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
 
     const abort = new AbortController()
     abortRef.current = abort
+    activePendingIdRef.current = pendingMessage.id
+    cancelledPendingIdsRef.current.delete(pendingMessage.id)
     for await (const update of client.assistant.streamMessage({
       text: prompt,
       sessionId: session.sessionId,
@@ -126,6 +130,7 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
       }
     }
     if (abortRef.current === abort) abortRef.current = null
+    if (activePendingIdRef.current === pendingMessage.id) activePendingIdRef.current = null
   }
 
   function applyAssistantResult(result: AuroraResponse<import('@aurora/client').AssistantSendMessageResult>, pendingId: string) {
@@ -167,6 +172,7 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
   }
 
   function applyAssistantStreamUpdate(update: AssistantStreamUpdate, pendingId: string) {
+    if (cancelledPendingIdsRef.current.has(pendingId)) return
     if (update.eventId) {
       setStreamState((current) => ({ ...current, lastEventId: update.eventId }))
     }
@@ -230,15 +236,7 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
       setSession((current) => ({
         sessionId: update.sessionId ?? current.sessionId ?? session.sessionId,
         messages: current.messages.map((message) =>
-          message.id === pendingId
-            ? {
-                id: update.eventId ?? message.id,
-                role: 'assistant',
-                text: update.text,
-                createdAt: message.createdAt,
-                status: 'sent'
-              }
-            : message
+          message.id === pendingId ? applyAssistantTerminalUpdate(message, update) : message
         )
       }))
       if (update.kind === 'completed') {
@@ -258,6 +256,8 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
 
   async function onCancel() {
     if (!controls.canCancel) return
+    const pendingId = activePendingIdRef.current
+    if (pendingId) cancelledPendingIdsRef.current.add(pendingId)
     abortRef.current?.abort()
     const result = await client.assistant.cancel({
       sessionId: session.sessionId,
@@ -456,6 +456,7 @@ export function assistantControlsForRoute(
 }
 
 export function applyAssistantStreamDelta(message: AssistantUiMessage, update: AssistantStreamUpdate): AssistantUiMessage {
+  if (message.status === 'cancelled') return message
   const currentText = message.text === 'Waiting for Aurora stream...' || message.text === 'Replaying stream from last backend event...'
     ? ''
     : message.text
@@ -463,6 +464,17 @@ export function applyAssistantStreamDelta(message: AssistantUiMessage, update: A
     ...message,
     text: `${currentText}${update.textDelta}`,
     status: 'streaming'
+  }
+}
+
+export function applyAssistantTerminalUpdate(message: AssistantUiMessage, update: AssistantStreamUpdate): AssistantUiMessage {
+  if (message.status === 'cancelled') return message
+  return {
+    id: update.eventId ?? message.id,
+    role: 'assistant',
+    text: update.text,
+    createdAt: message.createdAt,
+    status: 'sent'
   }
 }
 

--- a/packages/aurora-ui/src/nav.tsx
+++ b/packages/aurora-ui/src/nav.tsx
@@ -89,6 +89,19 @@ export const auroraMobileTabs = [
   auroraNavSections[2]!.items[3]!
 ]
 
+export const auroraAssistantCancellationItem = item(
+  'assistant-cancel',
+  'Assistant cancellation',
+  '/',
+  Sparkles,
+  'Orchestrator',
+  'Interrupt',
+  'use',
+  'personal',
+  'unsupported',
+  'UIA-002'
+)
+
 export function getAuroraNavItem(id: string): AuroraNavItem | undefined {
   for (const section of auroraNavSections) {
     const match = section.items.find((item) => item.id === id)

--- a/packages/aurora-ui/src/shell-data.ts
+++ b/packages/aurora-ui/src/shell-data.ts
@@ -7,7 +7,13 @@ import type {
   CapabilityProviderCandidate,
   NativeCapabilityManifest
 } from '@aurora/client'
-import { auroraNavSections, navItemSnapshot, type AuroraNavItem, type AuroraNavItemSnapshot } from './nav'
+import {
+  auroraAssistantCancellationItem,
+  auroraNavSections,
+  navItemSnapshot,
+  type AuroraNavItem,
+  type AuroraNavItemSnapshot
+} from './nav'
 
 export type ShellLoadState = 'loading' | 'ready' | 'error'
 
@@ -58,6 +64,7 @@ export interface AuroraShellSnapshot {
   nativePlatform: string
   nativeAvailable: boolean
   routes: RouteAvailability[]
+  assistantCancellationRoute: RouteAvailability | null
   error: string | null
 }
 
@@ -75,6 +82,7 @@ export const loadingShellSnapshot: AuroraShellSnapshot = {
   nativePlatform: 'unknown',
   nativeAvailable: false,
   routes: [],
+  assistantCancellationRoute: null,
   error: null
 }
 
@@ -98,6 +106,11 @@ export function snapshotFromGraph(
   const routes = auroraNavSections.flatMap((section) =>
     section.items.map((item) => routeAvailability(item, graph.explain(featureIdForNavItem(item)), native))
   )
+  const assistantCancellationRoute = routeAvailability(
+    auroraAssistantCancellationItem,
+    graph.explain(featureIdForNavItem(auroraAssistantCancellationItem)),
+    native
+  )
   return {
     loadState: 'ready',
     nodeName: graph.localNodeName || 'Aurora node',
@@ -112,6 +125,7 @@ export function snapshotFromGraph(
     nativePlatform: native?.platform ?? 'not available',
     nativeAvailable: native !== null,
     routes,
+    assistantCancellationRoute,
     error: null
   }
 }
@@ -134,6 +148,21 @@ export function errorShellSnapshot(transportKind: string, error: unknown): Auror
         requiresAdminAction: item.methodType === 'manage'
       }))
   )
+  const assistantCancellationRoute: RouteAvailability = {
+    item: navItemSnapshot(auroraAssistantCancellationItem),
+    state: 'unsupported',
+    explanation: 'Capability state could not be loaded from AuroraClient.',
+    providerLabel: 'No backend evidence',
+    blockers: ['sdk_error'],
+    repairActions: [repairAction('retry', 'Retry SDK request', '/', true, 'The shell needs a fresh AuroraClient response.')],
+    candidateProviders: [],
+    evidenceSources: ['AuroraClient error'],
+    selectorRequired: false,
+    approvalRequired: false,
+    routeable: false,
+    disabled: true,
+    requiresAdminAction: false
+  }
   return {
     ...loadingShellSnapshot,
     loadState: 'error',
@@ -143,7 +172,8 @@ export function errorShellSnapshot(transportKind: string, error: unknown): Auror
     routeCount: routes.length,
     blockedCount: routes.length,
     error: errorMessage(error),
-    routes
+    routes,
+    assistantCancellationRoute
   }
 }
 

--- a/packages/aurora-ui/src/styles.css
+++ b/packages/aurora-ui/src/styles.css
@@ -96,6 +96,10 @@ button, input, select, textarea { font: inherit; }
 .aui-assistant-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
 .aui-assistant-header h1 { margin: .15rem 0 0; font-size: clamp(1.65rem, 3vw, 2.45rem); line-height: 1.08; }
 .aui-assistant-badges { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: .45rem; max-width: 42rem; }
+.aui-stream-banner { display: flex; align-items: center; gap: .6rem; min-width: 0; border: 1px solid color-mix(in srgb, var(--aui-warning) 36%, var(--aui-border)); border-radius: .5rem; padding: .65rem .75rem; background: color-mix(in srgb, var(--aui-warning) 8%, var(--aui-surface)); color: var(--aui-ink); }
+.aui-stream-banner span { min-width: 0; overflow-wrap: anywhere; }
+.aui-stream-banner button { display: inline-flex; align-items: center; gap: .35rem; margin-left: auto; border: 1px solid var(--aui-border); border-radius: .45rem; padding: .45rem .6rem; background: var(--aui-surface); color: var(--aui-ink); font-weight: 750; }
+.aui-stream-banner button:disabled { cursor: not-allowed; opacity: .58; }
 .aui-assistant-grid { display: grid; min-height: 28rem; grid-template-columns: minmax(0, 1fr) minmax(16rem, 22rem); gap: .85rem; }
 .aui-chat-panel, .aui-route-panel, .aui-assistant-form { border: 1px solid var(--aui-border); border-radius: .5rem; background: var(--aui-surface); }
 .aui-chat-panel { display: flex; min-width: 0; flex-direction: column; gap: .65rem; overflow: auto; padding: .9rem; }
@@ -116,10 +120,11 @@ button, input, select, textarea { font: inherit; }
 .aui-route-panel dd { margin: .15rem 0 0; overflow-wrap: anywhere; }
 .aui-route-panel p { margin: 0; color: var(--aui-muted); line-height: 1.45; }
 .aui-route-panel [role="alert"] { color: var(--aui-danger); }
-.aui-assistant-form { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: .65rem; align-items: end; padding: .75rem; }
+.aui-assistant-form { display: grid; grid-template-columns: minmax(0, 1fr) auto auto auto; gap: .65rem; align-items: end; padding: .75rem; }
 .aui-assistant-form label { grid-column: 1 / -1; color: var(--aui-muted); font-size: .78rem; font-weight: 750; text-transform: uppercase; }
 .aui-assistant-form textarea { min-height: 5.2rem; resize: vertical; border: 1px solid var(--aui-border); border-radius: .45rem; padding: .7rem; background: var(--aui-surface); color: var(--aui-ink); }
 .aui-assistant-form button { display: inline-flex; align-items: center; justify-content: center; gap: .45rem; min-height: 2.65rem; border: 1px solid color-mix(in srgb, var(--aui-primary) 35%, var(--aui-border)); border-radius: .45rem; padding: .65rem .9rem; background: var(--aui-primary); color: white; font-weight: 750; }
+.aui-assistant-form .aui-secondary-button { border-color: var(--aui-border); background: var(--aui-surface-2); color: var(--aui-ink); }
 .aui-assistant-form button:disabled, .aui-assistant-form textarea:disabled { cursor: not-allowed; opacity: .58; }
 
 @media (max-width: 1100px) {
@@ -139,6 +144,8 @@ button, input, select, textarea { font: inherit; }
   .aui-topbar { padding-inline: .75rem; }
   .aui-assistant-header { display: grid; }
   .aui-assistant-badges { justify-content: flex-start; }
+  .aui-stream-banner { align-items: flex-start; flex-wrap: wrap; }
+  .aui-stream-banner button { margin-left: 0; }
   .aui-assistant-form { grid-template-columns: minmax(0, 1fr); }
   .aui-assistant-form button { width: 100%; }
   .aui-chat-bubble { max-width: 100%; }

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -17,6 +17,8 @@ import {
   buildOnboardingViewModel,
   RouteMatrix,
   StateSurface,
+  applyAssistantStreamDelta,
+  assistantControlsForRoute,
   assistantErrorMessage,
   buildShellSnapshot,
   errorShellSnapshot,
@@ -198,12 +200,86 @@ describe('Aurora production shell', () => {
     expect(assistantErrorMessage(new AuroraError({ code: 'auth', message: 'denied' }))).toContain('denied')
     expect(assistantErrorMessage(new AuroraError({ code: 'unavailable_service', message: 'down' }))).toContain('unavailable')
   })
+
+  it('keeps assistant stop capability disabled until Orchestrator.Interrupt evidence exists', async () => {
+    const snapshot = await buildShellSnapshot(new AuroraClient({ transport: new MockAuroraTransport() }))
+    const assistantRoute = route(snapshot, 'assistant')
+    const controlsWithoutInterrupt = assistantControlsForRoute(assistantRoute, undefined, true)
+
+    expect(controlsWithoutInterrupt.canCancel).toBe(false)
+    expect(controlsWithoutInterrupt.cancelReason).toContain('missing Orchestrator.Interrupt')
+
+    const interruptRoute = {
+      ...assistantRoute,
+      item: {
+        ...assistantRoute.item,
+        id: 'assistant-cancel',
+        capabilityMethod: 'Interrupt'
+      },
+      disabled: false,
+      blockers: [],
+      state: 'available-local' as const
+    }
+    const controlsWithInterrupt = assistantControlsForRoute(assistantRoute, interruptRoute, true)
+
+    expect(controlsWithInterrupt.canCancel).toBe(true)
+    expect(controlsWithInterrupt.cancelReason).toContain('supported')
+  })
+
+  it('accumulates assistant stream deltas without replacing backend text with local-only state', () => {
+    const message = {
+      id: 'assistant-pending',
+      role: 'assistant' as const,
+      text: 'Waiting for Aurora stream...',
+      createdAt: '2026-06-21T00:00:00Z',
+      status: 'streaming' as const
+    }
+
+    const first = applyAssistantStreamDelta(message, streamUpdate('Hel'))
+    const second = applyAssistantStreamDelta(first, streamUpdate('lo'))
+
+    expect(first.text).toBe('Hel')
+    expect(second.text).toBe('Hello')
+    expect(second.status).toBe('streaming')
+  })
 })
 
 function route(snapshot: Awaited<ReturnType<typeof buildShellSnapshot>>, id: string) {
   const match = snapshot.routes.find((candidate) => candidate.item.id === id)
   if (!match) throw new Error(`missing route ${id}`)
   return match
+}
+
+function streamUpdate(textDelta: string) {
+  return {
+    kind: 'delta' as const,
+    eventId: 'event-1',
+    sessionId: 'session-1',
+    text: textDelta,
+    textDelta,
+    modelLabel: null,
+    error: null,
+    audit: {
+      correlationId: 'corr-1',
+      eventKind: 'assistant.delta',
+      peerId: null,
+      principalId: null,
+      targetPeerId: null,
+      method: 'Orchestrator.ExternalUserInput',
+      busTopic: 'Orchestrator.ExternalUserInput',
+      toolId: null,
+      resourceId: null,
+      status: null,
+      transport: 'mock',
+      redaction: {
+        secretsRedacted: true,
+        redactedFields: [],
+        source: 'sdk' as const,
+        warnings: []
+      }
+    },
+    metadata: {}
+  }
 }
 
 function stateMatrixCatalog(): CapabilityCatalogResponse {

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -18,6 +18,7 @@ import {
   RouteMatrix,
   StateSurface,
   applyAssistantStreamDelta,
+  applyAssistantTerminalUpdate,
   assistantControlsForRoute,
   assistantErrorMessage,
   buildShellSnapshot,
@@ -241,6 +242,25 @@ describe('Aurora production shell', () => {
     expect(first.text).toBe('Hel')
     expect(second.text).toBe('Hello')
     expect(second.status).toBe('streaming')
+  })
+
+  it('keeps a cancelled assistant message from being overwritten by later stream events', () => {
+    const cancelled = {
+      id: 'assistant-pending',
+      role: 'assistant' as const,
+      text: 'Stopped by user.',
+      createdAt: '2026-06-21T00:00:00Z',
+      status: 'cancelled' as const
+    }
+    const completed = {
+      ...streamUpdate('Final response'),
+      kind: 'completed' as const,
+      text: 'Final response',
+      textDelta: 'Final response'
+    }
+
+    expect(applyAssistantStreamDelta(cancelled, streamUpdate('late delta'))).toEqual(cancelled)
+    expect(applyAssistantTerminalUpdate(cancelled, completed)).toEqual(cancelled)
   })
 })
 


### PR DESCRIPTION
## Summary
- Add SDK assistant streaming normalization over the event stream contract with fallback to non-streaming responses when streams are unavailable before data arrives.
- Add SDK cancellation through `Orchestrator.Interrupt` and expose typed interrupt request/response shapes.
- Wire caller `AbortSignal` into SDK event stream lifecycle so user Stop closes the stream and does not trigger fallback.
- Update the assistant UI to render live stream deltas, final/fallback/loss states, replay from last event, retry, and capability-driven stop controls.
- Guard cancelled pending assistant messages so late stream events cannot overwrite the cancelled state.
- Pass hidden `Orchestrator.Interrupt` capability evidence from the shell snapshot to the assistant page without adding it to navigation.

## Validation
- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test`
- `pnpm --filter @aurora/ui typecheck`
- `pnpm --filter @aurora/ui test`
- `pnpm --filter @aurora/web typecheck`
- `pnpm --filter @aurora/web build`

## Notes
- The stop button is disabled unless the capability graph includes usable `Orchestrator.Interrupt` evidence.
- User-initiated stream abort returns without fallback; fallback remains reserved for stream-unavailable-before-data cases.
- No Tauri/native work is included.
