### PR TITLE
Wire assistant voice mode UI

### DIFF
--- a/packages/aurora-ui/src/assistant-view.tsx
+++ b/packages/aurora-ui/src/assistant-view.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
-import { Link, Paperclip, RotateCcw, SendHorizontal, Share2, StopCircle, Trash2, WifiOff } from 'lucide-react'
+import { Link, Mic, Paperclip, Radio, RotateCcw, SendHorizontal, Share2, StopCircle, Trash2, Volume2, WifiOff } from 'lucide-react'
 import type {
   AttachmentContextIngestResponse,
   AttachmentContextItem,
@@ -16,7 +16,7 @@ import type {
   AuroraError,
   AuroraResponse
 } from '@aurora/client'
-import type { RouteAvailability } from './shell-data'
+import type { AssistantVoiceRoutes, RouteAvailability } from './shell-data'
 import { RouteSheet } from './route-sheet'
 import { EvidenceBadge, PrivacyBadge, StatusBadge } from './status-badges'
 
@@ -24,6 +24,11 @@ export interface AssistantViewProps {
   client: AuroraClient
   route: RouteAvailability
   cancellationRoute?: RouteAvailability | undefined
+  voiceRoutes?: AssistantVoiceRoutes | undefined
+  nativePlatform?: string | undefined
+  nativeAvailable?: boolean | undefined
+  nativePermissions?: Array<{ name: string; granted: boolean }> | undefined
+  nativeCapabilities?: Array<{ name: string; enabled: boolean }> | undefined
   storageKey?: string
 }
 
@@ -87,6 +92,51 @@ export interface AssistantAttachmentDraft {
   redacted: boolean
 }
 
+export type VoiceCaptureStatus = 'idle' | 'listening' | 'permission-denied' | 'no-device' | 'error'
+
+export interface VoiceCapabilityChip {
+  id: string
+  label: string
+  state: RouteAvailability['state']
+  privacyClass: 'public' | 'personal' | 'sensitive' | 'secret' | 'raw-audio' | 'credential' | 'admin-critical'
+  providerLabel: string
+  detail: string
+  blockers: string[]
+  evidence: string[]
+}
+
+export interface VoiceControlModel {
+  id: string
+  label: string
+  state: RouteAvailability['state']
+  enabled: boolean
+  reason: string
+  route: RouteAvailability | null
+}
+
+export interface VoiceEventRow {
+  id: string
+  label: string
+  state: RouteAvailability['state']
+  detail: string
+}
+
+export interface AssistantVoiceModel {
+  captureStatus: VoiceCaptureStatus
+  consentGranted: boolean
+  privacyClass: 'raw-audio'
+  retentionPolicy: string
+  sessionTtl: string
+  transport: string
+  targetLabel: string
+  chips: VoiceCapabilityChip[]
+  controls: VoiceControlModel[]
+  events: VoiceEventRow[]
+  routeSheetRoute: RouteAvailability
+  remoteAudioRoute: RouteAvailability
+  waveformBars: number[]
+}
+
 const defaultStorageKey = 'aurora.assistant.session.v1'
 const defaultContextLimits = {
   max_items: 8,
@@ -95,7 +145,17 @@ const defaultContextLimits = {
   max_text_chars: 120_000
 }
 
-export function AssistantView({ client, route, cancellationRoute, storageKey = defaultStorageKey }: AssistantViewProps) {
+export function AssistantView({
+  client,
+  route,
+  cancellationRoute,
+  voiceRoutes,
+  nativePlatform = 'not available',
+  nativeAvailable = false,
+  nativePermissions = [],
+  nativeCapabilities = [],
+  storageKey = defaultStorageKey
+}: AssistantViewProps) {
   const [session, setSession] = useState<AssistantSessionSnapshot>(() => emptyAssistantSession())
   const [text, setText] = useState('')
   const [urlDraft, setUrlDraft] = useState('')
@@ -108,8 +168,11 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
   const [lastError, setLastError] = useState<string | null>(null)
   const [lastPrompt, setLastPrompt] = useState<string | null>(null)
   const [streamState, setStreamState] = useState<AssistantStreamState>(() => idleAssistantStreamState())
+  const [voiceConsentGranted, setVoiceConsentGranted] = useState(false)
+  const [voiceCaptureStatus, setVoiceCaptureStatus] = useState<VoiceCaptureStatus>('idle')
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
   const abortRef = useRef<AbortController | null>(null)
+  const voiceStreamRef = useRef<MediaStream | null>(null)
   const activePendingIdRef = useRef<string | null>(null)
   const cancelledPendingIdsRef = useRef<Set<string>>(new Set())
   const routePolicy = useMemo(() => routePolicyFromRoute(route), [route])
@@ -123,6 +186,30 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
     attachment.status === 'staged' || attachment.status === 'error'
   )
   const contextSummary = summarizeAttachments(attachments)
+  const voiceModel = useMemo(
+    () => buildAssistantVoiceModel({
+      client,
+      route,
+      voiceRoutes,
+      nativePlatform,
+      nativeAvailable,
+      nativePermissions,
+      nativeCapabilities,
+      captureStatus: voiceCaptureStatus,
+      consentGranted: voiceConsentGranted
+    }),
+    [
+      client,
+      route,
+      voiceRoutes,
+      nativePlatform,
+      nativeAvailable,
+      nativePermissions,
+      nativeCapabilities,
+      voiceCaptureStatus,
+      voiceConsentGranted
+    ]
+  )
 
   useEffect(() => {
     setSession(loadAssistantSession(storageKey))
@@ -132,7 +219,10 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
     persistAssistantSession(storageKey, session)
   }, [session, storageKey])
 
-  useEffect(() => () => abortRef.current?.abort(), [])
+  useEffect(() => () => {
+    abortRef.current?.abort()
+    stopLocalCapture()
+  }, [])
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -448,6 +538,31 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
     setAttachments((current) => current.filter((attachment) => attachment.id !== id))
   }
 
+  async function toggleLocalCapture() {
+    if (voiceCaptureStatus === 'listening') {
+      stopLocalCapture()
+      setVoiceCaptureStatus('idle')
+      return
+    }
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      setVoiceCaptureStatus('no-device')
+      return
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      voiceStreamRef.current = stream
+      setVoiceCaptureStatus('listening')
+    } catch (error) {
+      const name = error instanceof DOMException ? error.name : ''
+      setVoiceCaptureStatus(name === 'NotAllowedError' || name === 'SecurityError' ? 'permission-denied' : 'error')
+    }
+  }
+
+  function stopLocalCapture() {
+    voiceStreamRef.current?.getTracks().forEach((track) => track.stop())
+    voiceStreamRef.current = null
+  }
+
   return (
     <section className="aui-assistant" aria-labelledby="assistant-title">
       <header className="aui-assistant-header">
@@ -526,6 +641,14 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
           />
         </aside>
       </div>
+
+      <VoiceModePanel
+        client={client}
+        model={voiceModel}
+        captureStatus={voiceCaptureStatus}
+        onToggleCapture={() => void toggleLocalCapture()}
+        onToggleConsent={() => setVoiceConsentGranted((current) => !current)}
+      />
 
       <section className="aui-attachment-panel" aria-labelledby="assistant-context-title">
         <div className="aui-attachment-head">
@@ -667,6 +790,216 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
           <span>Send</span>
         </button>
       </form>
+    </section>
+  )
+}
+
+export function buildAssistantVoiceModel(input: {
+  client: AuroraClient
+  route: RouteAvailability
+  voiceRoutes?: AssistantVoiceRoutes | undefined
+  nativePlatform?: string | undefined
+  nativeAvailable?: boolean | undefined
+  nativePermissions?: Array<{ name: string; granted: boolean }> | undefined
+  nativeCapabilities?: Array<{ name: string; enabled: boolean }> | undefined
+  captureStatus: VoiceCaptureStatus
+  consentGranted: boolean
+}): AssistantVoiceModel {
+  const transcription = input.voiceRoutes?.transcription ?? missingVoiceRoute('voice-transcription', 'Remote transcription', 'Transcription.Transcribe', 'raw-audio')
+  const wakeProcess = input.voiceRoutes?.wakeProcess ?? missingVoiceRoute('voice-wake-process', 'Wake audio processing', 'WakeWord.ProcessAudio', 'raw-audio')
+  const wakeControl = input.voiceRoutes?.wakeControl ?? missingVoiceRoute('voice-wake-control', 'Wake foreground control', 'WakeWord.Control', 'raw-audio')
+  const ttsSynthesize = input.voiceRoutes?.ttsSynthesize ?? missingVoiceRoute('voice-tts-synthesize', 'TTS synthesis', 'TTS.Synthesize', 'personal')
+  const ttsStop = input.voiceRoutes?.ttsStop ?? missingVoiceRoute('voice-tts-stop', 'TTS playback stop', 'TTS.Stop', 'personal')
+  const nativeCapture = nativeCaptureState(input.nativeAvailable ?? false, input.nativePlatform ?? 'not available', input.nativePermissions ?? [], input.nativeCapabilities ?? [])
+  const browserCaptureState = browserCaptureAvailability(input.client.transport.kind, input.captureStatus)
+  const remoteAudioRoute = remoteAudioRouteFor(transcription, ttsSynthesize, wakeProcess)
+
+  return {
+    captureStatus: input.captureStatus,
+    consentGranted: input.consentGranted,
+    privacyClass: 'raw-audio',
+    retentionPolicy: remoteAudioRoute.disabled ? 'not retained: route unavailable' : 'transient unless backend retention policy says otherwise',
+    sessionTtl: input.consentGranted ? 'current UI session' : 'consent not granted',
+    transport: input.client.transport.kind,
+    targetLabel: remoteAudioRoute.providerLabel,
+    chips: [
+      {
+        id: 'browser-capture',
+        label: 'Browser capture',
+        state: browserCaptureState.state,
+        privacyClass: 'raw-audio',
+        providerLabel: browserCaptureState.providerLabel,
+        detail: browserCaptureState.detail,
+        blockers: browserCaptureState.blockers,
+        evidence: [input.client.transport.kind, 'browser getUserMedia']
+      },
+      nativeCapture,
+      voiceChip('remote-processing', 'Remote processing', transcription, 'raw-audio', input.consentGranted
+        ? 'Remote STT route has UI session consent.'
+        : 'Remote STT route requires consent before audio leaves this device.'),
+      voiceChip('wake', 'Wake and background', wakeControl.disabled ? wakeProcess : wakeControl, 'raw-audio', wakeDetail(input.nativePlatform ?? 'not available', wakeControl, wakeProcess)),
+      voiceChip('tts', 'TTS synthesis', ttsSynthesize, 'personal', 'Batch synthesis is separate from playback hardware control.'),
+      voiceChip('playback', 'Local playback', ttsStop, 'personal', 'Playback stop/control is separate from remote synthesis.')
+    ],
+    controls: [
+      {
+        id: 'push-to-talk',
+        label: input.captureStatus === 'listening' ? 'Stop local capture' : 'Push to talk',
+        state: browserCaptureState.state,
+        enabled: browserCaptureState.state !== 'unsupported',
+        reason: browserCaptureState.detail,
+        route: null
+      },
+      {
+        id: 'remote-consent',
+        label: input.consentGranted ? 'Revoke audio consent' : 'Grant session consent',
+        state: remoteAudioRoute.disabled ? remoteAudioRoute.state : input.consentGranted ? 'available-local' : 'privacy-blocked',
+        enabled: !remoteAudioRoute.disabled || remoteAudioRoute.state === 'privacy-blocked',
+        reason: input.consentGranted
+          ? 'Consent can be revoked before starting another remote audio session.'
+          : 'Required before raw audio is routed to a remote peer/provider.',
+        route: remoteAudioRoute
+      },
+      voiceAction('remote-transcription', 'Start transcription', transcription, input.captureStatus, input.consentGranted),
+      voiceAction('wakeword', 'Wake foreground', wakeControl.disabled ? wakeProcess : wakeControl, input.captureStatus, input.consentGranted),
+      voiceAction('tts-synthesize', 'Synthesize speech', ttsSynthesize, input.captureStatus, input.consentGranted),
+      voiceAction('playback-stop', 'Stop playback', ttsStop, input.captureStatus, input.consentGranted)
+    ],
+    events: voiceEventRows(input.captureStatus, transcription),
+    routeSheetRoute: remoteAudioRoute,
+    remoteAudioRoute,
+    waveformBars: waveformBars(input.captureStatus)
+  }
+}
+
+function VoiceModePanel({
+  client,
+  model,
+  captureStatus,
+  onToggleCapture,
+  onToggleConsent
+}: {
+  client: AuroraClient
+  model: AssistantVoiceModel
+  captureStatus: VoiceCaptureStatus
+  onToggleCapture: () => void
+  onToggleConsent: () => void
+}) {
+  return (
+    <section className="aui-voice-panel" aria-labelledby="assistant-voice-title">
+      <header className="aui-voice-header">
+        <div>
+          <p className="aui-kicker">Voice</p>
+          <h2 id="assistant-voice-title">Voice modes</h2>
+        </div>
+        <div className="aui-assistant-badges" aria-label="Voice evidence">
+          <PrivacyBadge privacy={model.privacyClass} />
+          <EvidenceBadge label={model.transport} />
+          <EvidenceBadge label={model.consentGranted ? 'consent granted' : 'consent required'} />
+          <EvidenceBadge label={model.targetLabel} />
+        </div>
+      </header>
+
+      <div className="aui-voice-chip-grid" aria-label="Voice mode capability states">
+        {model.chips.map((chip) => (
+          <article key={chip.id} className="aui-voice-chip">
+            <header>
+              <strong>{chip.label}</strong>
+              <StatusBadge state={chip.state} />
+            </header>
+            <p>{chip.detail}</p>
+            <div className="aui-settings-inline">
+              <PrivacyBadge privacy={chip.privacyClass} />
+              <EvidenceBadge label={chip.providerLabel} />
+            </div>
+            <small>{chip.blockers.length > 0 ? chip.blockers.join(', ') : chip.evidence.join(', ')}</small>
+          </article>
+        ))}
+      </div>
+
+      <div className="aui-voice-body">
+        <section className="aui-voice-controls" aria-labelledby="voice-controls-title">
+          <h3 id="voice-controls-title">Session controls</h3>
+          <div className="aui-waveform" role="img" aria-label={`Capture state ${captureStatus}`}>
+            {model.waveformBars.map((height, index) => (
+              <span key={`${height}-${index}`} style={{ height: `${height}%` }} />
+            ))}
+          </div>
+          <div className="aui-voice-action-grid">
+            {model.controls.map((control) => {
+              const isCapture = control.id === 'push-to-talk'
+              const isConsent = control.id === 'remote-consent'
+              return (
+                <button
+                  key={control.id}
+                  type="button"
+                  disabled={!control.enabled}
+                  onClick={isCapture ? onToggleCapture : isConsent ? onToggleConsent : undefined}
+                >
+                  {isCapture ? <Mic size={16} aria-hidden /> : control.id.includes('tts') || control.id.includes('playback') ? <Volume2 size={16} aria-hidden /> : <Radio size={16} aria-hidden />}
+                  <span>{control.label}</span>
+                </button>
+              )
+            })}
+          </div>
+          <ul className="aui-voice-reasons" aria-live="polite">
+            {model.controls.map((control) => (
+              <li key={control.id}>
+                <StatusBadge state={control.state} />
+                <span>{control.reason}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <aside className="aui-voice-privacy" aria-label="Audio route privacy details">
+          <h3>Audio privacy</h3>
+          <dl>
+            <div><dt>Privacy class</dt><dd>{model.privacyClass}</dd></div>
+            <div><dt>Peer/provider</dt><dd>{model.targetLabel}</dd></div>
+            <div><dt>Transport</dt><dd>{model.transport}</dd></div>
+            <div><dt>Retention</dt><dd>{model.retentionPolicy}</dd></div>
+            <div><dt>Session TTL</dt><dd>{model.sessionTtl}</dd></div>
+          </dl>
+          <RouteSheet
+            client={client}
+            title="Audio route and consent"
+            description="Raw audio leaves the local device only when the selected route, consent, privacy indicator, and target policy allow it."
+            payload={{
+              audio_privacy_class: model.privacyClass,
+              capture_state: model.captureStatus,
+              retention_policy: model.retentionPolicy,
+              session_ttl: model.sessionTtl
+            }}
+            routeRequest={{
+              topic: model.routeSheetRoute.item.capabilityMethod
+                ? `${model.routeSheetRoute.item.capabilityModule}.${model.routeSheetRoute.item.capabilityMethod}`
+                : model.routeSheetRoute.item.capabilityModule,
+              method: model.routeSheetRoute.item.capabilityMethod ?? null,
+              include_candidates: true
+            }}
+            dataClasses={['raw-audio', model.routeSheetRoute.item.privacyClass]}
+            privacyClass="raw-audio"
+            consentGranted={model.consentGranted}
+            privacyIndicatorShown={model.captureStatus === 'listening' || model.consentGranted}
+            auditReceiptTarget={model.targetLabel}
+            requiresAdminAction={model.routeSheetRoute.requiresAdminAction}
+          />
+        </aside>
+      </div>
+
+      <section className="aui-voice-events" aria-labelledby="voice-events-title">
+        <h3 id="voice-events-title">Voice event stream</h3>
+        <ul>
+          {model.events.map((event) => (
+            <li key={event.id}>
+              <StatusBadge state={event.state} />
+              <strong>{event.label}</strong>
+              <span>{event.detail}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
     </section>
   )
 }
@@ -908,6 +1241,237 @@ function attachmentStateBadge(status: AttachmentTrayStatus) {
   if (status === 'uploading' || status === 'staged') return 'pending' as const
   if (status === 'unsupported') return 'unsupported' as const
   return 'denied' as const
+}
+
+function missingVoiceRoute(
+  id: string,
+  label: string,
+  capability: string,
+  privacyClass: VoiceCapabilityChip['privacyClass']
+): RouteAvailability {
+  const [capabilityModule, capabilityMethod] = capability.split('.')
+  return {
+    item: {
+      id,
+      label,
+      href: '/',
+      capabilityModule: capabilityModule ?? capability,
+      capabilityMethod: capabilityMethod ?? capability,
+      methodType: 'use' as const,
+      privacyClass,
+      fallbackState: 'unsupported' as const,
+      adminGated: false,
+      expectedTask: 'UIA-004'
+    },
+    state: 'unsupported',
+    explanation: `${capability} capability evidence is not available in the SDK snapshot.`,
+    providerLabel: 'UIA-004 pending',
+    blockers: ['capability_not_advertised'],
+    repairActions: [],
+    candidateProviders: [],
+    evidenceSources: ['missing voice route'],
+    selectorRequired: false,
+    approvalRequired: false,
+    routeable: false,
+    disabled: true,
+    requiresAdminAction: false
+  }
+}
+
+function nativeCaptureState(
+  nativeAvailable: boolean,
+  nativePlatform: string,
+  nativePermissions: Array<{ name: string; granted: boolean }>,
+  nativeCapabilities: Array<{ name: string; enabled: boolean }>
+): VoiceCapabilityChip {
+  const permission = nativePermissions.find((entry) => voiceNativeKey(entry.name))
+  const capability = nativeCapabilities.find((entry) => voiceNativeKey(entry.name))
+  const state = !nativeAvailable
+    ? 'unsupported'
+    : permission && !permission.granted
+      ? 'privacy-blocked'
+      : capability?.enabled
+        ? 'available-local'
+        : 'unsupported'
+  return {
+    id: 'native-capture',
+    label: 'Native capture',
+    state,
+    privacyClass: 'raw-audio',
+    providerLabel: nativeAvailable ? `native:${nativePlatform}` : 'native manifest missing',
+    detail: state === 'available-local'
+      ? 'SDK native manifest reports microphone or voice capture support.'
+      : state === 'privacy-blocked'
+        ? 'Native capture is blocked until the platform microphone permission is granted.'
+        : 'Tauri, Android, and iOS capture stay disabled until native manifest support lands.',
+    blockers: state === 'available-local' ? [] : [permission && !permission.granted ? `native permission missing: ${permission.name}` : 'native voice capture unavailable'],
+    evidence: nativeAvailable ? ['native-manifest'] : []
+  }
+}
+
+function voiceNativeKey(name: string): boolean {
+  const normalized = name.toLowerCase()
+  return normalized.includes('microphone') || normalized.includes('voice') || normalized.includes('audio')
+}
+
+function browserCaptureAvailability(
+  transportKind: string,
+  captureStatus: VoiceCaptureStatus
+): Pick<VoiceCapabilityChip, 'state' | 'providerLabel' | 'detail' | 'blockers'> {
+  if (transportKind === 'tauri-local' || transportKind === 'native-mobile') {
+    return {
+      state: 'unsupported',
+      providerLabel: transportKind,
+      detail: 'Native capture must come from the SDK native manifest for this transport.',
+      blockers: ['native_manifest_required']
+    }
+  }
+  if (captureStatus === 'listening') {
+    return {
+      state: 'available-local',
+      providerLabel: 'browser getUserMedia',
+      detail: 'Local browser microphone stream is active on this device.',
+      blockers: []
+    }
+  }
+  if (captureStatus === 'permission-denied') {
+    return {
+      state: 'denied',
+      providerLabel: 'browser getUserMedia',
+      detail: 'Browser microphone permission was denied.',
+      blockers: ['browser_microphone_permission_denied']
+    }
+  }
+  if (captureStatus === 'no-device') {
+    return {
+      state: 'unsupported',
+      providerLabel: 'browser getUserMedia',
+      detail: 'This runtime did not expose a browser microphone device API.',
+      blockers: ['browser_microphone_api_missing']
+    }
+  }
+  if (captureStatus === 'error') {
+    return {
+      state: 'degraded',
+      providerLabel: 'browser getUserMedia',
+      detail: 'Browser microphone capture failed; retry or inspect device settings.',
+      blockers: ['browser_microphone_error']
+    }
+  }
+  return {
+    state: 'pending',
+    providerLabel: 'browser getUserMedia',
+    detail: 'Local capture waits for the browser permission prompt.',
+    blockers: []
+  }
+}
+
+function voiceChip(
+  id: string,
+  label: string,
+  route: RouteAvailability,
+  privacyClass: VoiceCapabilityChip['privacyClass'],
+  detail: string
+): VoiceCapabilityChip {
+  return {
+    id,
+    label,
+    state: route.state,
+    privacyClass,
+    providerLabel: route.providerLabel,
+    detail,
+    blockers: route.blockers,
+    evidence: route.evidenceSources
+  }
+}
+
+function wakeDetail(nativePlatform: string, wakeControl: RouteAvailability, wakeProcess: RouteAvailability): string {
+  if (nativePlatform.toLowerCase().includes('ios')) {
+    return 'iOS wake/background assistant behavior remains foreground-only or app-owned unless native capability evidence proves otherwise.'
+  }
+  if (nativePlatform.toLowerCase().includes('android')) {
+    return 'Android wake/background behavior requires foreground service and native plugin evidence.'
+  }
+  if (!wakeControl.disabled) return 'Wake control is foreground-capable through backend route evidence.'
+  if (!wakeProcess.disabled) return 'Wake audio processing exists, but foreground/background control is not advertised.'
+  return 'Wakeword remains unsupported until backend and native capture capability evidence exists.'
+}
+
+function remoteAudioRouteFor(...routes: RouteAvailability[]): RouteAvailability {
+  return routes.find((route) => route.state === 'available-remote' || route.state === 'privacy-blocked') ??
+    routes.find((route) => !route.disabled) ??
+    routes[0]!
+}
+
+function voiceAction(
+  id: string,
+  label: string,
+  route: RouteAvailability,
+  captureStatus: VoiceCaptureStatus,
+  consentGranted: boolean
+): VoiceControlModel {
+  if (route.disabled) {
+    return {
+      id,
+      label,
+      state: route.state,
+      enabled: false,
+      reason: route.blockers.join(', ') || route.explanation,
+      route
+    }
+  }
+  if ((route.state === 'available-remote' || route.selectorRequired) && !consentGranted) {
+    return {
+      id,
+      label,
+      state: 'privacy-blocked',
+      enabled: false,
+      reason: 'Grant session consent before routing microphone/audio work to a remote peer.',
+      route
+    }
+  }
+  if ((id === 'remote-transcription' || id === 'wakeword') && captureStatus !== 'listening') {
+    return {
+      id,
+      label,
+      state: 'pending',
+      enabled: false,
+      reason: 'Start local capture before creating an audio session.',
+      route
+    }
+  }
+  return {
+    id,
+    label,
+    state: route.state,
+    enabled: false,
+    reason: 'Capability route is visible; typed audio session start/status SDK wiring is still required before dispatch.',
+    route
+  }
+}
+
+function voiceEventRows(captureStatus: VoiceCaptureStatus, transcription: RouteAvailability): VoiceEventRow[] {
+  const captureFailure: VoiceEventRow | null =
+    captureStatus === 'permission-denied'
+      ? { id: 'permission-loss', label: 'Local permission loss', state: 'denied', detail: 'Browser or native microphone permission was lost or denied.' }
+      : captureStatus === 'no-device' || captureStatus === 'error'
+        ? { id: 'capture-error', label: 'Capture error', state: captureStatus === 'no-device' ? 'unsupported' : 'degraded', detail: 'Local capture failed before audio could be routed.' }
+        : null
+  return [
+    { id: 'partial', label: 'Partial transcription', state: transcription.disabled ? 'unsupported' : 'pending', detail: 'Incremental text remains tied to backend stream events.' },
+    { id: 'final', label: 'Final transcription', state: transcription.disabled ? 'unsupported' : transcription.state, detail: 'Final text must come from Transcription backend evidence.' },
+    { id: 'timeout', label: 'Timeout', state: 'degraded', detail: 'Timeouts remain visible as retryable voice session outcomes.' },
+    { id: 'cancelled', label: 'Cancelled', state: 'pending', detail: 'Cancellation must revoke or stop the current audio session.' },
+    { id: 'remote-denied', label: 'Remote denial', state: 'denied', detail: 'Policy, selector, or peer denial is shown without silent fallback.' },
+    { id: 'peer-disconnect', label: 'Peer disconnect', state: 'stale', detail: 'Remote peer loss makes the current provider unselectable.' },
+    ...(captureFailure ? [captureFailure] : [])
+  ]
+}
+
+function waveformBars(captureStatus: VoiceCaptureStatus): number[] {
+  if (captureStatus === 'listening') return [24, 48, 72, 52, 84, 38, 64, 46, 76, 30, 58, 42]
+  if (captureStatus === 'permission-denied' || captureStatus === 'error') return [18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18]
+  return [12, 20, 14, 22, 16, 18, 12, 20, 14, 22, 16, 18]
 }
 
 function sourceLabel(source: AttachmentContextSourceChannel): string {

--- a/packages/aurora-ui/src/nav.tsx
+++ b/packages/aurora-ui/src/nav.tsx
@@ -102,6 +102,69 @@ export const auroraAssistantCancellationItem = item(
   'UIA-002'
 )
 
+export const auroraAssistantVoiceItems = {
+  transcription: item(
+    'voice-transcription',
+    'Remote transcription',
+    '/',
+    Sparkles,
+    'Transcription',
+    'Transcribe',
+    'use',
+    'raw-audio',
+    'unsupported',
+    'UIA-004'
+  ),
+  wakeProcess: item(
+    'voice-wake-process',
+    'Wake audio processing',
+    '/',
+    Sparkles,
+    'WakeWord',
+    'ProcessAudio',
+    'use',
+    'raw-audio',
+    'unsupported',
+    'UIA-004'
+  ),
+  wakeControl: item(
+    'voice-wake-control',
+    'Wake foreground control',
+    '/',
+    Sparkles,
+    'WakeWord',
+    'Control',
+    'use',
+    'raw-audio',
+    'unsupported',
+    'UIA-004'
+  ),
+  ttsSynthesize: item(
+    'voice-tts-synthesize',
+    'TTS synthesis',
+    '/',
+    Sparkles,
+    'TTS',
+    'Synthesize',
+    'use',
+    'personal',
+    'unsupported',
+    'UIA-004'
+  ),
+  ttsStop: item(
+    'voice-tts-stop',
+    'TTS playback stop',
+    '/',
+    Sparkles,
+    'TTS',
+    'Stop',
+    'use',
+    'personal',
+    'unsupported',
+    'UIA-004'
+  )
+} as const
+
 export function getAuroraNavItem(id: string): AuroraNavItem | undefined {
   for (const section of auroraNavSections) {
     const match = section.items.find((item) => item.id === id)

--- a/packages/aurora-ui/src/shell-data.ts
+++ b/packages/aurora-ui/src/shell-data.ts
@@ -9,6 +9,7 @@ import type {
 } from '@aurora/client'
 import {
   auroraAssistantCancellationItem,
+  auroraAssistantVoiceItems,
   auroraNavSections,
   navItemSnapshot,
   type AuroraNavItem,
@@ -67,7 +68,16 @@ export interface AuroraShellSnapshot {
   nativeCapabilities: Array<{ name: string; enabled: boolean }>
   routes: RouteAvailability[]
   assistantCancellationRoute: RouteAvailability | null
+  assistantVoiceRoutes: AssistantVoiceRoutes
   error: string | null
+}
+
+export interface AssistantVoiceRoutes {
+  transcription: RouteAvailability
+  wakeProcess: RouteAvailability
+  wakeControl: RouteAvailability
+  ttsSynthesize: RouteAvailability
+  ttsStop: RouteAvailability
 }
 
 export const loadingShellSnapshot: AuroraShellSnapshot = {
@@ -87,6 +97,7 @@ export const loadingShellSnapshot: AuroraShellSnapshot = {
   nativeCapabilities: [],
   routes: [],
   assistantCancellationRoute: null,
+  assistantVoiceRoutes: emptyAssistantVoiceRoutes(),
   error: null
 }
 
@@ -115,6 +126,7 @@ export function snapshotFromGraph(
     graph.explain(featureIdForNavItem(auroraAssistantCancellationItem)),
     native
   )
+  const assistantVoiceRoutes = assistantVoiceRoutesFromGraph(graph, native)
   return {
     loadState: 'ready',
     nodeName: graph.localNodeName || 'Aurora node',
@@ -132,6 +144,7 @@ export function snapshotFromGraph(
     nativeCapabilities: nativeCapabilityEntries(native?.capabilities),
     routes,
     assistantCancellationRoute,
+    assistantVoiceRoutes,
     error: null
   }
 }
@@ -169,6 +182,7 @@ export function errorShellSnapshot(transportKind: string, error: unknown): Auror
     disabled: true,
     requiresAdminAction: false
   }
+  const assistantVoiceRoutes = errorAssistantVoiceRoutes()
   return {
     ...loadingShellSnapshot,
     loadState: 'error',
@@ -179,7 +193,77 @@ export function errorShellSnapshot(transportKind: string, error: unknown): Auror
     blockedCount: routes.length,
     error: errorMessage(error),
     routes,
-    assistantCancellationRoute
+    assistantCancellationRoute,
+    assistantVoiceRoutes
+  }
+}
+
+function assistantVoiceRoutesFromGraph(
+  graph: CapabilityGraph,
+  native: NativeCapabilityManifest | null
+): AssistantVoiceRoutes {
+  return {
+    transcription: routeAvailability(
+      auroraAssistantVoiceItems.transcription,
+      graph.explain(featureIdForNavItem(auroraAssistantVoiceItems.transcription)),
+      native
+    ),
+    wakeProcess: routeAvailability(
+      auroraAssistantVoiceItems.wakeProcess,
+      graph.explain(featureIdForNavItem(auroraAssistantVoiceItems.wakeProcess)),
+      native
+    ),
+    wakeControl: routeAvailability(
+      auroraAssistantVoiceItems.wakeControl,
+      graph.explain(featureIdForNavItem(auroraAssistantVoiceItems.wakeControl)),
+      native
+    ),
+    ttsSynthesize: routeAvailability(
+      auroraAssistantVoiceItems.ttsSynthesize,
+      graph.explain(featureIdForNavItem(auroraAssistantVoiceItems.ttsSynthesize)),
+      native
+    ),
+    ttsStop: routeAvailability(
+      auroraAssistantVoiceItems.ttsStop,
+      graph.explain(featureIdForNavItem(auroraAssistantVoiceItems.ttsStop)),
+      native
+    )
+  }
+}
+
+function emptyAssistantVoiceRoutes(): AssistantVoiceRoutes {
+  return unsupportedAssistantVoiceRoutes('pending SDK request')
+}
+
+function errorAssistantVoiceRoutes(): AssistantVoiceRoutes {
+  return unsupportedAssistantVoiceRoutes('AuroraClient error')
+}
+
+function unsupportedAssistantVoiceRoutes(evidence: string): AssistantVoiceRoutes {
+  return {
+    transcription: unsupportedVoiceRoute(auroraAssistantVoiceItems.transcription, evidence),
+    wakeProcess: unsupportedVoiceRoute(auroraAssistantVoiceItems.wakeProcess, evidence),
+    wakeControl: unsupportedVoiceRoute(auroraAssistantVoiceItems.wakeControl, evidence),
+    ttsSynthesize: unsupportedVoiceRoute(auroraAssistantVoiceItems.ttsSynthesize, evidence),
+    ttsStop: unsupportedVoiceRoute(auroraAssistantVoiceItems.ttsStop, evidence)
+  }
+}
+
+function unsupportedVoiceRoute(item: AuroraNavItem, evidence: string): RouteAvailability {
+  return {
+    item: navItemSnapshot(item),
+    state: item.fallbackState,
+    explanation: 'Voice capability state could not be loaded from AuroraClient.',
+    providerLabel: `${item.expectedTask} pending`,
+    blockers: ['sdk_error'],
+    repairActions: [repairAction('retry', 'Retry SDK request', '/', true, 'The shell needs a fresh AuroraClient response.')],
+    candidateProviders: [],
+    evidenceSources: [evidence],
+    selectorRequired: false,
+    approvalRequired: false,
+    routeable: false,
+    disabled: true,
+    requiresAdminAction: item.methodType === 'manage'
   }
 }
 

--- a/packages/aurora-ui/src/styles.css
+++ b/packages/aurora-ui/src/styles.css
@@ -181,6 +181,33 @@ button, input, select, textarea { font: inherit; }
 .aui-assistant-form .aui-secondary-button { border-color: var(--aui-border); background: var(--aui-surface-2); color: var(--aui-ink); }
 .aui-assistant-form button:disabled, .aui-assistant-form textarea:disabled { cursor: not-allowed; opacity: .58; }
 
+.aui-voice-panel { display: grid; gap: .85rem; border: 1px solid var(--aui-border); border-radius: .5rem; background: var(--aui-surface); padding: .9rem; }
+.aui-voice-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.aui-voice-header h2 { margin: .15rem 0 0; font-size: 1rem; }
+.aui-voice-chip-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(12.5rem, 1fr)); gap: .65rem; }
+.aui-voice-chip { display: grid; align-content: start; gap: .5rem; min-width: 0; border: 1px solid var(--aui-border); border-radius: .5rem; background: color-mix(in srgb, var(--aui-surface-2) 45%, white); padding: .7rem; }
+.aui-voice-chip header { display: flex; align-items: flex-start; justify-content: space-between; gap: .5rem; }
+.aui-voice-chip strong, .aui-voice-chip p, .aui-voice-chip small { min-width: 0; overflow-wrap: anywhere; }
+.aui-voice-chip p { margin: 0; color: var(--aui-muted); font-size: .84rem; line-height: 1.42; }
+.aui-voice-chip small { color: var(--aui-muted); font-size: .75rem; }
+.aui-voice-body { display: grid; grid-template-columns: minmax(0, 1fr) minmax(17rem, 24rem); gap: .85rem; align-items: start; }
+.aui-voice-controls, .aui-voice-privacy, .aui-voice-events { display: grid; gap: .75rem; min-width: 0; border: 1px solid var(--aui-border); border-radius: .5rem; background: color-mix(in srgb, var(--aui-surface-2) 35%, white); padding: .8rem; }
+.aui-voice-controls h3, .aui-voice-privacy h3, .aui-voice-events h3 { margin: 0; font-size: .96rem; }
+.aui-waveform { display: grid; grid-template-columns: repeat(12, 1fr); align-items: center; gap: .25rem; height: 5rem; min-width: 0; border: 1px solid var(--aui-border); border-radius: .5rem; padding: .55rem; background: var(--aui-surface); }
+.aui-waveform span { display: block; min-height: .35rem; border-radius: 999px; background: color-mix(in srgb, var(--aui-primary) 78%, white); }
+.aui-voice-action-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .45rem; }
+.aui-voice-action-grid button { display: inline-flex; align-items: center; justify-content: center; gap: .35rem; min-height: 2.55rem; min-width: 0; border: 1px solid color-mix(in srgb, var(--aui-primary) 28%, var(--aui-border)); border-radius: .45rem; padding: .5rem .55rem; background: var(--aui-surface); color: var(--aui-primary); font-size: .84rem; font-weight: 800; }
+.aui-voice-action-grid button span { min-width: 0; overflow-wrap: anywhere; }
+.aui-voice-action-grid button:disabled { cursor: not-allowed; opacity: .58; }
+.aui-voice-reasons, .aui-voice-events ul { display: grid; gap: .45rem; margin: 0; padding: 0; list-style: none; }
+.aui-voice-reasons li, .aui-voice-events li { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: .35rem .5rem; align-items: center; min-width: 0; border: 1px solid var(--aui-border); border-radius: .45rem; background: var(--aui-surface); padding: .5rem; }
+.aui-voice-reasons span, .aui-voice-events span, .aui-voice-events strong { min-width: 0; overflow-wrap: anywhere; }
+.aui-voice-reasons span, .aui-voice-events span { color: var(--aui-muted); font-size: .82rem; line-height: 1.35; }
+.aui-voice-events span { grid-column: 2; }
+.aui-voice-privacy dl { display: grid; gap: .5rem; margin: 0; }
+.aui-voice-privacy dt { color: var(--aui-muted); font-size: .73rem; font-weight: 750; text-transform: uppercase; }
+.aui-voice-privacy dd { margin: .15rem 0 0; overflow-wrap: anywhere; }
+
 .aui-tool-panel { display: grid; gap: 1rem; }
 .aui-tool-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
 .aui-tool-header h1 { margin: .15rem 0 0; font-size: clamp(1.65rem, 3vw, 2.45rem); line-height: 1.08; }
@@ -266,6 +293,7 @@ button, input, select, textarea { font: inherit; }
   .aui-activity { display: none; }
   .aui-assistant-grid { grid-template-columns: minmax(0, 1fr); }
   .aui-route-panel { order: -1; }
+  .aui-voice-body { grid-template-columns: minmax(0, 1fr); }
   .aui-tool-layout { grid-template-columns: minmax(0, 1fr); }
   .aui-tool-summary { position: static; order: -1; }
   .aui-settings-grid, .aui-route-defaults, .aui-settings-facts { grid-template-columns: minmax(0, 1fr); }
@@ -281,6 +309,9 @@ button, input, select, textarea { font: inherit; }
   .aui-topbar { padding-inline: .75rem; }
   .aui-assistant-header { display: grid; }
   .aui-assistant-badges { justify-content: flex-start; }
+  .aui-voice-header { display: grid; }
+  .aui-voice-action-grid { grid-template-columns: minmax(0, 1fr); }
+  .aui-voice-action-grid button { width: 100%; }
   .aui-stream-banner { align-items: flex-start; flex-wrap: wrap; }
   .aui-stream-banner button { margin-left: 0; }
   .aui-attachment-head { display: grid; }

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -34,6 +34,7 @@ import {
   submitToolDenialAction,
   ToolApprovalPanel,
   assistantErrorMessage,
+  buildAssistantVoiceModel,
   buildShellSnapshot,
   buildSettingsPermissionsModel,
   errorShellSnapshot,
@@ -209,10 +210,23 @@ describe('Aurora production shell', () => {
       routeable: true
     }
     const markup = renderToStaticMarkup(
-      <AssistantView client={new AuroraClient({ transport: new MockAuroraTransport() })} route={enabledRoute} />
+      <AssistantView
+        client={new AuroraClient({ transport: new MockAuroraTransport() })}
+        route={enabledRoute}
+        voiceRoutes={snapshot.assistantVoiceRoutes}
+        nativeAvailable={snapshot.nativeAvailable}
+        nativePlatform={snapshot.nativePlatform}
+        nativePermissions={snapshot.nativePermissions}
+        nativeCapabilities={snapshot.nativeCapabilities}
+      />
     )
 
     expect(markup).toContain('Text chat')
+    expect(markup).toContain('Voice modes')
+    expect(markup).toContain('Browser capture')
+    expect(markup).toContain('Native capture')
+    expect(markup).toContain('Audio route and consent')
+    expect(markup).toContain('Voice event stream')
     expect(markup).toContain('local / Orchestrator.ExternalUserInput')
     expect(markup).toContain('model pending')
     expect(markup).toContain('personal')
@@ -227,10 +241,130 @@ describe('Aurora production shell', () => {
     expect(markup).toContain('0 context ready')
 
     const disabledMarkup = renderToStaticMarkup(
-      <AssistantView client={new AuroraClient({ transport: new MockAuroraTransport() })} route={assistantRoute} />
+      <AssistantView
+        client={new AuroraClient({ transport: new MockAuroraTransport() })}
+        route={assistantRoute}
+        voiceRoutes={snapshot.assistantVoiceRoutes}
+      />
     )
     expect(disabledMarkup).toContain('Assistant send is disabled')
     expect(disabledMarkup).toContain('Assistant capability is unavailable')
+  })
+
+  it('builds assistant voice routes from capability graph and native manifest evidence', async () => {
+    const transport = new MockAuroraTransport()
+    transport.register('Gateway.GetCapabilityCatalog', () => voiceModeCatalog())
+    transport.register('Native.GetCapabilityManifest', () => ({
+      platform: 'tauri-desktop',
+      permissions: { microphone: true },
+      capabilities: { voiceCapture: true }
+    }))
+    const client = new AuroraClient({ transport })
+    const snapshot = await buildShellSnapshot(client)
+
+    expect(snapshot.assistantVoiceRoutes.transcription.state).toBe('available-local')
+    expect(snapshot.assistantVoiceRoutes.ttsSynthesize.state).toBe('available-remote')
+    expect(snapshot.assistantVoiceRoutes.wakeControl.state).toBe('available-local')
+
+    const model = buildAssistantVoiceModel({
+      client,
+      route: enabledRoute(route(snapshot, 'assistant')),
+      voiceRoutes: snapshot.assistantVoiceRoutes,
+      nativeAvailable: snapshot.nativeAvailable,
+      nativePlatform: snapshot.nativePlatform,
+      nativePermissions: snapshot.nativePermissions,
+      nativeCapabilities: snapshot.nativeCapabilities,
+      captureStatus: 'listening',
+      consentGranted: true
+    })
+
+    expect(model.chips.find((chip) => chip.id === 'native-capture')?.state).toBe('available-local')
+    expect(model.chips.find((chip) => chip.id === 'remote-processing')?.state).toBe('available-local')
+    expect(model.controls.find((control) => control.id === 'remote-transcription')?.reason).toContain('typed audio session')
+    expect(model.events.map((event) => event.id)).toEqual(expect.arrayContaining(['partial', 'final', 'timeout', 'cancelled', 'remote-denied', 'peer-disconnect']))
+  })
+
+  it('keeps remote STT consent-gated, denial visible, and revoked consent blocking dispatch', async () => {
+    const transport = new MockAuroraTransport()
+    transport.register('Gateway.GetCapabilityCatalog', () => voiceModeCatalog('remote-stt'))
+    const client = new AuroraClient({ transport })
+    const snapshot = await buildShellSnapshot(client)
+    const assistantRoute = enabledRoute(route(snapshot, 'assistant'))
+
+    const noConsent = buildAssistantVoiceModel({
+      client,
+      route: assistantRoute,
+      voiceRoutes: snapshot.assistantVoiceRoutes,
+      captureStatus: 'listening',
+      consentGranted: false
+    })
+    expect(noConsent.controls.find((control) => control.id === 'remote-transcription')?.state).toBe('privacy-blocked')
+    expect(noConsent.controls.find((control) => control.id === 'remote-transcription')?.reason).toContain('Grant session consent')
+
+    const granted = buildAssistantVoiceModel({
+      client,
+      route: assistantRoute,
+      voiceRoutes: snapshot.assistantVoiceRoutes,
+      captureStatus: 'listening',
+      consentGranted: true
+    })
+    expect(granted.sessionTtl).toBe('current UI session')
+
+    const revoked = buildAssistantVoiceModel({
+      client,
+      route: assistantRoute,
+      voiceRoutes: snapshot.assistantVoiceRoutes,
+      captureStatus: 'listening',
+      consentGranted: false
+    })
+    expect(revoked.sessionTtl).toBe('consent not granted')
+
+    const deniedTransport = new MockAuroraTransport()
+    deniedTransport.register('Gateway.GetCapabilityCatalog', () => voiceModeCatalog('remote-denied'))
+    const deniedSnapshot = await buildShellSnapshot(new AuroraClient({ transport: deniedTransport }))
+    expect(deniedSnapshot.assistantVoiceRoutes.transcription.state).toBe('denied')
+  })
+
+  it('covers peer disconnect, local permission loss, and mobile foreground-only voice limits', async () => {
+    const staleTransport = new MockAuroraTransport()
+    staleTransport.register('Gateway.GetCapabilityCatalog', () => voiceModeCatalog('stale-remote'))
+    const staleClient = new AuroraClient({ transport: staleTransport })
+    const staleSnapshot = await buildShellSnapshot(staleClient)
+    const staleModel = buildAssistantVoiceModel({
+      client: staleClient,
+      route: enabledRoute(route(staleSnapshot, 'assistant')),
+      voiceRoutes: staleSnapshot.assistantVoiceRoutes,
+      captureStatus: 'permission-denied',
+      consentGranted: true
+    })
+
+    expect(staleSnapshot.assistantVoiceRoutes.transcription.state).toBe('stale')
+    expect(staleModel.events.find((event) => event.id === 'peer-disconnect')?.state).toBe('stale')
+    expect(staleModel.events.find((event) => event.id === 'permission-loss')?.state).toBe('denied')
+
+    const mobileTransport = new MockAuroraTransport()
+    mobileTransport.register('Gateway.GetCapabilityCatalog', () => voiceModeCatalog())
+    mobileTransport.register('Native.GetCapabilityManifest', () => ({
+      platform: 'ios',
+      permissions: { microphone: false },
+      capabilities: { voiceCapture: false }
+    }))
+    const mobileClient = new AuroraClient({ transport: mobileTransport })
+    const mobileSnapshot = await buildShellSnapshot(mobileClient)
+    const mobileModel = buildAssistantVoiceModel({
+      client: mobileClient,
+      route: enabledRoute(route(mobileSnapshot, 'assistant')),
+      voiceRoutes: mobileSnapshot.assistantVoiceRoutes,
+      nativeAvailable: mobileSnapshot.nativeAvailable,
+      nativePlatform: mobileSnapshot.nativePlatform,
+      nativePermissions: mobileSnapshot.nativePermissions,
+      nativeCapabilities: mobileSnapshot.nativeCapabilities,
+      captureStatus: 'idle',
+      consentGranted: false
+    })
+
+    expect(mobileModel.chips.find((chip) => chip.id === 'native-capture')?.state).toBe('privacy-blocked')
+    expect(mobileModel.chips.find((chip) => chip.id === 'wake')?.detail).toContain('foreground-only')
   })
 
   it('maps assistant attachment drafts to backend context payloads and statuses', () => {
@@ -726,6 +860,139 @@ function enabledRoute(match: ReturnType<typeof route>) {
     blockers: [],
     routeable: true
   }
+}
+
+function voiceModeCatalog(variant: 'local' | 'remote-stt' | 'remote-denied' | 'stale-remote' = 'local'): CapabilityCatalogResponse {
+  const catalog = cloneFixture(capabilityCatalogFixture)
+  const baseProvider = catalog.providers[0]!
+  const baseAction = catalog.actions[0]!
+  const localTranscription = provider(baseProvider, {
+    provider_id: 'local:Transcription',
+    module: 'Transcription',
+    service_instance_id: 'transcription-local',
+    reason: 'Local transcription provider is available.'
+  })
+  const remoteTranscription = provider(baseProvider, {
+    provider_id: 'mesh:studio:Transcription',
+    peer_id: 'studio-peer',
+    provider_kind: 'remote',
+    node_name: 'Studio node',
+    module: 'Transcription',
+    service_instance_id: 'transcription-studio',
+    reason: 'Remote transcription provider is eligible.'
+  })
+  const deniedTranscription = provider(remoteTranscription, {
+    eligible: false,
+    reason_code: 'policy_denied',
+    reason: 'Remote transcription denied by peer policy.',
+    policy: {
+      ...remoteTranscription.policy,
+      denial_reasons: ['policy_denied'],
+      mesh_visible: true,
+      trust_tier: 'paired'
+    }
+  })
+  const staleTranscription = provider(remoteTranscription, {
+    eligible: false,
+    status: 'stale',
+    reason_code: 'peer_disconnect',
+    reason: 'Remote transcription peer disconnected.',
+    freshness: {
+      ...remoteTranscription.freshness,
+      stale: true,
+      last_probe_age_s: 900
+    }
+  })
+  const wake = provider(baseProvider, {
+    provider_id: 'local:WakeWord',
+    module: 'WakeWord',
+    service_instance_id: 'wake-local',
+    reason: 'Foreground wake control is available locally.'
+  })
+  const ttsRemote = provider(baseProvider, {
+    provider_id: 'mesh:kitchen:TTS',
+    peer_id: 'kitchen-peer',
+    provider_kind: 'remote',
+    node_name: 'Kitchen node',
+    module: 'TTS',
+    service_instance_id: 'tts-kitchen',
+    reason: 'Remote TTS synthesis provider is eligible.'
+  })
+  const transcriptionProvider = variant === 'remote-stt'
+    ? remoteTranscription
+    : variant === 'remote-denied'
+      ? deniedTranscription
+      : variant === 'stale-remote'
+        ? staleTranscription
+        : localTranscription
+
+  catalog.providers = [transcriptionProvider, wake, ttsRemote]
+  catalog.actions = [
+    action(baseAction, transcriptionProvider, {
+      action_id: `${transcriptionProvider.provider_id}:Transcribe`,
+      method: 'Transcribe',
+      bindability: variant === 'remote-denied' ? 'denied' : variant === 'stale-remote' ? 'unavailable' : 'available',
+      policy: {
+        ...transcriptionProvider.policy,
+        required_permissions: ['Transcription.use'],
+        resource_scope: 'raw-audio',
+        mesh_visible: transcriptionProvider.provider_kind !== 'local',
+        trust_tier: transcriptionProvider.provider_kind === 'local' ? 'local' : 'paired'
+      },
+      freshness: transcriptionProvider.freshness
+    }),
+    action(baseAction, wake, {
+      action_id: 'local:WakeWord:ProcessAudio',
+      method: 'ProcessAudio',
+      policy: {
+        ...wake.policy,
+        required_permissions: ['WakeWord.use'],
+        resource_scope: 'raw-audio'
+      }
+    }),
+    action(baseAction, wake, {
+      action_id: 'local:WakeWord:Control',
+      method: 'Control',
+      policy: {
+        ...wake.policy,
+        required_permissions: ['WakeWord.use'],
+        resource_scope: 'raw-audio'
+      }
+    }),
+    action(baseAction, ttsRemote, {
+      action_id: 'mesh:kitchen:TTS:Synthesize',
+      method: 'Synthesize',
+      policy: {
+        ...ttsRemote.policy,
+        required_permissions: ['TTS.use'],
+        mesh_visible: true,
+        trust_tier: 'paired'
+      }
+    }),
+    action(baseAction, ttsRemote, {
+      action_id: 'mesh:kitchen:TTS:Stop',
+      method: 'Stop',
+      policy: {
+        ...ttsRemote.policy,
+        required_permissions: ['TTS.use'],
+        mesh_visible: true,
+        trust_tier: 'paired'
+      }
+    })
+  ]
+  catalog.provider_index = {
+    Transcription: [transcriptionProvider.provider_id],
+    WakeWord: [wake.provider_id],
+    TTS: [ttsRemote.provider_id]
+  }
+  catalog.action_index = {
+    'Transcription.Transcribe': [`${transcriptionProvider.provider_id}:Transcribe`],
+    'WakeWord.ProcessAudio': ['local:WakeWord:ProcessAudio'],
+    'WakeWord.Control': ['local:WakeWord:Control'],
+    'TTS.Synthesize': ['mesh:kitchen:TTS:Synthesize'],
+    'TTS.Stop': ['mesh:kitchen:TTS:Stop']
+  }
+  return catalog
 }
 
 function stateMatrixCatalog(): CapabilityCatalogResponse {


### PR DESCRIPTION
## Summary

- Adds SDK/capability-derived assistant voice routes for transcription, wake, TTS synthesis, and playback control.
- Adds an assistant voice panel that separates browser capture, native capture, remote processing, wake/background, TTS synthesis, and playback states.
- Shows raw-audio route/privacy consent details through RouteSheet and keeps backend/native-only actions disabled until capability evidence and typed audio session wiring exist.
- Covers local STT, remote STT consent gating, remote denial, consent revocation, peer disconnect, permission loss, and mobile foreground-only limitations in UI tests.

## Validation

- `pnpm --filter @aurora/client build`
- `pnpm --filter @aurora/ui typecheck`
- `pnpm --filter @aurora/ui test`
- `pnpm --filter @aurora/ui build`

## Notes

- Browser PTT uses local `getUserMedia` permission evidence only; it does not claim backend streaming until a typed audio session start/status SDK contract exists.
- Tauri, Android, and iOS capture remain gated by SDK native manifest capability and permission evidence.
