### PR TITLE
PER-260 wire attachments and share intake UI

### DIFF
--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -41,6 +41,8 @@ import type {
   AuthValidateTokenRequest,
   AuthValidateTokenResponse,
   AuthWhoAmIResponse,
+  AttachmentContextIngestRequest,
+  AttachmentContextIngestResponse,
   AssistantSendMessageRequest,
   AssistantSendMessageResult,
   AssistantCancelRequest,
@@ -385,6 +387,16 @@ export class RouteClient {
 
 export class AssistantClient {
   constructor(private readonly client: AuroraClient) {}
+
+  ingestContext(
+    input: AttachmentContextIngestRequest
+  ): Promise<AuroraResponse<AttachmentContextIngestResponse>> {
+    return this.client.requestResult<AttachmentContextIngestResponse, AttachmentContextIngestRequest>(
+      ORCHESTRATOR_METHODS.ingestContext,
+      input,
+      { path: routePath('Orchestrator', 'IngestContext') }
+    )
+  }
 
   async sendMessage(input: AssistantSendMessageRequest): Promise<AuroraResponse<AssistantSendMessageResult>> {
     const text = input.text.trim()

--- a/packages/aurora-sdk/src/descriptors.ts
+++ b/packages/aurora-sdk/src/descriptors.ts
@@ -47,6 +47,7 @@ export const TOOLING_METHODS = {
 export const ORCHESTRATOR_METHODS = {
   userInput: 'Orchestrator.UserInput',
   externalUserInput: 'Orchestrator.ExternalUserInput',
+  ingestContext: 'Orchestrator.IngestContext',
   interrupt: 'Orchestrator.Interrupt',
   toolResult: 'Orchestrator.ToolResult',
   response: 'Orchestrator.Response'

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -682,7 +682,7 @@ export const gatewayBuiltinRoutesFixture: GatewayBuiltinRouteDescriptor[] = [
 
 export const backendInventoryFixture: BackendInventory = {
   generated_by: 'scripts/generate_backend_inventory.py',
-  method_count: 5,
+  method_count: 6,
   gateway_builtin_count: 2,
   methods: [
     {
@@ -784,6 +784,29 @@ export const backendInventoryFixture: BackendInventory = {
       output_schema: null,
       source: 'static_contract',
       source_file: 'tests/fixtures/gateway.py:1'
+    },
+    {
+      module: 'Orchestrator',
+      name: 'IngestContext',
+      summary: 'Ingest assistant attachment and shared context metadata',
+      bus_topic: 'Orchestrator.IngestContext',
+      routePath: '/api/Orchestrator/IngestContext',
+      route_kind: 'dynamic',
+      exposure: 'external',
+      method_type: 'use',
+      required_perms: ['Orchestrator.use'],
+      input_model: 'AttachmentContextIngestRequest',
+      output_model: 'AttachmentContextIngestResponse',
+      input_schema: {
+        title: 'AttachmentContextIngestRequest',
+        type: 'object'
+      },
+      output_schema: {
+        title: 'AttachmentContextIngestResponse',
+        type: 'object'
+      },
+      source: 'live_registry',
+      source_file: 'app/services/orchestrator/service.py:245'
     }
   ],
   gateway_builtins: [

--- a/packages/aurora-sdk/src/mock.ts
+++ b/packages/aurora-sdk/src/mock.ts
@@ -7,6 +7,14 @@ import {
 } from './events.js'
 import { cloneFixture, defaultMockAuroraFixtures, type MockAuroraFixtureSet } from './fixtures.js'
 import type { AuroraEvent, AuroraTransportEnvelope } from './types.js'
+import type {
+  AttachmentContextIngestRequest,
+  AttachmentContextIngestResponse,
+  AttachmentContextItem,
+  AttachmentContextItemResult,
+  AttachmentContextPrivacyClass,
+  AttachmentContextStoragePolicy
+} from './types.js'
 import type { AuroraTransport, AuroraTransportRequest, AuroraTransportResponse } from './transport.js'
 
 export type MockHandler<TPayload = unknown, TData = unknown> = (
@@ -48,6 +56,7 @@ export class MockAuroraTransport implements AuroraTransport {
       .register('Gateway.ExplainRoute', () => cloneFixture(fixtures.routeExplain))
       .register('Native.GetCapabilityManifest', () => cloneFixture(fixtures.nativeManifest))
       .register('Tooling.GetToolCatalog', () => cloneFixture(fixtures.toolCatalog))
+      .register('Orchestrator.IngestContext', (request) => mockIngestContext(request.payload))
       .register('Orchestrator.ExternalUserInput', (request) => ({
         text: `Mock Aurora response to "${mockPromptText(request.payload)}"`,
         session_id: mockSessionId(request.payload),
@@ -154,6 +163,148 @@ function mockSessionId(payload: unknown): string {
     if (typeof sessionId === 'string' && sessionId.trim()) return sessionId
   }
   return 'mock-assistant-session'
+}
+
+function mockIngestContext(payload: unknown): AttachmentContextIngestResponse {
+  const request = normalizeIngestRequest(payload)
+  const acceptedItems: AttachmentContextItemResult[] = []
+  const rejectedItems: AttachmentContextItemResult[] = []
+  let totalBytes = 0
+
+  request.items.forEach((item, index) => {
+    const itemBytes = contextItemSize(item)
+    totalBytes += itemBytes
+    const base = contextResult(item, index, request.storage_policy, request.privacy_class, itemBytes)
+
+    if (request.storage_policy === 'reject') {
+      rejectedItems.push({
+        ...base,
+        status: 'rejected',
+        reason_code: 'storage_policy_reject',
+        message: 'Storage policy rejects attachment/context ingestion'
+      })
+      return
+    }
+
+    if (['secret', 'credential', 'raw-audio'].includes(request.privacy_class)) {
+      rejectedItems.push({
+        ...base,
+        status: 'rejected',
+        reason_code: 'privacy_class_blocked',
+        message: 'Privacy class is not accepted for assistant context ingestion'
+      })
+      return
+    }
+
+    if (itemBytes > request.limits.max_item_bytes) {
+      rejectedItems.push({
+        ...base,
+        status: 'rejected',
+        reason_code: 'item_too_large',
+        message: `Context item exceeds limit ${request.limits.max_item_bytes} bytes`
+      })
+      return
+    }
+
+    if (totalBytes > request.limits.max_total_bytes) {
+      rejectedItems.push({
+        ...base,
+        status: 'rejected',
+        reason_code: 'total_too_large',
+        message: `Context batch exceeds limit ${request.limits.max_total_bytes} bytes`
+      })
+      return
+    }
+
+    if (!contextText(item)) {
+      rejectedItems.push({
+        ...base,
+        status: 'unsupported',
+        reason_code: 'no_text_context',
+        message: 'Only text-like attachment/context content is supported'
+      })
+      return
+    }
+
+    const redacted = contextText(item).includes('sk-') || contextText(item).includes('password')
+    acceptedItems.push({
+      ...base,
+      status: redacted ? 'redacted' : request.storage_policy === 'rag' ? 'stored' : 'accepted',
+      stored_namespace: request.storage_policy === 'rag' ? request.namespace : null,
+      stored_key: request.storage_policy === 'rag' ? `mock-context-${index}` : null,
+      redacted,
+      redaction_reasons: redacted ? ['secret_pattern'] : [],
+      message: 'Context accepted for assistant use'
+    })
+  })
+
+  return {
+    accepted: acceptedItems.length > 0,
+    rejected: rejectedItems.length > 0,
+    total_items: request.items.length,
+    accepted_items: acceptedItems,
+    rejected_items: rejectedItems,
+    total_bytes: totalBytes,
+    storage_policy: request.storage_policy,
+    privacy_class: request.privacy_class,
+    audit_event: 'assistant.context.ingested',
+    correlation_id: request.correlation_id ?? 'mock-context-correlation',
+    secrets_redacted: true
+  }
+}
+
+function normalizeIngestRequest(payload: unknown): Required<Pick<
+  AttachmentContextIngestRequest,
+  'items' | 'namespace' | 'storage_policy' | 'privacy_class'
+>> & Pick<AttachmentContextIngestRequest, 'correlation_id'> & {
+  limits: Required<NonNullable<AttachmentContextIngestRequest['limits']>>
+} {
+  const input = typeof payload === 'object' && payload !== null ? payload as AttachmentContextIngestRequest : { items: [] }
+  return {
+    items: Array.isArray(input.items) ? input.items : [],
+    namespace: input.namespace ?? 'assistant.attachments',
+    storage_policy: input.storage_policy ?? 'ephemeral',
+    privacy_class: input.privacy_class ?? 'personal',
+    correlation_id: input.correlation_id ?? null,
+    limits: {
+      max_items: input.limits?.max_items ?? 8,
+      max_item_bytes: input.limits?.max_item_bytes ?? 262_144,
+      max_total_bytes: input.limits?.max_total_bytes ?? 1_048_576,
+      max_text_chars: input.limits?.max_text_chars ?? 120_000
+    }
+  }
+}
+
+function contextResult(
+  item: AttachmentContextItem,
+  index: number,
+  storagePolicy: AttachmentContextStoragePolicy,
+  privacyClass: AttachmentContextPrivacyClass,
+  acceptedBytes: number
+): AttachmentContextItemResult {
+  return {
+    item_id: `mock-context-${index}`,
+    kind: item.kind,
+    status: 'accepted',
+    storage_policy: storagePolicy,
+    privacy_class: privacyClass,
+    accepted_bytes: acceptedBytes,
+    stored_namespace: null,
+    stored_key: null,
+    redacted: false,
+    redaction_reasons: [],
+    reason_code: null,
+    message: ''
+  }
+}
+
+function contextItemSize(item: AttachmentContextItem): number {
+  if (typeof item.size_bytes === 'number') return item.size_bytes
+  return new TextEncoder().encode(contextText(item)).length
+}
+
+function contextText(item: AttachmentContextItem): string {
+  return item.content_text ?? item.url ?? item.title ?? ''
 }
 
 async function* normalizeMockEvents<TPayload>(

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -179,6 +179,96 @@ export interface AssistantCancelRequest {
   reason?: string
 }
 
+export type AttachmentContextKind = 'text' | 'url' | 'file' | 'image'
+export type AttachmentContextPrivacyClass = Exclude<PrivacyClass, 'admin-critical'>
+export type AttachmentContextSourceChannel =
+  | 'chat'
+  | 'api'
+  | 'desktop'
+  | 'mobile_share_sheet'
+  | 'deep_link'
+  | 'browser_extension'
+export type AttachmentContextStoragePolicy = 'ephemeral' | 'rag' | 'reject'
+export type AttachmentContextStatus =
+  | 'accepted'
+  | 'stored'
+  | 'rejected'
+  | 'redacted'
+  | 'unsupported'
+
+export interface AttachmentContextLimits {
+  max_items: number
+  max_item_bytes: number
+  max_total_bytes: number
+  max_text_chars: number
+}
+
+export interface AttachmentContextSource {
+  channel: AttachmentContextSourceChannel
+  display_name?: string | null
+  uri?: string | null
+  mime_type?: string | null
+  platform?: string | null
+  originating_app?: string | null
+  shared_at?: string | null
+  principal_id?: string | null
+  device_id?: string | null
+  peer_id?: string | null
+}
+
+export interface AttachmentContextItem {
+  kind: AttachmentContextKind
+  content_text?: string | null
+  url?: string | null
+  title?: string | null
+  filename?: string | null
+  mime_type?: string | null
+  size_bytes?: number | null
+  source?: Partial<AttachmentContextSource> | null
+  metadata?: JsonObject
+}
+
+export interface AttachmentContextIngestRequest {
+  items: AttachmentContextItem[]
+  session_id?: string | null
+  namespace?: string
+  storage_policy?: AttachmentContextStoragePolicy
+  privacy_class?: AttachmentContextPrivacyClass
+  caller_principal_id?: string | null
+  correlation_id?: string | null
+  policy_decision_id?: string | null
+  limits?: Partial<AttachmentContextLimits>
+}
+
+export interface AttachmentContextItemResult {
+  item_id: string
+  kind: AttachmentContextKind
+  status: AttachmentContextStatus
+  storage_policy: AttachmentContextStoragePolicy
+  privacy_class: AttachmentContextPrivacyClass
+  accepted_bytes: number
+  stored_namespace: string | null
+  stored_key: string | null
+  redacted: boolean
+  redaction_reasons: string[]
+  reason_code: string | null
+  message: string
+}
+
+export interface AttachmentContextIngestResponse {
+  accepted: boolean
+  rejected: boolean
+  total_items: number
+  accepted_items: AttachmentContextItemResult[]
+  rejected_items: AttachmentContextItemResult[]
+  total_bytes: number
+  storage_policy: AttachmentContextStoragePolicy
+  privacy_class: AttachmentContextPrivacyClass
+  audit_event: string
+  correlation_id: string | null
+  secrets_redacted: boolean
+}
+
 export type ContractExposure = 'internal' | 'external' | 'both' | 'gateway_builtin' | string
 export type ContractMethodType = 'use' | 'manage' | 'event' | 'gateway' | string
 

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -426,6 +426,78 @@ describe('AuroraClient', () => {
     expect(uiMockReferenceFixtureSummary.privacyClasses).toContain('admin-critical')
   })
 
+  it('ingests assistant attachment context through the typed SDK namespace', async () => {
+    const client = new AuroraClient({ transport: new MockAuroraTransport() })
+
+    await expect(
+      client.assistant.ingestContext({
+        items: [
+          {
+            kind: 'text',
+            content_text: 'Screenshot OCR with password=redacted by backend',
+            title: 'Screenshot OCR',
+            source: { channel: 'mobile_share_sheet', display_name: 'Android share sheet' }
+          },
+          {
+            kind: 'image',
+            filename: 'screen.png',
+            mime_type: 'image/png',
+            size_bytes: 42_000,
+            source: { channel: 'mobile_share_sheet', display_name: 'Android share sheet' }
+          }
+        ],
+        privacy_class: 'personal',
+        storage_policy: 'ephemeral',
+        limits: { max_item_bytes: 262_144 }
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        ok: true,
+        data: expect.objectContaining({
+          accepted: true,
+          rejected: true,
+          accepted_items: [
+            expect.objectContaining({
+              kind: 'text',
+              status: 'redacted',
+              redacted: true,
+              privacy_class: 'personal'
+            })
+          ],
+          rejected_items: [
+            expect.objectContaining({
+              kind: 'image',
+              status: 'unsupported',
+              reason_code: 'no_text_context'
+            })
+          ],
+          secrets_redacted: true
+        })
+      })
+    )
+
+    await expect(
+      client.assistant.ingestContext({
+        items: [{ kind: 'text', content_text: 'token body' }],
+        privacy_class: 'credential'
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        ok: true,
+        data: expect.objectContaining({
+          accepted: false,
+          rejected: true,
+          rejected_items: [
+            expect.objectContaining({
+              status: 'rejected',
+              reason_code: 'privacy_class_blocked'
+            })
+          ]
+        })
+      })
+    )
+  })
+
   it('evaluates route policy denials without downgrading privacy blockers to unavailable', () => {
     const evaluation = evaluateRoutePolicy({
       route: routeExplainFixture,

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -98,6 +98,32 @@ describe('AuroraClient', () => {
     )
   })
 
+  it('advertises assistant context ingestion from backend inventory descriptors', () => {
+    const descriptors = describeBackendInventory(backendInventoryFixture)
+
+    expect(descriptors.methods).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          busTopic: ORCHESTRATOR_METHODS.ingestContext,
+          routePath: '/api/Orchestrator/IngestContext',
+          exposure: 'external',
+          methodType: 'use',
+          requiredPermissions: ['Orchestrator.use'],
+          inputModel: 'AttachmentContextIngestRequest',
+          outputModel: 'AttachmentContextIngestResponse',
+          availableOverHttp: true,
+          routeKind: 'dynamic'
+        })
+      ])
+    )
+    expect(descriptors.methodTypes[ORCHESTRATOR_METHODS.ingestContext]).toEqual(
+      expect.objectContaining({
+        requestModel: 'AttachmentContextIngestRequest',
+        responseModel: 'AttachmentContextIngestResponse'
+      })
+    )
+  })
+
   it('summarizes capability catalog responses without inventing state', async () => {
     const catalog = {
       ...capabilityCatalogFixture,

--- a/packages/aurora-sdk/tests/conformance.test.ts
+++ b/packages/aurora-sdk/tests/conformance.test.ts
@@ -252,7 +252,8 @@ describe('SDK transport conformance', () => {
       'Gateway.GetRegistry',
       'Gateway.GetDeploymentTopology',
       'Gateway.GetWebRTCDiagnostics',
-      'Gateway.InternalOnly'
+      'Gateway.InternalOnly',
+      'Orchestrator.IngestContext'
     ])
     expect(generated.gatewayBuiltins.map((route) => route.routePath)).toEqual(['/api/registry', '/api/admin/peers'])
     expect(comparison).toEqual({ ok: true, checked: 4, issues: [] })

--- a/packages/aurora-ui/src/assistant-view.tsx
+++ b/packages/aurora-ui/src/assistant-view.tsx
@@ -1,8 +1,13 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
-import { RotateCcw, SendHorizontal, StopCircle, WifiOff } from 'lucide-react'
+import { Link, Paperclip, RotateCcw, SendHorizontal, Share2, StopCircle, Trash2, WifiOff } from 'lucide-react'
 import type {
+  AttachmentContextIngestResponse,
+  AttachmentContextItem,
+  AttachmentContextPrivacyClass,
+  AttachmentContextSourceChannel,
+  AttachmentContextStatus,
   AssistantMessage as SdkAssistantMessage,
   AssistantRoutePolicy,
   AssistantStreamUpdate,
@@ -51,11 +56,52 @@ export interface AssistantControlState {
   cancelReason: string
 }
 
+export type AttachmentTrayStatus =
+  | 'staged'
+  | 'uploading'
+  | 'accepted'
+  | 'redacted'
+  | 'stored'
+  | 'unsupported'
+  | 'rejected'
+  | 'error'
+
+export interface AssistantAttachmentDraft {
+  id: string
+  kind: 'text' | 'url' | 'file' | 'image'
+  label: string
+  detail: string
+  contentText?: string | null
+  url?: string | null
+  filename?: string | null
+  mimeType?: string | null
+  sizeBytes?: number | null
+  sourceChannel: AttachmentContextSourceChannel
+  sourceDisplayName: string
+  privacyClass: AttachmentContextPrivacyClass
+  status: AttachmentTrayStatus
+  progress: number
+  message: string
+  reasonCode?: string | null
+  redacted: boolean
+}
+
 const defaultStorageKey = 'aurora.assistant.session.v1'
+const defaultContextLimits = {
+  max_items: 8,
+  max_item_bytes: 262_144,
+  max_total_bytes: 1_048_576,
+  max_text_chars: 120_000
+}
 
 export function AssistantView({ client, route, cancellationRoute, storageKey = defaultStorageKey }: AssistantViewProps) {
   const [session, setSession] = useState<AssistantSessionSnapshot>(() => emptyAssistantSession())
   const [text, setText] = useState('')
+  const [urlDraft, setUrlDraft] = useState('')
+  const [sharedTextDraft, setSharedTextDraft] = useState('')
+  const [privacyClass, setPrivacyClass] = useState<AttachmentContextPrivacyClass>('personal')
+  const [sourceChannel, setSourceChannel] = useState<AttachmentContextSourceChannel>('chat')
+  const [attachments, setAttachments] = useState<AssistantAttachmentDraft[]>([])
   const [lastResult, setLastResult] = useState<SdkAssistantMessage | null>(null)
   const [modelLabel, setModelLabel] = useState<string | null>(null)
   const [lastError, setLastError] = useState<string | null>(null)
@@ -68,8 +114,14 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
   const routePolicy = useMemo(() => routePolicyFromRoute(route), [route])
   const isSending = session.messages.some((message) => message.status === 'sending')
   const isStreaming = session.messages.some((message) => message.status === 'streaming')
-  const controls = assistantControlsForRoute(route, cancellationRoute, isSending || isStreaming)
+  const hasContextUpload = attachments.some((attachment) => attachment.status === 'uploading')
+  const controls = assistantControlsForRoute(route, cancellationRoute, isSending || isStreaming || hasContextUpload)
   const canSend = controls.canSend
+  const canAttach = !route.disabled && !isSending && !isStreaming && !hasContextUpload
+  const attachmentsAwaitingValidation = attachments.filter((attachment) =>
+    attachment.status === 'staged' || attachment.status === 'error'
+  )
+  const contextSummary = summarizeAttachments(attachments)
 
   useEffect(() => {
     setSession(loadAssistantSession(storageKey))
@@ -85,6 +137,8 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
     event.preventDefault()
     const prompt = text.trim()
     if (!prompt || !canSend) return
+    const contextResult = await ingestPendingAttachments()
+    if (contextResult === 'blocked') return
     await startAssistantTurn(prompt)
   }
 
@@ -132,6 +186,81 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
     }
     if (abortRef.current === abort) abortRef.current = null
     if (activePendingIdRef.current === pendingMessage.id) activePendingIdRef.current = null
+  }
+
+  async function ingestPendingAttachments(): Promise<'ready' | 'blocked'> {
+    if (attachments.some((attachment) => attachment.status === 'rejected' || attachment.status === 'unsupported')) {
+      setLastError('Remove rejected or unsupported context items before sending.')
+      return 'blocked'
+    }
+    const pending = attachments.filter((attachment) => attachment.status === 'staged' || attachment.status === 'error')
+    if (pending.length === 0) return 'ready'
+
+    setLastError(null)
+    setAttachments((current) =>
+      current.map((attachment) =>
+        pending.some((candidate) => candidate.id === attachment.id)
+          ? { ...attachment, status: 'uploading', progress: 48, message: 'Uploading context metadata through AuroraClient' }
+          : attachment
+      )
+    )
+
+    const result = await client.assistant.ingestContext({
+      items: pending.map(attachmentToContextItem),
+      session_id: session.sessionId,
+      namespace: 'assistant.attachments',
+      storage_policy: 'ephemeral',
+      privacy_class: privacyClass,
+      limits: defaultContextLimits
+    })
+
+    if (!result.ok) {
+      const message = assistantErrorMessage(result.error)
+      setLastError(message)
+      setAttachments((current) =>
+        current.map((attachment) =>
+          pending.some((candidate) => candidate.id === attachment.id)
+            ? { ...attachment, status: 'error', progress: 0, message }
+            : attachment
+        )
+      )
+      return 'blocked'
+    }
+
+    applyContextIngestResult(pending, result.data)
+    return result.data.accepted && !result.data.rejected ? 'ready' : 'blocked'
+  }
+
+  function applyContextIngestResult(
+    pending: AssistantAttachmentDraft[],
+    response: AttachmentContextIngestResponse
+  ) {
+    const outcomes = new Map(
+      [...response.accepted_items, ...response.rejected_items]
+        .map((outcome) => [Number(outcome.item_id.split('-').at(-1)), outcome] as const)
+        .filter(([index]) => Number.isFinite(index))
+    )
+    setAttachments((current) =>
+      current.map((attachment) => {
+        const pendingIndex = pending.findIndex((candidate) => candidate.id === attachment.id)
+        if (pendingIndex === -1) return attachment
+        const outcome = outcomes.get(pendingIndex)
+        if (!outcome) {
+          return { ...attachment, status: 'error', progress: 0, message: 'No backend outcome was returned for this context item.' }
+        }
+        return {
+          ...attachment,
+          status: attachmentStatusFromBackend(outcome.status),
+          progress: isAcceptedContextStatus(outcome.status) ? 100 : 0,
+          message: outcome.message || outcome.reason_code || 'Context ingestion completed.',
+          reasonCode: outcome.reason_code,
+          redacted: outcome.redacted
+        }
+      })
+    )
+    if (response.rejected) {
+      setLastError('Some context items were rejected or unsupported. Remove or revise them before retrying.')
+    }
   }
 
   function applyAssistantResult(result: AuroraResponse<import('@aurora/client').AssistantSendMessageResult>, pendingId: string) {
@@ -284,6 +413,44 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
     await startAssistantTurn(replay ? lastPrompt : lastPrompt, replay ? streamState.lastEventId : null)
   }
 
+  function addUrlAttachment() {
+    const value = urlDraft.trim()
+    if (!value || !canAttach) return
+    setAttachments((current) => [...current, createAttachmentDraft({
+      kind: 'url',
+      label: urlLabel(value),
+      detail: value,
+      url: value,
+      sourceChannel,
+      privacyClass
+    })])
+    setUrlDraft('')
+  }
+
+  function addSharedTextAttachment() {
+    const value = sharedTextDraft.trim()
+    if (!value || !canAttach) return
+    setAttachments((current) => [...current, createAttachmentDraft({
+      kind: 'text',
+      label: 'Shared text',
+      detail: `${value.length} characters`,
+      contentText: value,
+      sourceChannel,
+      privacyClass
+    })])
+    setSharedTextDraft('')
+  }
+
+  async function onFileInput(files: FileList | null) {
+    if (!files || !canAttach) return
+    const next = await Promise.all([...files].map((file) => fileToAttachmentDraft(file, sourceChannel, privacyClass)))
+    setAttachments((current) => [...current, ...next])
+  }
+
+  function removeAttachment(id: string) {
+    setAttachments((current) => current.filter((attachment) => attachment.id !== id))
+  }
+
   return (
     <section className="aui-assistant" aria-labelledby="assistant-title">
       <header className="aui-assistant-header">
@@ -299,6 +466,7 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
           <EvidenceBadge label={client.transport.kind} />
           <EvidenceBadge label={streamState.status === 'idle' ? 'stream ready' : `stream ${streamState.status}`} />
           {session.sessionId ? <EvidenceBadge label={`session ${session.sessionId}`} /> : null}
+          <EvidenceBadge label={`${contextSummary.ready} context ready`} />
         </div>
       </header>
 
@@ -336,6 +504,7 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
             <div><dt>Cancellation</dt><dd>{controls.canCancel ? 'supported' : controls.cancelReason}</dd></div>
             <div><dt>Last stream event</dt><dd>{streamState.lastEventId ?? 'none'}</dd></div>
             <div><dt>Model</dt><dd>{modelLabel ?? (lastResult ? 'not reported' : 'pending backend response')}</dd></div>
+            <div><dt>Context</dt><dd>{contextSummary.ready} ready, {contextSummary.blocked} blocked</dd></div>
           </dl>
           <p>{route.explanation}</p>
           {route.disabled ? <p role="alert">Assistant send is disabled: {route.blockers.join(', ') || 'capability unavailable'}.</p> : null}
@@ -361,6 +530,122 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
         </aside>
       </div>
 
+      <section className="aui-attachment-panel" aria-labelledby="assistant-context-title">
+        <div className="aui-attachment-head">
+          <div>
+            <p className="aui-kicker">Context intake</p>
+            <h2 id="assistant-context-title">Attachments and shared content</h2>
+          </div>
+          <div className="aui-assistant-badges" aria-label="Context route and privacy evidence">
+            <PrivacyBadge privacy={privacyClass} />
+            <EvidenceBadge label={route.providerLabel} />
+            <EvidenceBadge label={sourceLabel(sourceChannel)} />
+          </div>
+        </div>
+
+        <div className="aui-attachment-controls">
+          <label>
+            Privacy label
+            <select
+              value={privacyClass}
+              onChange={(event) => setPrivacyClass(event.currentTarget.value as AttachmentContextPrivacyClass)}
+              disabled={!canAttach}
+            >
+              <option value="public">Public</option>
+              <option value="personal">Personal</option>
+              <option value="sensitive">Sensitive</option>
+              <option value="secret">Secret</option>
+              <option value="credential">Credential</option>
+              <option value="raw-audio">Raw audio</option>
+            </select>
+          </label>
+          <label>
+            Share source
+            <select
+              value={sourceChannel}
+              onChange={(event) => setSourceChannel(event.currentTarget.value as AttachmentContextSourceChannel)}
+              disabled={!canAttach}
+            >
+              <option value="chat">Chat composer</option>
+              <option value="desktop">Desktop drop</option>
+              <option value="mobile_share_sheet">Mobile share sheet</option>
+              <option value="deep_link">Deep link</option>
+              <option value="browser_extension">Browser extension</option>
+            </select>
+          </label>
+          <label>
+            URL
+            <span className="aui-inline-action">
+              <input
+                value={urlDraft}
+                onChange={(event) => setUrlDraft(event.currentTarget.value)}
+                disabled={!canAttach}
+                placeholder="https://example.com/context"
+              />
+              <button type="button" onClick={addUrlAttachment} disabled={!canAttach || !urlDraft.trim()}>
+                <Link size={16} aria-hidden />
+                Add URL
+              </button>
+            </span>
+          </label>
+          <label>
+            Shared text
+            <span className="aui-inline-action">
+              <textarea
+                value={sharedTextDraft}
+                onChange={(event) => setSharedTextDraft(event.currentTarget.value)}
+                disabled={!canAttach}
+                placeholder="Paste shared text or screenshot OCR"
+                rows={2}
+              />
+              <button type="button" onClick={addSharedTextAttachment} disabled={!canAttach || !sharedTextDraft.trim()}>
+                <Share2 size={16} aria-hidden />
+                Add text
+              </button>
+            </span>
+          </label>
+          <label className="aui-file-picker">
+            <Paperclip size={16} aria-hidden />
+            <span>Add files or images</span>
+            <input
+              type="file"
+              multiple
+              disabled={!canAttach}
+              onChange={(event) => {
+                void onFileInput(event.currentTarget.files)
+                event.currentTarget.value = ''
+              }}
+            />
+          </label>
+        </div>
+
+        <p className="aui-attachment-note">
+          Native mobile share payloads remain disabled until the Android and iOS native manifests advertise them; staged items still use the backend ingestion contract through AuroraClient.
+        </p>
+
+        {attachments.length === 0 ? (
+          <div className="aui-attachment-empty">No context attached.</div>
+        ) : (
+          <ul className="aui-attachment-list" aria-label="Attached context items">
+            {attachments.map((attachment) => (
+              <li key={attachment.id} className={`aui-attachment-item aui-attachment-${attachment.status}`}>
+                <div>
+                  <strong>{attachment.label}</strong>
+                  <span>{attachment.detail}</span>
+                  <small>{sourceLabel(attachment.sourceChannel)} / {attachment.privacyClass} / {attachment.message}</small>
+                  {attachment.status === 'uploading' ? <progress value={attachment.progress} max={100}>{attachment.progress}%</progress> : null}
+                </div>
+                <StatusBadge state={attachmentStateBadge(attachment.status)} />
+                <button type="button" onClick={() => removeAttachment(attachment.id)} aria-label={`Remove ${attachment.label}`}>
+                  <Trash2 size={16} aria-hidden />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {attachmentsAwaitingValidation.length > 0 ? <p className="aui-attachment-note">{attachmentsAwaitingValidation.length} item(s) will be validated before the prompt is sent.</p> : null}
+      </section>
+
       <form className="aui-assistant-form" onSubmit={onSubmit}>
         <label htmlFor="assistant-prompt">Prompt</label>
         <textarea
@@ -380,13 +665,47 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
           <RotateCcw size={17} aria-hidden />
           <span>Retry</span>
         </button>
-        <button type="submit" disabled={!canSend || text.trim().length === 0} aria-label="Send assistant prompt">
+        <button type="submit" disabled={!canSend || hasContextUpload || text.trim().length === 0} aria-label="Send assistant prompt">
           <SendHorizontal size={17} aria-hidden />
           <span>Send</span>
         </button>
       </form>
     </section>
   )
+}
+
+export function attachmentToContextItem(attachment: AssistantAttachmentDraft): AttachmentContextItem {
+  const source = {
+    channel: attachment.sourceChannel,
+    display_name: attachment.sourceDisplayName,
+    mime_type: attachment.mimeType ?? null,
+    uri: attachment.url ?? null,
+    shared_at: new Date().toISOString()
+  }
+  return {
+    kind: attachment.kind,
+    content_text: attachment.contentText ?? null,
+    url: attachment.url ?? null,
+    title: attachment.label,
+    filename: attachment.filename ?? null,
+    mime_type: attachment.mimeType ?? null,
+    size_bytes: attachment.sizeBytes ?? null,
+    source,
+    metadata: {
+      ui_status: attachment.status,
+      route_privacy_class: attachment.privacyClass
+    }
+  }
+}
+
+export function attachmentStatusFromBackend(status: AttachmentContextStatus): AttachmentTrayStatus {
+  if (status === 'accepted' || status === 'redacted' || status === 'stored') return status
+  if (status === 'unsupported') return 'unsupported'
+  return 'rejected'
+}
+
+export function isAcceptedContextStatus(status: AttachmentContextStatus): boolean {
+  return status === 'accepted' || status === 'redacted' || status === 'stored'
 }
 
 export function emptyAssistantSession(): AssistantSessionSnapshot {
@@ -495,6 +814,106 @@ export function applyAssistantTerminalUpdate(message: AssistantUiMessage, update
     createdAt: message.createdAt,
     status: 'sent'
   }
+}
+
+function createAttachmentDraft(input: {
+  kind: AssistantAttachmentDraft['kind']
+  label: string
+  detail: string
+  contentText?: string | null
+  url?: string | null
+  filename?: string | null
+  mimeType?: string | null
+  sizeBytes?: number | null
+  sourceChannel: AttachmentContextSourceChannel
+  privacyClass: AttachmentContextPrivacyClass
+}): AssistantAttachmentDraft {
+  return {
+    id: `context-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    kind: input.kind,
+    label: input.label,
+    detail: input.detail,
+    contentText: input.contentText ?? null,
+    url: input.url ?? null,
+    filename: input.filename ?? null,
+    mimeType: input.mimeType ?? null,
+    sizeBytes: input.sizeBytes ?? null,
+    sourceChannel: input.sourceChannel,
+    sourceDisplayName: sourceLabel(input.sourceChannel),
+    privacyClass: input.privacyClass,
+    status: input.kind === 'image' && !input.contentText ? 'unsupported' : 'staged',
+    progress: 0,
+    message: input.kind === 'image' && !input.contentText
+      ? 'Image binaries require OCR or native payload support before ingestion.'
+      : 'Staged for backend validation.',
+    reasonCode: null,
+    redacted: false
+  }
+}
+
+async function fileToAttachmentDraft(
+  file: File,
+  sourceChannel: AttachmentContextSourceChannel,
+  privacyClass: AttachmentContextPrivacyClass
+): Promise<AssistantAttachmentDraft> {
+  const isTextLike = file.type.startsWith('text/') || ['application/json', 'application/xml'].includes(file.type)
+  const isImage = file.type.startsWith('image/')
+  let contentText: string | null = null
+  if (isTextLike) {
+    contentText = await file.text()
+  }
+  return createAttachmentDraft({
+    kind: isImage ? 'image' : 'file',
+    label: file.name,
+    detail: `${file.type || 'unknown type'} / ${formatBytes(file.size)}`,
+    contentText,
+    filename: file.name,
+    mimeType: file.type || null,
+    sizeBytes: file.size,
+    sourceChannel,
+    privacyClass
+  })
+}
+
+function summarizeAttachments(attachments: AssistantAttachmentDraft[]): { ready: number; blocked: number } {
+  return attachments.reduce(
+    (summary, attachment) => {
+      if (['accepted', 'redacted', 'stored'].includes(attachment.status)) summary.ready += 1
+      if (['unsupported', 'rejected', 'error'].includes(attachment.status)) summary.blocked += 1
+      return summary
+    },
+    { ready: 0, blocked: 0 }
+  )
+}
+
+function attachmentStateBadge(status: AttachmentTrayStatus) {
+  if (status === 'accepted' || status === 'stored' || status === 'redacted') return 'available-local' as const
+  if (status === 'uploading' || status === 'staged') return 'pending' as const
+  if (status === 'unsupported') return 'unsupported' as const
+  return 'denied' as const
+}
+
+function sourceLabel(source: AttachmentContextSourceChannel): string {
+  if (source === 'mobile_share_sheet') return 'mobile share sheet'
+  if (source === 'deep_link') return 'deep link'
+  if (source === 'browser_extension') return 'browser extension'
+  if (source === 'desktop') return 'desktop'
+  if (source === 'api') return 'API'
+  return 'chat composer'
+}
+
+function urlLabel(value: string): string {
+  try {
+    return new URL(value).hostname
+  } catch {
+    return 'URL context'
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }
 
 function ChatBubble({ message }: { message: AssistantUiMessage }) {

--- a/packages/aurora-ui/src/assistant-view.tsx
+++ b/packages/aurora-ui/src/assistant-view.tsx
@@ -5,6 +5,7 @@ import { Link, Paperclip, RotateCcw, SendHorizontal, Share2, StopCircle, Trash2,
 import type {
   AttachmentContextIngestResponse,
   AttachmentContextItem,
+  AttachmentContextItemResult,
   AttachmentContextPrivacyClass,
   AttachmentContextSourceChannel,
   AttachmentContextStatus,
@@ -235,11 +236,7 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
     pending: AssistantAttachmentDraft[],
     response: AttachmentContextIngestResponse
   ) {
-    const outcomes = new Map(
-      [...response.accepted_items, ...response.rejected_items]
-        .map((outcome) => [Number(outcome.item_id.split('-').at(-1)), outcome] as const)
-        .filter(([index]) => Number.isFinite(index))
-    )
+    const outcomes = mapContextIngestOutcomesByPendingIndex(response)
     setAttachments((current) =>
       current.map((attachment) => {
         const pendingIndex = pending.findIndex((candidate) => candidate.id === attachment.id)
@@ -706,6 +703,26 @@ export function attachmentStatusFromBackend(status: AttachmentContextStatus): At
 
 export function isAcceptedContextStatus(status: AttachmentContextStatus): boolean {
   return status === 'accepted' || status === 'redacted' || status === 'stored'
+}
+
+export function contextIngestOutcomeIndex(itemId: string): number | null {
+  const productionMatch = /^context-(\d+)-.+$/.exec(itemId)
+  if (productionMatch) return Number(productionMatch[1])
+  const mockMatch = /^mock-context-(\d+)$/.exec(itemId)
+  if (mockMatch) return Number(mockMatch[1])
+  return null
+}
+
+export function mapContextIngestOutcomesByPendingIndex(
+  response: Pick<AttachmentContextIngestResponse, 'accepted_items' | 'rejected_items'>
+): Map<number, AttachmentContextItemResult> {
+  const outcomes = new Map<number, AttachmentContextItemResult>()
+  for (const outcome of [...response.accepted_items, ...response.rejected_items]) {
+    const index = contextIngestOutcomeIndex(outcome.item_id)
+    if (index === null) continue
+    outcomes.set(index, outcome)
+  }
+  return outcomes
 }
 
 export function emptyAssistantSession(): AssistantSessionSnapshot {

--- a/packages/aurora-ui/src/styles.css
+++ b/packages/aurora-ui/src/styles.css
@@ -152,6 +152,28 @@ button, input, select, textarea { font: inherit; }
 .aui-route-sheet-footer .aui-button { display: inline-flex; align-items: center; justify-content: center; gap: .4rem; min-height: 2.45rem; color: var(--aui-ink); font-weight: 750; }
 .aui-route-sheet-footer .aui-button:disabled { cursor: not-allowed; opacity: .58; }
 .aui-route-sheet-footer p { color: var(--aui-danger); font-size: .84rem; }
+.aui-attachment-panel { display: grid; gap: .8rem; border: 1px solid var(--aui-border); border-radius: .5rem; background: var(--aui-surface); padding: .9rem; }
+.aui-attachment-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.aui-attachment-head h2 { margin: .15rem 0 0; font-size: 1rem; }
+.aui-attachment-controls { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .7rem; align-items: end; }
+.aui-attachment-controls label { display: grid; gap: .35rem; min-width: 0; color: var(--aui-muted); font-size: .76rem; font-weight: 750; text-transform: uppercase; }
+.aui-attachment-controls input, .aui-attachment-controls textarea, .aui-attachment-controls select { width: 100%; min-width: 0; border: 1px solid var(--aui-border); border-radius: .45rem; padding: .55rem .65rem; background: var(--aui-surface); color: var(--aui-ink); text-transform: none; }
+.aui-inline-action { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: .45rem; align-items: stretch; }
+.aui-inline-action button, .aui-file-picker { display: inline-flex; align-items: center; justify-content: center; gap: .4rem; min-height: 2.55rem; border: 1px solid color-mix(in srgb, var(--aui-primary) 28%, var(--aui-border)); border-radius: .45rem; padding: .55rem .75rem; background: var(--aui-surface-2); color: var(--aui-primary); font-weight: 750; text-transform: none; }
+.aui-inline-action button:disabled, .aui-file-picker:has(input:disabled) { cursor: not-allowed; opacity: .58; }
+.aui-file-picker { position: relative; align-self: end; min-width: 0; cursor: pointer; }
+.aui-file-picker input { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
+.aui-attachment-note { margin: 0; color: var(--aui-muted); line-height: 1.45; }
+.aui-attachment-empty { display: grid; min-height: 3.4rem; place-items: center; border: 1px dashed var(--aui-border); border-radius: .5rem; color: var(--aui-muted); }
+.aui-attachment-list { display: grid; gap: .5rem; margin: 0; padding: 0; list-style: none; }
+.aui-attachment-item { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; gap: .6rem; align-items: center; border: 1px solid var(--aui-border); border-radius: .5rem; padding: .65rem; background: color-mix(in srgb, var(--aui-surface-2) 55%, white); }
+.aui-attachment-item strong, .aui-attachment-item span, .aui-attachment-item small { display: block; min-width: 0; overflow-wrap: anywhere; }
+.aui-attachment-item span, .aui-attachment-item small { color: var(--aui-muted); font-size: .78rem; line-height: 1.35; }
+.aui-attachment-item button { display: grid; width: 2rem; height: 2rem; place-items: center; border: 1px solid var(--aui-border); border-radius: .45rem; background: var(--aui-surface); color: var(--aui-muted); }
+.aui-attachment-rejected, .aui-attachment-error { border-color: color-mix(in srgb, var(--aui-danger) 35%, var(--aui-border)); }
+.aui-attachment-unsupported { border-color: color-mix(in srgb, var(--aui-muted) 50%, var(--aui-border)); opacity: .88; }
+.aui-attachment-uploading { border-color: color-mix(in srgb, var(--aui-warning) 40%, var(--aui-border)); }
+.aui-attachment-item progress { width: 100%; height: .55rem; margin-top: .4rem; accent-color: var(--aui-primary); }
 .aui-assistant-form { display: grid; grid-template-columns: minmax(0, 1fr) auto auto auto; gap: .65rem; align-items: end; padding: .75rem; }
 .aui-assistant-form label { grid-column: 1 / -1; color: var(--aui-muted); font-size: .78rem; font-weight: 750; text-transform: uppercase; }
 .aui-assistant-form textarea { min-height: 5.2rem; resize: vertical; border: 1px solid var(--aui-border); border-radius: .45rem; padding: .7rem; background: var(--aui-surface); color: var(--aui-ink); }
@@ -225,6 +247,11 @@ button, input, select, textarea { font: inherit; }
   .aui-assistant-badges { justify-content: flex-start; }
   .aui-stream-banner { align-items: flex-start; flex-wrap: wrap; }
   .aui-stream-banner button { margin-left: 0; }
+  .aui-attachment-head { display: grid; }
+  .aui-attachment-controls { grid-template-columns: minmax(0, 1fr); }
+  .aui-inline-action { grid-template-columns: minmax(0, 1fr); }
+  .aui-attachment-item { grid-template-columns: minmax(0, 1fr) auto; }
+  .aui-attachment-item .aui-badge { grid-column: 1; width: fit-content; }
   .aui-assistant-form { grid-template-columns: minmax(0, 1fr); }
   .aui-assistant-form button { width: 100%; }
   .aui-chat-bubble { max-width: 100%; }

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -23,9 +23,12 @@ import {
   buildRouteSheetViewModel,
   RouteMatrix,
   StateSurface,
+  attachmentStatusFromBackend,
+  attachmentToContextItem,
   applyAssistantStreamDelta,
   applyAssistantTerminalUpdate,
   assistantControlsForRoute,
+  isAcceptedContextStatus,
   submitToolDenialAction,
   ToolApprovalPanel,
   assistantErrorMessage,
@@ -131,12 +134,64 @@ describe('Aurora production shell', () => {
     expect(markup).toContain('personal')
     expect(markup).toContain('Start with a prompt')
     expect(markup).toContain('Ask Aurora...')
+    expect(markup).toContain('Attachments and shared content')
+    expect(markup).toContain('Privacy label')
+    expect(markup).toContain('Share source')
+    expect(markup).toContain('Add URL')
+    expect(markup).toContain('Add files or images')
+    expect(markup).toContain('Native mobile share payloads remain disabled')
+    expect(markup).toContain('0 context ready')
 
     const disabledMarkup = renderToStaticMarkup(
       <AssistantView client={new AuroraClient({ transport: new MockAuroraTransport() })} route={assistantRoute} />
     )
     expect(disabledMarkup).toContain('Assistant send is disabled')
     expect(disabledMarkup).toContain('Assistant capability is unavailable')
+  })
+
+  it('maps assistant attachment drafts to backend context payloads and statuses', () => {
+    const item = attachmentToContextItem({
+      id: 'context-1',
+      kind: 'url',
+      label: 'docs.example',
+      detail: 'https://docs.example/context',
+      contentText: null,
+      url: 'https://docs.example/context',
+      filename: null,
+      mimeType: 'text/uri-list',
+      sizeBytes: 28,
+      sourceChannel: 'mobile_share_sheet',
+      sourceDisplayName: 'mobile share sheet',
+      privacyClass: 'sensitive',
+      status: 'staged',
+      progress: 0,
+      message: 'Staged for backend validation.',
+      reasonCode: null,
+      redacted: false
+    })
+
+    expect(item).toEqual(
+      expect.objectContaining({
+        kind: 'url',
+        url: 'https://docs.example/context',
+        title: 'docs.example',
+        source: expect.objectContaining({
+          channel: 'mobile_share_sheet',
+          display_name: 'mobile share sheet'
+        }),
+        metadata: expect.objectContaining({
+          ui_status: 'staged',
+          route_privacy_class: 'sensitive'
+        })
+      })
+    )
+    expect(attachmentStatusFromBackend('accepted')).toBe('accepted')
+    expect(attachmentStatusFromBackend('stored')).toBe('stored')
+    expect(attachmentStatusFromBackend('redacted')).toBe('redacted')
+    expect(attachmentStatusFromBackend('unsupported')).toBe('unsupported')
+    expect(attachmentStatusFromBackend('rejected')).toBe('rejected')
+    expect(isAcceptedContextStatus('accepted')).toBe(true)
+    expect(isAcceptedContextStatus('unsupported')).toBe(false)
   })
 
 

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -28,7 +28,9 @@ import {
   applyAssistantStreamDelta,
   applyAssistantTerminalUpdate,
   assistantControlsForRoute,
+  contextIngestOutcomeIndex,
   isAcceptedContextStatus,
+  mapContextIngestOutcomesByPendingIndex,
   submitToolDenialAction,
   ToolApprovalPanel,
   assistantErrorMessage,
@@ -194,7 +196,50 @@ describe('Aurora production shell', () => {
     expect(isAcceptedContextStatus('unsupported')).toBe(false)
   })
 
+  it('maps production context ingest item ids back to pending attachments', () => {
+    const outcomes = mapContextIngestOutcomesByPendingIndex({
+      accepted_items: [
+        {
+          item_id: 'context-0-abc123def456',
+          kind: 'url',
+          status: 'accepted',
+          storage_policy: 'ephemeral',
+          privacy_class: 'personal',
+          accepted_bytes: 64,
+          stored_namespace: null,
+          stored_key: null,
+          redacted: false,
+          redaction_reasons: [],
+          reason_code: null,
+          message: 'URL accepted'
+        }
+      ],
+      rejected_items: [
+        {
+          item_id: 'context-1-fedcba654321',
+          kind: 'image',
+          status: 'unsupported',
+          storage_policy: 'ephemeral',
+          privacy_class: 'personal',
+          accepted_bytes: 0,
+          stored_namespace: null,
+          stored_key: null,
+          redacted: false,
+          redaction_reasons: [],
+          reason_code: 'unsupported_type',
+          message: 'Images are not supported by this route.'
+        }
+      ]
+    })
 
+    expect(contextIngestOutcomeIndex('context-0-abc123def456')).toBe(0)
+    expect(contextIngestOutcomeIndex('context-1-fedcba654321')).toBe(1)
+    expect(contextIngestOutcomeIndex('mock-context-2')).toBe(2)
+    expect(contextIngestOutcomeIndex('context-abc123def456')).toBeNull()
+    expect(outcomes.get(0)?.status).toBe('accepted')
+    expect(outcomes.get(1)?.status).toBe('unsupported')
+    expect(outcomes.get(1)?.reason_code).toBe('unsupported_type')
+  })
 
   it('renders onboarding modes, endpoint validation, login, pairing, and fallback states from SDK evidence', async () => {
     const client = new AuroraClient({ transport: new MockAuroraTransport() })

--- a/tests/unit/gateway/test_backend_inventory.py
+++ b/tests/unit/gateway/test_backend_inventory.py
@@ -93,6 +93,22 @@ def test_backend_inventory_includes_model_runtime_contracts():
         assert methods[topic]["required_perms"] == ["Orchestrator.manage"]
 
 
+def test_backend_inventory_includes_attachment_context_ingestion_contract():
+    inventory = build_inventory()
+    methods = {method["bus_topic"]: method for method in inventory["methods"]}
+
+    ingest = methods[OrchestratorMethods.INGEST_CONTEXT]
+    assert ingest["routePath"] == "/api/Orchestrator/IngestContext"
+    assert ingest["exposure"] == "external"
+    assert ingest["method_type"] == "use"
+    assert ingest["required_perms"] == ["Orchestrator.use"]
+    assert ingest["input_model"] == "AttachmentContextIngestRequest"
+    assert ingest["output_model"] == "AttachmentContextIngestResponse"
+    assert ingest["input_schema"]["title"] == "AttachmentContextIngestRequest"
+    assert ingest["output_schema"]["title"] == "AttachmentContextIngestResponse"
+    assert ingest["source_file"].startswith("app/services/orchestrator/service.py:")
+
+
 def test_backend_inventory_includes_admin_pending_pairing_queue_contract():
     inventory = build_inventory()
     methods = {method["bus_topic"]: method for method in inventory["methods"]}


### PR DESCRIPTION
## Summary
- add typed SDK support for Orchestrator.IngestContext attachment/share intake
- wire assistant attachment controls for URL, shared text, and local files/images through backend ingestion
- add attachment status/error rendering, responsive styles, and focused UI/SDK tests

## Verification
- pnpm --filter @aurora/client typecheck
- pnpm --filter @aurora/client build
- pnpm --filter @aurora/client test
- pnpm --filter @aurora/ui typecheck
- pnpm --filter @aurora/ui test
- pnpm --filter @aurora/ui build

## Notes
- native mobile share entrypoints remain gated until Android/iOS manifests advertise support
- no backend service files changed