### PR TITLE
PER-247 implement Tauri command bridge

### DIFF
--- a/apps/aurora-tauri/README.md
+++ b/apps/aurora-tauri/README.md
@@ -4,7 +4,7 @@ This package is the official Tauri 2 desktop shell for Aurora. It hosts the prod
 
 ## Modes
 
-- Desktop local: uses the Tauri IPC bridge and reports local sidecar health. TAURI-001 does not launch Python sidecars; TAURI-002 owns supervision.
+- Desktop local: uses the Tauri IPC bridge and reports local sidecar health. TAURI-004 exposes the command bridge and native manifest; TAURI-002 owns Python sidecar supervision.
 - Desktop thin: set `AURORA_TAURI_REMOTE_GATEWAY_URL` and `AURORA_TAURI_ALLOW_REMOTE_GATEWAY=1` for the Rust bridge to proxy SDK requests to a remote Gateway without a sidecar.
 - Browser development fallback: `VITE_AURORA_GATEWAY_URL` selects HTTP transport; no Gateway URL uses SDK mock fixtures.
 
@@ -18,4 +18,4 @@ cd apps/aurora-tauri/src-tauri && cargo check
 
 ## Scope Boundary
 
-The frontend must use `AuroraClient`; screens must not call Tauri `invoke` except through the SDK transport adapter or this package's runtime bootstrap. Storage, file access, native audio, and sidecar process launch are intentionally disabled until their dedicated follow-up tasks.
+The frontend must use `AuroraClient`; screens must not call Tauri `invoke` except through the SDK transport adapter or this package's runtime bootstrap. Storage, file access, native audio, event subscription streaming, and sidecar process launch are intentionally disabled or explicitly unsupported until their dedicated follow-up tasks.

--- a/apps/aurora-tauri/SECURITY.md
+++ b/apps/aurora-tauri/SECURITY.md
@@ -1,14 +1,20 @@
 # Aurora Tauri Security Review
 
-TAURI-001 exposes only the minimum command and capability surface needed to launch the shared React UI through the official Tauri 2 shell.
+TAURI-004 exposes only the minimum command and capability surface needed for the shared React UI to talk through `AuroraClient` and inspect native shell capability evidence through the official Tauri 2 shell.
 
 ## Exposed Commands
 
 | Command | Purpose | Permission | Notes |
 | --- | --- | --- | --- |
-| `aurora_request` | Proxies typed `AuroraClient` requests to the configured Aurora Gateway. | `aurora-request` | Allows loopback HTTP(S) by default. Remote Gateway origins require `AURORA_TAURI_ALLOW_REMOTE_GATEWAY=1`. Only `content-type`, `x-correlation-id`, and `x-request-id` frontend headers are forwarded. Gateway bearer tokens are read from process environment, not web storage. |
-| `aurora_native_capability_manifest` | Returns Tauri shell capability evidence to the SDK. | `aurora-native-capability-manifest` | Reports allowed and denied native capabilities without secrets. |
+| `aurora_command` | Proxies typed `AuroraClient` requests to the configured Aurora Gateway. | `aurora-command` | Allows loopback HTTP(S) by default. Remote Gateway origins require `AURORA_TAURI_ALLOW_REMOTE_GATEWAY=1`. Only `content-type`, `x-correlation-id`, and `x-request-id` frontend headers are forwarded. Gateway bearer tokens are read from process environment, not web storage. |
+| `aurora_request` | Compatibility alias for the prior SDK request bridge. | `aurora-request` | Delegates to `aurora_command`; retained for migration only. |
+| `aurora_subscribe` | Declares the SDK event subscription bridge. | `aurora-subscribe` | Returns `unsupported_feature` until BE-003 defines the unified backend event stream contract. |
+| `aurora_native_capability_manifest`, `native_capabilities` | Returns Tauri shell capability evidence to the SDK. | `aurora-native-capability-manifest` | Reports allowed and denied native capabilities without secrets. |
 | `aurora_sidecar_status` | Reports local sidecar health. | `aurora-sidecar-status` | TAURI-001 does not launch or manage Python sidecars. It reports sidecar supervision as pending TAURI-002. |
+| `aurora_log_tail` | Reports whether a local sidecar log tail is available. | `aurora-log-tail` | Does not read arbitrary files; returns unavailable until TAURI-002 provides a supervised log source. |
+| `aurora_secure_storage_get`, `aurora_secure_storage_set`, `aurora_secure_storage_delete` | SDK secure-storage helper surface. | `aurora-secure-storage` | Returns `native_permission_missing`; no secure storage plugin is enabled in this task. |
+| `aurora_local_file_read`, `aurora_local_file_write`, `aurora_local_file_pick` | SDK local-file helper surface. | `aurora-local-file` | Returns `native_permission_missing`; no filesystem plugin or file scope is granted. |
+| `aurora_secure_file_handle_open` | Future secure file-handle surface. | `aurora-secure-file-handle` | Returns `native_permission_missing`; scoped handle design is deferred. |
 | `aurora_shutdown` | Exits the shell cleanly. | `aurora-shutdown` | Does not terminate external Aurora processes in TAURI-001. |
 
 ## Capability File
@@ -18,7 +24,7 @@ TAURI-001 exposes only the minimum command and capability surface needed to laun
 - `core:app:default`
 - `core:event:default`
 - `core:window:default`
-- the four Aurora app-command permissions listed above
+- the Aurora app-command permissions listed above
 
 ## Denied By Default
 

--- a/apps/aurora-tauri/src-tauri/build.rs
+++ b/apps/aurora-tauri/src-tauri/build.rs
@@ -2,8 +2,19 @@ fn main() {
     tauri_build::try_build(tauri_build::Attributes::new().app_manifest(
         tauri_build::AppManifest::new().commands(&[
             "aurora_request",
+            "aurora_command",
+            "aurora_subscribe",
             "aurora_sidecar_status",
             "aurora_native_capability_manifest",
+            "native_capabilities",
+            "aurora_log_tail",
+            "aurora_secure_storage_get",
+            "aurora_secure_storage_set",
+            "aurora_secure_storage_delete",
+            "aurora_local_file_read",
+            "aurora_local_file_write",
+            "aurora_local_file_pick",
+            "aurora_secure_file_handle_open",
             "aurora_shutdown",
         ]),
     ))

--- a/apps/aurora-tauri/src-tauri/capabilities/aurora-main.json
+++ b/apps/aurora-tauri/src-tauri/capabilities/aurora-main.json
@@ -1,15 +1,21 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "aurora-main",
-  "description": "Main Aurora desktop shell capability. Grants only the TAURI-001 SDK bridge, native manifest, sidecar health, shutdown, and minimal window/app/event primitives.",
+  "description": "Main Aurora desktop shell capability. Grants only the TAURI-004 SDK bridge, native manifest, sidecar health, log-tail status, explicit denied native helper commands, shutdown, and minimal window/app/event primitives.",
   "windows": ["main"],
   "permissions": [
     "core:app:default",
     "core:event:default",
     "core:window:default",
+    "aurora-command",
     "aurora-request",
+    "aurora-subscribe",
     "aurora-native-capability-manifest",
     "aurora-sidecar-status",
+    "aurora-log-tail",
+    "aurora-secure-storage",
+    "aurora-local-file",
+    "aurora-secure-file-handle",
     "aurora-shutdown"
   ]
 }

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-command.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-command.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-command"
+description = "Allow the frontend SDK adapter to proxy typed AuroraClient command requests to the configured Aurora Gateway origin."
+commands.allow = ["aurora_command"]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-local-file.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-local-file.toml
@@ -1,0 +1,8 @@
+[[permission]]
+identifier = "aurora-local-file"
+description = "Allow local-file helper commands to return structured native-permission-missing responses without granting broad filesystem access."
+commands.allow = [
+  "aurora_local_file_read",
+  "aurora_local_file_write",
+  "aurora_local_file_pick"
+]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-log-tail.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-log-tail.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-log-tail"
+description = "Allow the frontend SDK adapter to query non-secret sidecar log-tail availability without reading arbitrary files."
+commands.allow = ["aurora_log_tail"]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-native-capability-manifest.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-native-capability-manifest.toml
@@ -1,4 +1,4 @@
 [[permission]]
 identifier = "aurora-native-capability-manifest"
 description = "Allow the frontend SDK adapter to read the Tauri shell capability manifest."
-commands.allow = ["aurora_native_capability_manifest"]
+commands.allow = ["aurora_native_capability_manifest", "native_capabilities"]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-request.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-request.toml
@@ -1,4 +1,4 @@
 [[permission]]
 identifier = "aurora-request"
-description = "Allow the frontend SDK adapter to proxy typed AuroraClient requests to the configured Gateway origin."
+description = "Compatibility permission for the legacy AuroraClient Tauri request bridge."
 commands.allow = ["aurora_request"]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-secure-file-handle.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-secure-file-handle.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-secure-file-handle"
+description = "Allow secure file-handle helper commands to return structured native-permission-missing responses until a scoped handle design is implemented."
+commands.allow = ["aurora_secure_file_handle_open"]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-secure-storage.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-secure-storage.toml
@@ -1,0 +1,8 @@
+[[permission]]
+identifier = "aurora-secure-storage"
+description = "Allow secure-storage helper commands to return structured native-permission-missing responses until TAURI-003 enables storage."
+commands.allow = [
+  "aurora_secure_storage_get",
+  "aurora_secure_storage_set",
+  "aurora_secure_storage_delete"
+]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-subscribe.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-subscribe.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-subscribe"
+description = "Allow the frontend SDK adapter to request the Aurora event subscription bridge; currently returns an explicit unsupported-feature response until the backend event stream contract lands."
+commands.allow = ["aurora_subscribe"]

--- a/apps/aurora-tauri/src-tauri/src/lib.rs
+++ b/apps/aurora-tauri/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::env;
@@ -25,6 +25,13 @@ struct AuroraRequest {
 struct AuroraEnvelope {
     data: Value,
     audit: AuroraAudit,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuroraSubscribeRequest {
+    topics: Vec<String>,
+    stream: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -58,6 +65,23 @@ struct SidecarStatus {
     details: BTreeMap<String, Value>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LogTailRequest {
+    lines: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LogTailResult {
+    available: bool,
+    source: String,
+    lines: Vec<String>,
+    truncated: bool,
+    reason: Option<String>,
+    max_lines: usize,
+}
+
 #[derive(Debug, Serialize)]
 struct NativeCapabilityManifest {
     platform: String,
@@ -73,6 +97,10 @@ enum AuroraCommandError {
     Gateway(String),
     #[error("Gateway response was not JSON")]
     InvalidGatewayResponse,
+    #[error("{0} is not available because the required native permission is disabled")]
+    NativePermissionMissing(String),
+    #[error("{0}")]
+    UnsupportedFeature(String),
 }
 
 impl Serialize for AuroraCommandError {
@@ -80,12 +108,28 @@ impl Serialize for AuroraCommandError {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        let mut state = serializer.serialize_struct("AuroraCommandError", 3)?;
+        state.serialize_field("code", self.code())?;
+        state.serialize_field("message", &self.to_string())?;
+        state.serialize_field(
+            "detail",
+            &json!({
+                "code": self.code(),
+                "message": self.to_string(),
+                "secrets_redacted": true,
+            }),
+        )?;
+        state.end()
     }
 }
 
 #[tauri::command]
 async fn aurora_request(request: AuroraRequest) -> Result<AuroraEnvelope, AuroraCommandError> {
+    aurora_command(request).await
+}
+
+#[tauri::command]
+async fn aurora_command(request: AuroraRequest) -> Result<AuroraEnvelope, AuroraCommandError> {
     if request.method == NATIVE_MANIFEST_METHOD {
         return Ok(envelope(
             request.method,
@@ -134,6 +178,19 @@ async fn aurora_request(request: AuroraRequest) -> Result<AuroraEnvelope, Aurora
 }
 
 #[tauri::command]
+async fn aurora_subscribe(
+    request: AuroraSubscribeRequest,
+) -> Result<Vec<Value>, AuroraCommandError> {
+    let topics = request.topics.join(",");
+    let stream = request.stream.unwrap_or_else(|| "event".to_string());
+    Err(AuroraCommandError::UnsupportedFeature(
+        format!(
+            "aurora_subscribe is deferred until BE-003 provides a unified event stream contract; stream={stream}, topics={topics}"
+        ),
+    ))
+}
+
+#[tauri::command]
 async fn aurora_sidecar_status() -> Result<SidecarStatus, AuroraCommandError> {
     let gateway = gateway_url()?;
     let mut details = BTreeMap::new();
@@ -166,9 +223,105 @@ async fn aurora_native_capability_manifest() -> Result<NativeCapabilityManifest,
 }
 
 #[tauri::command]
+async fn native_capabilities() -> Result<NativeCapabilityManifest, AuroraCommandError> {
+    Ok(native_capability_manifest())
+}
+
+#[tauri::command]
+async fn aurora_log_tail(
+    request: Option<LogTailRequest>,
+) -> Result<LogTailResult, AuroraCommandError> {
+    let max_lines = request
+        .and_then(|request| request.lines)
+        .unwrap_or(100)
+        .clamp(1, 500);
+    Ok(LogTailResult {
+        available: false,
+        source: "aurora-sidecar".to_string(),
+        lines: Vec::new(),
+        truncated: false,
+        reason: Some(
+            "TAURI-002 sidecar supervision is not implemented in this shell; no local log source is active"
+                .to_string(),
+        ),
+        max_lines,
+    })
+}
+
+#[tauri::command]
+async fn aurora_secure_storage_get(key: String) -> Result<Value, AuroraCommandError> {
+    let _ = key;
+    Err(native_permission_missing("aurora.secureStorage"))
+}
+
+#[tauri::command]
+async fn aurora_secure_storage_set(
+    key: String,
+    value: String,
+) -> Result<Value, AuroraCommandError> {
+    let _ = (key, value);
+    Err(native_permission_missing("aurora.secureStorage"))
+}
+
+#[tauri::command]
+async fn aurora_secure_storage_delete(key: String) -> Result<Value, AuroraCommandError> {
+    let _ = key;
+    Err(native_permission_missing("aurora.secureStorage"))
+}
+
+#[tauri::command]
+async fn aurora_local_file_read(
+    path: String,
+    options: Option<Value>,
+) -> Result<Value, AuroraCommandError> {
+    let _ = (path, options);
+    Err(native_permission_missing("aurora.localFileRead"))
+}
+
+#[tauri::command]
+async fn aurora_local_file_write(
+    path: String,
+    data: Value,
+    options: Option<Value>,
+) -> Result<Value, AuroraCommandError> {
+    let _ = (path, data, options);
+    Err(native_permission_missing("aurora.localFileWrite"))
+}
+
+#[tauri::command]
+async fn aurora_local_file_pick(options: Option<Value>) -> Result<Value, AuroraCommandError> {
+    let _ = options;
+    Err(native_permission_missing("aurora.secureFileHandle"))
+}
+
+#[tauri::command]
+async fn aurora_secure_file_handle_open(
+    options: Option<Value>,
+) -> Result<Value, AuroraCommandError> {
+    let _ = options;
+    Err(native_permission_missing("aurora.secureFileHandle"))
+}
+
+#[tauri::command]
 async fn aurora_shutdown(app: AppHandle) -> Result<(), AuroraCommandError> {
     app.exit(0);
     Ok(())
+}
+
+impl AuroraCommandError {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidGatewayOrigin(_) => "validation_error",
+            Self::Gateway(_) => "transport_loss",
+            Self::InvalidGatewayResponse => "validation_error",
+            Self::NativePermissionMissing(_) => "native_permission_missing",
+            Self::UnsupportedFeature(_) => "unsupported_feature",
+        }
+    }
+}
+
+fn native_permission_missing(permission: &'static str) -> AuroraCommandError {
+    AuroraCommandError::NativePermissionMissing(permission.to_string())
 }
 
 fn envelope(method: String, data: Value) -> AuroraEnvelope {
@@ -191,21 +344,27 @@ fn envelope(method: String, data: Value) -> AuroraEnvelope {
 
 fn native_capability_manifest() -> NativeCapabilityManifest {
     let mut permissions = BTreeMap::new();
+    permissions.insert("aurora.command".to_string(), true);
     permissions.insert("aurora.request".to_string(), true);
+    permissions.insert("aurora.subscribe".to_string(), true);
     permissions.insert("aurora.nativeCapabilityManifest".to_string(), true);
     permissions.insert("aurora.sidecarStatus".to_string(), true);
     permissions.insert("aurora.shutdown".to_string(), true);
+    permissions.insert("aurora.logTail".to_string(), true);
     permissions.insert("aurora.secureStorage".to_string(), false);
     permissions.insert("aurora.localFileRead".to_string(), false);
     permissions.insert("aurora.localFileWrite".to_string(), false);
+    permissions.insert("aurora.secureFileHandle".to_string(), false);
     permissions.insert("aurora.shell".to_string(), false);
     permissions.insert("aurora.processSpawn".to_string(), false);
 
     let mut capabilities = BTreeMap::new();
     capabilities.insert("desktop.thinGateway".to_string(), true);
     capabilities.insert("desktop.localSidecarHealth".to_string(), true);
+    capabilities.insert("desktop.logTail".to_string(), false);
     capabilities.insert("desktop.localSidecarSupervision".to_string(), false);
     capabilities.insert("native.secureCredentialStorage".to_string(), false);
+    capabilities.insert("native.secureFileHandles".to_string(), false);
     capabilities.insert("native.filesystem".to_string(), false);
     capabilities.insert("native.audio".to_string(), false);
 
@@ -289,8 +448,19 @@ pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             aurora_request,
+            aurora_command,
+            aurora_subscribe,
             aurora_sidecar_status,
             aurora_native_capability_manifest,
+            native_capabilities,
+            aurora_log_tail,
+            aurora_secure_storage_get,
+            aurora_secure_storage_set,
+            aurora_secure_storage_delete,
+            aurora_local_file_read,
+            aurora_local_file_write,
+            aurora_local_file_pick,
+            aurora_secure_file_handle_open,
             aurora_shutdown
         ])
         .run(tauri::generate_context!())

--- a/packages/aurora-sdk/README.md
+++ b/packages/aurora-sdk/README.md
@@ -109,7 +109,7 @@ const transport = new TauriLocalTransport({
   // Optional in tests; production Tauri shells can rely on window.__TAURI__.core.invoke.
   invoke: window.__TAURI__.core.invoke,
   commands: {
-    request: 'aurora_request',
+    request: 'aurora_command',
     sidecarStatus: 'aurora_sidecar_status',
     nativeCapabilityManifest: 'aurora_native_capability_manifest'
   }
@@ -148,7 +148,7 @@ const picked = await transport.pickLocalFile({ filters: [{ name: 'Audio', extens
 const file = picked.cancelled ? null : await transport.readLocalFile(picked.paths[0]!, { encoding: 'base64' })
 ```
 
-Internal bus access is explicit to the Tauri command implementation. The SDK preserves `method`, `busTopic`, payload, timeout, audit hints, permission casing, and returned correlation/redaction metadata when it invokes `aurora_request`.
+Internal bus access is explicit to the Tauri command implementation. The SDK preserves `method`, `busTopic`, payload, timeout, audit hints, permission casing, and returned correlation/redaction metadata when it invokes `aurora_command`.
 
 ## Mesh
 
@@ -381,7 +381,7 @@ Tauri local shells expose the same API through an IPC command that returns backe
 ```ts
 const transport = new TauriLocalTransport({
   invoke: window.__TAURI__.core.invoke,
-  commands: { eventSubscribe: 'aurora_event_subscribe' }
+  commands: { eventSubscribe: 'aurora_subscribe' }
 })
 const client = new AuroraClient({ transport })
 

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -137,10 +137,13 @@ export type {
   LocalFileReadResult,
   LocalFileWriteOptions,
   LocalFileWriteResult,
+  SecureFileHandleOpenOptions,
   SecureStorageGetResult,
   SecureStorageWriteResult,
   TauriCommandNames,
   TauriInvoke,
+  TauriLogTailRequest,
+  TauriLogTailResult,
   TauriLocalTransportOptions,
   TauriSidecarStatus
 } from './tauri.js'

--- a/packages/aurora-sdk/src/tauri.ts
+++ b/packages/aurora-sdk/src/tauri.ts
@@ -14,12 +14,14 @@ export interface TauriCommandNames {
   request: string
   sidecarStatus: string
   nativeCapabilityManifest: string
+  logTail: string
   secureStorageGet: string
   secureStorageSet: string
   secureStorageDelete: string
   localFileRead: string
   localFileWrite: string
   localFilePick: string
+  secureFileHandleOpen: string
   eventSubscribe: string
 }
 
@@ -38,6 +40,19 @@ export interface TauriSidecarStatus {
   version?: string | null
   lastError?: string | null
   details?: JsonObject
+}
+
+export interface TauriLogTailRequest {
+  lines?: number
+}
+
+export interface TauriLogTailResult {
+  available: boolean
+  source: string
+  lines: string[]
+  truncated: boolean
+  reason?: string | null
+  maxLines?: number
 }
 
 export interface SecureStorageGetResult {
@@ -82,17 +97,23 @@ export interface LocalFilePickResult {
   cancelled: boolean
 }
 
+export interface SecureFileHandleOpenOptions extends LocalFilePickOptions {
+  mode?: 'read' | 'write' | 'readwrite'
+}
+
 const DEFAULT_COMMANDS: TauriCommandNames = {
-  request: 'aurora_request',
+  request: 'aurora_command',
   sidecarStatus: 'aurora_sidecar_status',
   nativeCapabilityManifest: 'aurora_native_capability_manifest',
+  logTail: 'aurora_log_tail',
   secureStorageGet: 'aurora_secure_storage_get',
   secureStorageSet: 'aurora_secure_storage_set',
   secureStorageDelete: 'aurora_secure_storage_delete',
   localFileRead: 'aurora_local_file_read',
   localFileWrite: 'aurora_local_file_write',
   localFilePick: 'aurora_local_file_pick',
-  eventSubscribe: 'aurora_event_subscribe'
+  secureFileHandleOpen: 'aurora_secure_file_handle_open',
+  eventSubscribe: 'aurora_subscribe'
 }
 
 export class TauriLocalTransport implements AuroraTransport {
@@ -138,6 +159,10 @@ export class TauriLocalTransport implements AuroraTransport {
     return this.invokeCommand<NativeCapabilityManifest>(this.commands.nativeCapabilityManifest)
   }
 
+  getLogTail(request: TauriLogTailRequest = {}): Promise<TauriLogTailResult> {
+    return this.invokeCommand<TauriLogTailResult>(this.commands.logTail, { request })
+  }
+
   secureStorageGet(key: string): Promise<SecureStorageGetResult> {
     return this.invokeCommand<SecureStorageGetResult>(this.commands.secureStorageGet, { key })
   }
@@ -164,6 +189,10 @@ export class TauriLocalTransport implements AuroraTransport {
 
   pickLocalFile(options: LocalFilePickOptions = {}): Promise<LocalFilePickResult> {
     return this.invokeCommand<LocalFilePickResult>(this.commands.localFilePick, { options })
+  }
+
+  openSecureFileHandle(options: SecureFileHandleOpenOptions = {}): Promise<LocalFilePickResult> {
+    return this.invokeCommand<LocalFilePickResult>(this.commands.secureFileHandleOpen, { options })
   }
 
   async subscribe<TEventPayload = unknown, TPayload = unknown>(

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -1598,7 +1598,7 @@ describe('AuroraClient', () => {
 
     expect(registry.digest).toBe('fixture')
     expect(calls[0]).toEqual({
-      command: 'aurora_request',
+      command: 'aurora_command',
       args: {
         request: expect.objectContaining({
           method: 'Gateway.GetRegistry',
@@ -1631,6 +1631,8 @@ describe('AuroraClient', () => {
             return { running: true, mode: 'sidecar', pid: 42 }
           case 'aurora_native_capability_manifest':
             return nativeCapabilityManifestFixture
+          case 'aurora_log_tail':
+            return { available: false, source: 'aurora-sidecar', lines: [], truncated: false }
           case 'aurora_secure_storage_get':
             return { key: 'session', value: 'token-ref' }
           case 'aurora_secure_storage_set':
@@ -1642,6 +1644,8 @@ describe('AuroraClient', () => {
             return { path: String(args?.path), ok: true, bytesWritten: 5 }
           case 'aurora_local_file_pick':
             return { paths: ['/tmp/a.txt'], cancelled: false }
+          case 'aurora_secure_file_handle_open':
+            return { paths: ['/tmp/a.txt'], cancelled: false }
           default:
             throw new Error(`Unexpected command ${command}`)
         }
@@ -1652,6 +1656,12 @@ describe('AuroraClient', () => {
       expect.objectContaining({ running: true, mode: 'sidecar' })
     )
     await expect(transport.getNativeCapabilityManifest()).resolves.toEqual(nativeCapabilityManifestFixture)
+    await expect(transport.getLogTail({ lines: 10 })).resolves.toEqual({
+      available: false,
+      source: 'aurora-sidecar',
+      lines: [],
+      truncated: false
+    })
     await expect(transport.secureStorageGet('session')).resolves.toEqual({ key: 'session', value: 'token-ref' })
     await expect(transport.secureStorageSet('session', 'token-ref')).resolves.toEqual({ key: 'session', ok: true })
     await expect(transport.secureStorageDelete('session')).resolves.toEqual({ key: 'session', ok: true })
@@ -1669,19 +1679,27 @@ describe('AuroraClient', () => {
       paths: ['/tmp/a.txt'],
       cancelled: false
     })
+    await expect(transport.openSecureFileHandle({ mode: 'read' })).resolves.toEqual({
+      paths: ['/tmp/a.txt'],
+      cancelled: false
+    })
 
     expect(calls.map((call) => call.command)).toEqual([
       'aurora_sidecar_status',
       'aurora_native_capability_manifest',
+      'aurora_log_tail',
       'aurora_secure_storage_get',
       'aurora_secure_storage_set',
       'aurora_secure_storage_delete',
       'aurora_local_file_read',
       'aurora_local_file_write',
-      'aurora_local_file_pick'
+      'aurora_local_file_pick',
+      'aurora_secure_file_handle_open'
     ])
-    expect(calls[3]?.args).toEqual({ key: 'session', value: 'token-ref' })
-    expect(calls[6]?.args).toEqual({ path: '/tmp/a.txt', data: 'hello', options: {} })
+    expect(calls[2]?.args).toEqual({ request: { lines: 10 } })
+    expect(calls[4]?.args).toEqual({ key: 'session', value: 'token-ref' })
+    expect(calls[7]?.args).toEqual({ path: '/tmp/a.txt', data: 'hello', options: {} })
+    expect(calls[9]?.args).toEqual({ options: { mode: 'read' } })
   })
 
   it('classifies Tauri auth, permission, validation, timeout, unavailable, unsupported, privacy, native permission, and transport-loss failures', async () => {
@@ -2107,7 +2125,7 @@ describe('AuroraClient', () => {
   it('adapts Tauri and mesh event streams without changing backend evidence', async () => {
     const tauri = new TauriLocalTransport({
       invoke: async (command, args) => {
-        expect(command).toBe('aurora_event_subscribe')
+        expect(command).toBe('aurora_subscribe')
         expect(args?.request).toEqual(expect.objectContaining({ stream: 'config' }))
         return [{ id: 'config-1', kind: 'config.updated', payload: { key: 'ui.dark_mode' }, correlation_id: 'corr-config' }]
       }

--- a/packages/aurora-sdk/tests/conformance.test.ts
+++ b/packages/aurora-sdk/tests/conformance.test.ts
@@ -64,7 +64,7 @@ const conformanceCases: ConformanceCase[] = [
       new AuroraClient({
         transport: new TauriLocalTransport({
           invoke: async (command, args) => {
-            if (command !== 'aurora_request') {
+            if (command !== 'aurora_command') {
               throw new Error(`Unexpected Tauri command ${command}`)
             }
             const request = readTauriRequest(args)
@@ -197,7 +197,7 @@ describe('SDK transport conformance', () => {
       new AuroraClient({
         transport: new TauriLocalTransport({
           invoke: async (command, args) => {
-            if (command !== 'aurora_request') throw new Error(`Unexpected Tauri command ${command}`)
+            if (command !== 'aurora_command') throw new Error(`Unexpected Tauri command ${command}`)
             return { data: conformanceResponse(readTauriRequest(args).method), status: 200 }
           }
         })


### PR DESCRIPTION
## Summary

Implements the TAURI-004 command bridge surface for the Aurora Tauri shell and updates the SDK adapter to use it.

- Adds `aurora_command`, `aurora_subscribe`, `native_capabilities`, `aurora_log_tail`, denied secure-storage/local-file/secure-file-handle commands, and keeps `aurora_request` as a compatibility alias.
- Updates Tauri capability/permission files so every exposed command is listed and broad filesystem/shell/process/native storage permissions remain denied by default.
- Updates `TauriLocalTransport` defaults, helper methods, tests, and security docs for the new command names and structured native-permission errors.

## Validation

- `cargo fmt` in `apps/aurora-tauri/src-tauri`
- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test`
- `pnpm --filter @aurora/client build`
- `pnpm --filter @aurora/tauri-ui typecheck`
- `pnpm --filter @aurora/tauri-ui test`
- `pnpm --filter @aurora/tauri-ui build`

## Known Environment Gap

`cargo check` in `apps/aurora-tauri/src-tauri` could not complete in this container because Linux Tauri system development packages are missing: `glib-2.0` / `gobject-2.0` pkg-config files. Attempting to install the required system libraries was blocked because `sudo` requires an interactive password.

Smoke launch was not run for the same native dependency/display environment reason.
