### PR TITLE
Wire memory provenance UI

### DIFF
--- a/app/services/gateway/utils/crypto.py
+++ b/app/services/gateway/utils/crypto.py
@@ -122,7 +122,7 @@ def verify_token(secret: str, token: str) -> dict[str, Any]:
         msg = f"{h}.{p}".encode()
         expected_sig = hmac.new(secret.encode(), msg=msg, digestmod=hashlib.sha256).digest()
 
-        if not hmac.compare_digest(expected_sig, b64d(s)):
+        if not hmac.compare_digest(b64(expected_sig), s):
             raise TokenError("bad signature")
 
         payload = json.loads(b64d(p))

--- a/apps/aurora-web/app/memory/memory-client.tsx
+++ b/apps/aurora-web/app/memory/memory-client.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { MemoryView, type RouteAvailability } from '@aurora/ui'
+import { createAuroraBrowserClient } from '../aurora-client'
+
+export function MemoryClientPage({ route }: { route: RouteAvailability }) {
+  return <MemoryView client={createAuroraBrowserClient()} route={route} />
+}

--- a/apps/aurora-web/app/memory/page.tsx
+++ b/apps/aurora-web/app/memory/page.tsx
@@ -1,11 +1,19 @@
-import { AuroraRoutePage } from '../page-content'
+import { StateSurface, type RouteAvailability } from '@aurora/ui'
+import { getShellSnapshot } from '../shell-state'
+import { MemoryClientPage } from './memory-client'
 
-export default function Page() {
-  return (
-    <AuroraRoutePage
-      routeId="memory"
-      title="Memory"
-      description="Memory and RAG views stay capability-gated until provenance, namespace, export, import, and tombstone contracts are wired."
-    />
-  )
+export default async function Page() {
+  const snapshot = await getShellSnapshot()
+  const route = snapshot.routes.find((candidate) => candidate.item.id === 'memory')
+  if (!route) {
+    return (
+      <StateSurface
+        title="Memory"
+        state="unsupported"
+        description="Memory route availability could not be resolved from the AuroraClient capability graph."
+        evidence={snapshot.evidenceSource}
+      />
+    )
+  }
+  return <MemoryClientPage route={route as RouteAvailability} />
 }

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -11,6 +11,7 @@ import {
 } from './transport.js'
 import { EventStreamClient, type AuroraEventSubscription, type AuroraSubscribeOptions } from './events.js'
 import { AdminActionClient, ApprovalClient } from './admin.js'
+import { MemoryClient } from './memory.js'
 import { AUTH_METHODS, describeRegistry, GATEWAY_METHODS, ORCHESTRATOR_METHODS, TOOLING_METHODS, routePath } from './descriptors.js'
 import { buildAdminOverviewManifest, buildCapabilityGraph, summarizeCapabilities } from './capabilities.js'
 import { buildPermissionCatalog, checkAccess, hasPermission, resolveEffectivePermissions } from './permissions.js'
@@ -93,6 +94,7 @@ export class AuroraClient {
   readonly permissions: PermissionClient
   readonly routes: RouteClient
   readonly assistant: AssistantClient
+  readonly memory: MemoryClient
   readonly tools: ToolClient
   readonly scheduler: SchedulerClient
   readonly admin: AdminActionClient
@@ -112,6 +114,7 @@ export class AuroraClient {
     this.permissions = new PermissionClient(this)
     this.routes = new RouteClient(this)
     this.assistant = new AssistantClient(this)
+    this.memory = new MemoryClient(this)
     this.tools = new ToolClient(this)
     this.scheduler = new SchedulerClient(this)
     this.admin = new AdminActionClient(this)

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -13,6 +13,16 @@ import type {
   RouteExplainResponse,
   WebRTCDiagnosticsResponse
 } from './types.js'
+import type {
+  DBGetMessagesResponse,
+  DBRAGExportNamespaceResponse,
+  DBRAGExportRecord,
+  DBRAGImportNamespaceResponse,
+  DBRAGListNamespacesResponse,
+  DBRAGProvenance,
+  DBRAGSearchRemoteResponse,
+  DBRAGSearchRemoteRequest
+} from './memory.js'
 import { describeBackendInventory, describeRegistry } from './descriptors.js'
 
 export const emptyRegistryFixture: GetRegistryResponse = {
@@ -1232,6 +1242,251 @@ export const toolCatalogFixture = {
   secrets_redacted: true
 } as const
 
+const memoryProvenanceFixture: DBRAGProvenance = {
+  source_peer_id: 'local-peer',
+  owner_peer_id: 'local-peer',
+  namespace: 'main.memories',
+  record_id: 'memory-001',
+  origin_principal_id: 'user-local',
+  created_at: '2026-06-19T00:00:00Z',
+  updated_at: '2026-06-19T00:05:00Z',
+  schema_version: 'rag-provenance.v1',
+  policy_decision_id: 'policy-local-memory',
+  correlation_id: 'corr-memory-local',
+  imported_at: null,
+  import_operation_id: null,
+  tombstone: false,
+  deleted_at: null,
+  deleted_by: null,
+  delete_reason: null
+}
+
+const remoteMemoryProvenanceFixture: DBRAGProvenance = {
+  ...memoryProvenanceFixture,
+  source_peer_id: 'peer-studio-gpu',
+  owner_peer_id: 'peer-studio-gpu',
+  namespace: 'peer-studio-gpu.memories',
+  record_id: 'remote-memory-002',
+  origin_principal_id: 'remote-user',
+  policy_decision_id: 'policy-remote-memory',
+  correlation_id: 'corr-memory-remote'
+}
+
+export const memoryMessagesFixture: DBGetMessagesResponse = {
+  total: 2,
+  has_more: false,
+  messages: [
+    {
+      id: 'conversation-001',
+      role: 'user',
+      content: 'Summarize recent mesh pairing failures.',
+      message_type: 'TEXT',
+      created_at: '2026-06-19T00:00:00Z',
+      privacy_class: 'personal',
+      source: 'DB.GetMessages'
+    },
+    {
+      id: 'conversation-002',
+      role: 'assistant',
+      content: 'Mesh pairing failures were denied by explicit selector policy.',
+      message_type: 'TEXT',
+      created_at: '2026-06-19T00:01:00Z',
+      privacy_class: 'personal',
+      source: 'DB.GetMessages'
+    }
+  ]
+}
+
+export const memoryNamespacesFixture: DBRAGListNamespacesResponse = {
+  namespaces: [
+    {
+      namespace: 'main.memories',
+      source_peer_id: 'local-peer',
+      owner_peer_id: 'local-peer',
+      provider_peer_id: 'local-peer',
+      availability: 'available',
+      record_count: 42,
+      embedding_model: 'mock-local-embeddings',
+      schema_version: 'rag-provenance.v1',
+      freshness: 'fresh',
+      policy: {
+        sharing_mode: 'remote_query',
+        privacy_class: 'personal',
+        allowed_operations: ['search', 'export', 'delete'],
+        explicit_selector_required: false,
+        export_supported: true,
+        import_supported: false,
+        delete_supported: true,
+        requires_admin_approval: true,
+        denial_reason: null
+      }
+    },
+    {
+      namespace: 'main.rag',
+      source_peer_id: 'local-peer',
+      owner_peer_id: 'local-peer',
+      provider_peer_id: 'local-peer',
+      availability: 'available',
+      record_count: 12,
+      embedding_model: 'mock-local-embeddings',
+      schema_version: 'rag-provenance.v1',
+      freshness: 'fresh',
+      policy: {
+        sharing_mode: 'export_import',
+        privacy_class: 'sensitive',
+        allowed_operations: ['search', 'export', 'import'],
+        explicit_selector_required: false,
+        export_supported: true,
+        import_supported: true,
+        delete_supported: false,
+        requires_admin_approval: true,
+        denial_reason: null
+      }
+    },
+    {
+      namespace: 'peer-studio-gpu.memories',
+      source_peer_id: 'peer-studio-gpu',
+      owner_peer_id: 'peer-studio-gpu',
+      provider_peer_id: 'peer-studio-gpu',
+      availability: 'available',
+      record_count: 7,
+      embedding_model: 'mock-remote-embeddings',
+      schema_version: 'rag-provenance.v1',
+      freshness: 'last probe 4s ago',
+      policy: {
+        sharing_mode: 'remote_query',
+        privacy_class: 'personal',
+        allowed_operations: ['search'],
+        explicit_selector_required: true,
+        export_supported: false,
+        import_supported: false,
+        delete_supported: false,
+        requires_admin_approval: false,
+        denial_reason: null
+      }
+    },
+    {
+      namespace: 'peer-cabin-node.archive',
+      source_peer_id: 'peer-cabin-node',
+      owner_peer_id: 'peer-cabin-node',
+      provider_peer_id: 'peer-cabin-node',
+      availability: 'stale',
+      record_count: null,
+      embedding_model: 'legacy-embedding-v0',
+      schema_version: 'rag-provenance.v1',
+      freshness: 'last probe 900s ago',
+      policy: {
+        sharing_mode: 'remote_query',
+        privacy_class: 'sensitive',
+        allowed_operations: [],
+        explicit_selector_required: true,
+        export_supported: false,
+        import_supported: false,
+        delete_supported: false,
+        requires_admin_approval: false,
+        denial_reason: 'stale peer'
+      }
+    },
+    {
+      namespace: 'peer-denied.secret',
+      source_peer_id: 'peer-denied',
+      owner_peer_id: 'peer-denied',
+      provider_peer_id: 'peer-denied',
+      availability: 'denied',
+      record_count: null,
+      embedding_model: null,
+      schema_version: 'rag-provenance.v1',
+      freshness: null,
+      policy: {
+        sharing_mode: 'never',
+        privacy_class: 'secret',
+        allowed_operations: [],
+        explicit_selector_required: true,
+        export_supported: false,
+        import_supported: false,
+        delete_supported: false,
+        requires_admin_approval: false,
+        denial_reason: 'remote namespace denied by policy'
+      }
+    }
+  ]
+}
+
+export function memorySearchFixture(request: DBRAGSearchRemoteRequest): DBRAGSearchRemoteResponse {
+  if (request.namespace.includes('denied')) {
+    return {
+      decision: 'denied',
+      items: [],
+      denial_reason: 'remote namespace denied by policy',
+      policy_decision_id: 'policy-denied-memory',
+      correlation_id: request.correlation_id ?? 'corr-memory-denied'
+    }
+  }
+  if (request.namespace.includes('cabin')) {
+    return {
+      decision: 'unavailable',
+      items: [],
+      denial_reason: 'stale peer',
+      policy_decision_id: 'policy-stale-memory',
+      correlation_id: request.correlation_id ?? 'corr-memory-stale'
+    }
+  }
+  const provenance = request.namespace.includes('peer-studio')
+    ? remoteMemoryProvenanceFixture
+    : memoryProvenanceFixture
+  return {
+    decision: 'allowed',
+    denial_reason: null,
+    policy_decision_id: provenance.policy_decision_id,
+    correlation_id: request.correlation_id ?? provenance.correlation_id,
+    items: [
+      {
+        key: provenance.record_id,
+        namespace: request.namespace,
+        value: request.query
+          ? `Search hit for "${request.query}" from ${request.namespace}`
+          : `Recent memory from ${request.namespace}`,
+        search_score: 0.92,
+        provenance: { ...provenance, namespace: request.namespace },
+        redacted: request.namespace.includes('peer-studio'),
+        redaction_reasons: request.namespace.includes('peer-studio') ? ['remote snippet redacted'] : []
+      }
+    ]
+  }
+}
+
+const memoryExportRecordFixture: DBRAGExportRecord = {
+  key: 'memory-001',
+  value: 'Redacted export preview',
+  provenance: memoryProvenanceFixture,
+  redacted: true,
+  redaction_reasons: ['mock fixture redacts export payloads']
+}
+
+export const memoryExportFixture: DBRAGExportNamespaceResponse = {
+  decision: 'allowed',
+  namespace: 'main.memories',
+  source_peer_id: 'local-peer',
+  owner_peer_id: 'local-peer',
+  schema_version: 'rag-export.v1',
+  records: [memoryExportRecordFixture],
+  tombstone_count: 1,
+  denial_reason: null,
+  policy_decision_id: 'policy-local-memory',
+  correlation_id: 'corr-memory-export'
+}
+
+export const memoryImportFixture: DBRAGImportNamespaceResponse = {
+  decision: 'allowed',
+  imported_count: 1,
+  skipped_count: 0,
+  target_namespace: 'imports.preview',
+  import_operation_id: 'import-preview-001',
+  denial_reason: null,
+  policy_decision_id: 'policy-import-memory',
+  correlation_id: 'corr-memory-import'
+}
+
 export const uiMockReferenceFixtureSummary = {
   source: 'modules/ui-mock-reference/lib/aurora/data.ts',
   deploymentMode: 'Server',
@@ -1260,6 +1515,10 @@ export interface MockAuroraFixtureSet {
   routeExplain: RouteExplainResponse
   nativeManifest: NativeCapabilityManifest
   toolCatalog: typeof toolCatalogFixture
+  memoryMessages: DBGetMessagesResponse
+  memoryNamespaces: DBRAGListNamespacesResponse
+  memoryExport: DBRAGExportNamespaceResponse
+  memoryImport: DBRAGImportNamespaceResponse
   backendInventory: BackendInventory
   gatewayBuiltins: GatewayBuiltinRouteDescriptor[]
 }
@@ -1273,6 +1532,10 @@ export const defaultMockAuroraFixtures: MockAuroraFixtureSet = {
   routeExplain: routeExplainFixture,
   nativeManifest: nativeCapabilityManifestFixture,
   toolCatalog: toolCatalogFixture,
+  memoryMessages: memoryMessagesFixture,
+  memoryNamespaces: memoryNamespacesFixture,
+  memoryExport: memoryExportFixture,
+  memoryImport: memoryImportFixture,
   backendInventory: backendInventoryFixture,
   gatewayBuiltins: gatewayBuiltinRoutesFixture
 }

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -1,6 +1,12 @@
 export { AuroraClient } from './client.js'
 export { AdminActionClient, ApprovalClient, adminActionAudit } from './admin.js'
 export {
+  DB_METHODS,
+  MemoryClient,
+  normalizeConversationMessage,
+  normalizeRagPrivacyClass
+} from './memory.js'
+export {
   SCHEDULER_METHODS,
   SchedulerClient,
   normalizeSchedulerActionSupport,
@@ -89,6 +95,7 @@ export {
 } from './fixtures.js'
 export type * from './types.js'
 export type * from './admin.js'
+export type * from './memory.js'
 export type * from './scheduler.js'
 export type * from './tools.js'
 export type * from './transport.js'

--- a/packages/aurora-sdk/src/memory.ts
+++ b/packages/aurora-sdk/src/memory.ts
@@ -1,0 +1,316 @@
+import type { AuroraClient } from './client.js'
+import { routePath } from './descriptors.js'
+import type { AuroraResponse } from './transport.js'
+import type { JsonValue, PrivacyClass } from './types.js'
+
+export const DB_METHODS = {
+  getMessages: 'DB.GetMessages',
+  ragDelete: 'DB.RAGDelete',
+  ragListNamespaces: 'DB.RAGListNamespaces',
+  ragSearchRemote: 'DB.RAGSearchRemote',
+  ragGetProvenance: 'DB.RAGGetProvenance',
+  ragExportNamespace: 'DB.RAGExportNamespace',
+  ragImportNamespace: 'DB.RAGImportNamespace'
+} as const
+
+export type RAGPolicyDecision = 'allowed' | 'denied' | 'unavailable' | 'conflict'
+export type RAGNamespaceAvailability = 'available' | 'unavailable' | 'stale' | 'denied'
+export type RAGSharingMode = 'remote_query' | 'export_import' | 'one_way_sync' | 'never'
+export type RAGPrivacyClass = 'public' | 'internal' | 'personal' | 'sensitive' | 'secret'
+
+export interface MeshAddressSelectorLike {
+  peer_id?: string | null
+  provider_id?: string | null
+  service_instance_id?: string | null
+  resource_namespace?: string | null
+  [key: string]: JsonValue | undefined
+}
+
+export interface DBGetMessagesRequest {
+  limit?: number
+  offset?: number
+  role?: string | null
+  message_type?: string | null
+  mesh_selector?: MeshAddressSelectorLike | null
+}
+
+export interface DBGetMessagesResponse {
+  messages: Array<Record<string, JsonValue>>
+  total: number
+  has_more: boolean
+}
+
+export interface DBRAGNamespacePolicy {
+  sharing_mode: RAGSharingMode
+  privacy_class: RAGPrivacyClass
+  allowed_operations: string[]
+  explicit_selector_required: boolean
+  export_supported: boolean
+  import_supported: boolean
+  delete_supported: boolean
+  requires_admin_approval: boolean
+  denial_reason: string | null
+}
+
+export interface DBRAGNamespaceInfo {
+  namespace: string
+  source_peer_id: string
+  owner_peer_id: string
+  provider_peer_id: string | null
+  availability: RAGNamespaceAvailability
+  policy: DBRAGNamespacePolicy
+  record_count: number | null
+  embedding_model: string | null
+  schema_version: string
+  freshness: string | null
+}
+
+export interface DBRAGListNamespacesRequest {
+  include_remote?: boolean
+  include_unavailable?: boolean
+  namespace_prefix?: string | null
+  mesh_selector?: MeshAddressSelectorLike | null
+}
+
+export interface DBRAGListNamespacesResponse {
+  namespaces: DBRAGNamespaceInfo[]
+}
+
+export interface DBRAGProvenance {
+  source_peer_id: string
+  owner_peer_id: string
+  namespace: string
+  record_id: string
+  origin_principal_id: string
+  created_at: string
+  updated_at: string
+  schema_version: string
+  policy_decision_id: string
+  correlation_id: string
+  imported_at: string | null
+  import_operation_id: string | null
+  tombstone: boolean
+  deleted_at: string | null
+  deleted_by: string | null
+  delete_reason: string | null
+}
+
+export interface DBRAGProvenanceItem {
+  key: string
+  value: JsonValue
+  namespace: string
+  search_score: number | null
+  provenance: DBRAGProvenance
+  redacted: boolean
+  redaction_reasons: string[]
+}
+
+export interface DBRAGSearchRemoteRequest {
+  namespace: string
+  query: string
+  limit?: number
+  offset?: number
+  mesh_selector?: MeshAddressSelectorLike | null
+  caller_peer_id?: string | null
+  caller_principal_id?: string | null
+  policy_decision_id?: string | null
+  correlation_id?: string | null
+}
+
+export interface DBRAGSearchRemoteResponse {
+  decision: RAGPolicyDecision
+  items: DBRAGProvenanceItem[]
+  denial_reason: string | null
+  policy_decision_id: string
+  correlation_id: string
+}
+
+export interface DBRAGGetProvenanceRequest {
+  namespace: string
+  key: string
+  mesh_selector?: MeshAddressSelectorLike | null
+  correlation_id?: string | null
+}
+
+export interface DBRAGGetProvenanceResponse {
+  provenance: DBRAGProvenance | null
+  decision: RAGPolicyDecision
+  denial_reason: string | null
+}
+
+export interface DBRAGExportRecord {
+  key: string
+  value: JsonValue
+  provenance: DBRAGProvenance
+  redacted: boolean
+  redaction_reasons: string[]
+}
+
+export interface DBRAGExportNamespaceRequest {
+  namespace: string
+  limit?: number
+  offset?: number
+  include_tombstones?: boolean
+  caller_principal_id?: string | null
+  policy_decision_id?: string | null
+  correlation_id?: string | null
+  mesh_selector?: MeshAddressSelectorLike | null
+}
+
+export interface DBRAGExportNamespaceResponse {
+  decision: RAGPolicyDecision
+  namespace: string
+  source_peer_id: string
+  owner_peer_id: string
+  schema_version: string
+  records: DBRAGExportRecord[]
+  tombstone_count: number
+  denial_reason: string | null
+  policy_decision_id: string
+  correlation_id: string
+}
+
+export interface DBRAGImportNamespaceRequest {
+  source_namespace: string
+  target_namespace: string
+  records: DBRAGExportRecord[]
+  source_peer_id: string
+  owner_peer_id: string
+  allow_owner_overwrite?: boolean
+  caller_principal_id?: string | null
+  policy_decision_id?: string | null
+  correlation_id?: string | null
+  mesh_selector?: MeshAddressSelectorLike | null
+}
+
+export interface DBRAGImportNamespaceResponse {
+  decision: RAGPolicyDecision
+  imported_count: number
+  skipped_count: number
+  target_namespace: string
+  import_operation_id: string
+  denial_reason: string | null
+  policy_decision_id: string
+  correlation_id: string
+}
+
+export interface DBRAGDeleteRequest {
+  namespace: string
+  key: string
+  mesh_selector?: MeshAddressSelectorLike | null
+}
+
+export interface NormalizedConversation {
+  id: string
+  role: string
+  content: string
+  messageType: string
+  createdAt: string | null
+  privacyClass: PrivacyClass
+  source: string
+}
+
+export function normalizeConversationMessage(message: Record<string, JsonValue>): NormalizedConversation {
+  return {
+    id: primitiveToString(message.id ?? message.message_id ?? message.key ?? 'message'),
+    role: primitiveToString(message.role ?? 'unknown'),
+    content: primitiveToString(message.content ?? message.text ?? message.value ?? ''),
+    messageType: primitiveToString(message.message_type ?? message.type ?? 'TEXT'),
+    createdAt: primitiveToNullableString(message.created_at ?? message.timestamp ?? null),
+    privacyClass: normalizePrivacyClass(message.privacy_class),
+    source: primitiveToString(message.source ?? 'DB.GetMessages')
+  }
+}
+
+export function normalizeRagPrivacyClass(value: RAGPrivacyClass): PrivacyClass {
+  if (value === 'internal') return 'sensitive'
+  return value
+}
+
+export class MemoryClient {
+  constructor(private readonly client: AuroraClient) {}
+
+  listMessages(request: DBGetMessagesRequest = {}): Promise<AuroraResponse<DBGetMessagesResponse>> {
+    return this.client.requestResult<DBGetMessagesResponse, DBGetMessagesRequest>(
+      DB_METHODS.getMessages,
+      request,
+      { path: routePath('DB', 'GetMessages') }
+    )
+  }
+
+  listNamespaces(request: DBRAGListNamespacesRequest = {}): Promise<AuroraResponse<DBRAGListNamespacesResponse>> {
+    return this.client.requestResult<DBRAGListNamespacesResponse, DBRAGListNamespacesRequest>(
+      DB_METHODS.ragListNamespaces,
+      request,
+      { path: routePath('DB', 'RAGListNamespaces') }
+    )
+  }
+
+  search(request: DBRAGSearchRemoteRequest): Promise<AuroraResponse<DBRAGSearchRemoteResponse>> {
+    return this.client.requestResult<DBRAGSearchRemoteResponse, DBRAGSearchRemoteRequest>(
+      DB_METHODS.ragSearchRemote,
+      request,
+      { path: routePath('DB', 'RAGSearchRemote') }
+    )
+  }
+
+  getProvenance(request: DBRAGGetProvenanceRequest): Promise<AuroraResponse<DBRAGGetProvenanceResponse>> {
+    return this.client.requestResult<DBRAGGetProvenanceResponse, DBRAGGetProvenanceRequest>(
+      DB_METHODS.ragGetProvenance,
+      request,
+      { path: routePath('DB', 'RAGGetProvenance') }
+    )
+  }
+
+  exportNamespace(request: DBRAGExportNamespaceRequest): Promise<AuroraResponse<DBRAGExportNamespaceResponse>> {
+    return this.client.requestResult<DBRAGExportNamespaceResponse, DBRAGExportNamespaceRequest>(
+      DB_METHODS.ragExportNamespace,
+      request,
+      { path: routePath('DB', 'RAGExportNamespace') }
+    )
+  }
+
+  importNamespace(request: DBRAGImportNamespaceRequest): Promise<AuroraResponse<DBRAGImportNamespaceResponse>> {
+    return this.client.requestResult<DBRAGImportNamespaceResponse, DBRAGImportNamespaceRequest>(
+      DB_METHODS.ragImportNamespace,
+      request,
+      { path: routePath('DB', 'RAGImportNamespace') }
+    )
+  }
+
+  deleteRecord(request: DBRAGDeleteRequest): Promise<AuroraResponse<unknown>> {
+    return this.client.requestResult<unknown, DBRAGDeleteRequest>(
+      DB_METHODS.ragDelete,
+      request,
+      { path: routePath('DB', 'RAGDelete') }
+    )
+  }
+}
+
+function normalizePrivacyClass(value: JsonValue | undefined): PrivacyClass {
+  if (
+    value === 'public' ||
+    value === 'personal' ||
+    value === 'sensitive' ||
+    value === 'secret' ||
+    value === 'raw-audio' ||
+    value === 'credential' ||
+    value === 'admin-critical'
+  ) {
+    return value
+  }
+  if (value === 'internal') return 'sensitive'
+  return 'personal'
+}
+
+function primitiveToString(value: JsonValue | undefined): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (value === null || value === undefined) return ''
+  return JSON.stringify(value)
+}
+
+function primitiveToNullableString(value: JsonValue | undefined): string | null {
+  const text = primitiveToString(value)
+  return text || null
+}

--- a/packages/aurora-sdk/src/mock.ts
+++ b/packages/aurora-sdk/src/mock.ts
@@ -5,7 +5,8 @@ import {
   type AuroraEventSubscription,
   type AuroraStreamRequest
 } from './events.js'
-import { cloneFixture, defaultMockAuroraFixtures, type MockAuroraFixtureSet } from './fixtures.js'
+import { cloneFixture, defaultMockAuroraFixtures, memorySearchFixture, type MockAuroraFixtureSet } from './fixtures.js'
+import type { DBRAGSearchRemoteRequest } from './memory.js'
 import type { AuroraEvent, AuroraTransportEnvelope } from './types.js'
 import type {
   AttachmentContextIngestRequest,
@@ -57,6 +58,12 @@ export class MockAuroraTransport implements AuroraTransport {
       .register('Native.GetCapabilityManifest', () => cloneFixture(fixtures.nativeManifest))
       .register('Tooling.GetToolCatalog', () => cloneFixture(fixtures.toolCatalog))
       .register('Orchestrator.IngestContext', (request) => mockIngestContext(request.payload))
+      .register('DB.GetMessages', () => cloneFixture(fixtures.memoryMessages))
+      .register('DB.RAGListNamespaces', () => cloneFixture(fixtures.memoryNamespaces))
+      .register('DB.RAGSearchRemote', (request) => memorySearchFixture(request.payload as DBRAGSearchRemoteRequest))
+      .register('DB.RAGExportNamespace', () => cloneFixture(fixtures.memoryExport))
+      .register('DB.RAGImportNamespace', () => cloneFixture(fixtures.memoryImport))
+      .register('DB.RAGDelete', () => ({ success: true }))
       .register('Orchestrator.ExternalUserInput', (request) => ({
         text: `Mock Aurora response to "${mockPromptText(request.payload)}"`,
         session_id: mockSessionId(request.payload),

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   AuroraClient,
   AuroraError,
+  DB_METHODS,
   HttpGatewayTransport,
   MeshP2PTransport,
   MockAuroraTransport,
@@ -2475,6 +2476,31 @@ describe('AuroraClient assistant namespace', () => {
     if (result.ok) throw new Error('expected empty prompt failure')
     expect(result.error).toBeInstanceOf(AuroraError)
     expect(result.error.code).toBe('validation')
+  })
+})
+
+describe('AuroraClient memory namespace', () => {
+  it('uses typed DB/RAG methods with provenance and policy responses', async () => {
+    const client = new AuroraClient({ transport: new MockAuroraTransport() })
+    const namespaces = await client.memory.listNamespaces({ include_remote: true, include_unavailable: true })
+    const messages = await client.memory.listMessages({ limit: 2 })
+    const search = await client.memory.search({
+      namespace: 'peer-studio-gpu.memories',
+      query: 'mesh pairing'
+    })
+    const denied = await client.memory.search({
+      namespace: 'peer-denied.secret',
+      query: 'secret'
+    })
+
+    expect(namespaces.ok).toBe(true)
+    expect(namespaces.ok && namespaces.data.namespaces.some((namespace) => namespace.namespace === 'peer-studio-gpu.memories')).toBe(true)
+    expect(messages.ok && messages.data.messages[0]?.content).toContain('mesh pairing')
+    expect(search.ok && search.audit.method).toBe(DB_METHODS.ragSearchRemote)
+    expect(search.ok && search.data.items[0]?.provenance.source_peer_id).toBe('peer-studio-gpu')
+    expect(search.ok && search.data.items[0]?.redacted).toBe(true)
+    expect(denied.ok && denied.data.decision).toBe('denied')
+    expect(denied.ok && denied.data.denial_reason).toContain('denied')
   })
 })
 

--- a/packages/aurora-ui/src/assistant-view.tsx
+++ b/packages/aurora-ui/src/assistant-view.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
-import { Link, Paperclip, RotateCcw, SendHorizontal, Share2, StopCircle, Trash2, WifiOff } from 'lucide-react'
+import { Link, Mic, Paperclip, Radio, RotateCcw, SendHorizontal, Share2, StopCircle, Trash2, Volume2, WifiOff } from 'lucide-react'
 import type {
   AttachmentContextIngestResponse,
   AttachmentContextItem,
@@ -16,7 +16,7 @@ import type {
   AuroraError,
   AuroraResponse
 } from '@aurora/client'
-import type { RouteAvailability } from './shell-data'
+import type { AssistantVoiceRoutes, RouteAvailability } from './shell-data'
 import { RouteSheet } from './route-sheet'
 import { EvidenceBadge, PrivacyBadge, StatusBadge } from './status-badges'
 
@@ -24,6 +24,11 @@ export interface AssistantViewProps {
   client: AuroraClient
   route: RouteAvailability
   cancellationRoute?: RouteAvailability | undefined
+  voiceRoutes?: AssistantVoiceRoutes | undefined
+  nativePlatform?: string | undefined
+  nativeAvailable?: boolean | undefined
+  nativePermissions?: Array<{ name: string; granted: boolean }> | undefined
+  nativeCapabilities?: Array<{ name: string; enabled: boolean }> | undefined
   storageKey?: string
 }
 
@@ -87,6 +92,51 @@ export interface AssistantAttachmentDraft {
   redacted: boolean
 }
 
+export type VoiceCaptureStatus = 'idle' | 'listening' | 'permission-denied' | 'no-device' | 'error'
+
+export interface VoiceCapabilityChip {
+  id: string
+  label: string
+  state: RouteAvailability['state']
+  privacyClass: 'public' | 'personal' | 'sensitive' | 'secret' | 'raw-audio' | 'credential' | 'admin-critical'
+  providerLabel: string
+  detail: string
+  blockers: string[]
+  evidence: string[]
+}
+
+export interface VoiceControlModel {
+  id: string
+  label: string
+  state: RouteAvailability['state']
+  enabled: boolean
+  reason: string
+  route: RouteAvailability | null
+}
+
+export interface VoiceEventRow {
+  id: string
+  label: string
+  state: RouteAvailability['state']
+  detail: string
+}
+
+export interface AssistantVoiceModel {
+  captureStatus: VoiceCaptureStatus
+  consentGranted: boolean
+  privacyClass: 'raw-audio'
+  retentionPolicy: string
+  sessionTtl: string
+  transport: string
+  targetLabel: string
+  chips: VoiceCapabilityChip[]
+  controls: VoiceControlModel[]
+  events: VoiceEventRow[]
+  routeSheetRoute: RouteAvailability
+  remoteAudioRoute: RouteAvailability
+  waveformBars: number[]
+}
+
 const defaultStorageKey = 'aurora.assistant.session.v1'
 const defaultContextLimits = {
   max_items: 8,
@@ -95,7 +145,17 @@ const defaultContextLimits = {
   max_text_chars: 120_000
 }
 
-export function AssistantView({ client, route, cancellationRoute, storageKey = defaultStorageKey }: AssistantViewProps) {
+export function AssistantView({
+  client,
+  route,
+  cancellationRoute,
+  voiceRoutes,
+  nativePlatform = 'not available',
+  nativeAvailable = false,
+  nativePermissions = [],
+  nativeCapabilities = [],
+  storageKey = defaultStorageKey
+}: AssistantViewProps) {
   const [session, setSession] = useState<AssistantSessionSnapshot>(() => emptyAssistantSession())
   const [text, setText] = useState('')
   const [urlDraft, setUrlDraft] = useState('')
@@ -108,8 +168,11 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
   const [lastError, setLastError] = useState<string | null>(null)
   const [lastPrompt, setLastPrompt] = useState<string | null>(null)
   const [streamState, setStreamState] = useState<AssistantStreamState>(() => idleAssistantStreamState())
+  const [voiceConsentGranted, setVoiceConsentGranted] = useState(false)
+  const [voiceCaptureStatus, setVoiceCaptureStatus] = useState<VoiceCaptureStatus>('idle')
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
   const abortRef = useRef<AbortController | null>(null)
+  const voiceStreamRef = useRef<MediaStream | null>(null)
   const activePendingIdRef = useRef<string | null>(null)
   const cancelledPendingIdsRef = useRef<Set<string>>(new Set())
   const routePolicy = useMemo(() => routePolicyFromRoute(route), [route])
@@ -123,6 +186,30 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
     attachment.status === 'staged' || attachment.status === 'error'
   )
   const contextSummary = summarizeAttachments(attachments)
+  const voiceModel = useMemo(
+    () => buildAssistantVoiceModel({
+      client,
+      route,
+      voiceRoutes,
+      nativePlatform,
+      nativeAvailable,
+      nativePermissions,
+      nativeCapabilities,
+      captureStatus: voiceCaptureStatus,
+      consentGranted: voiceConsentGranted
+    }),
+    [
+      client,
+      route,
+      voiceRoutes,
+      nativePlatform,
+      nativeAvailable,
+      nativePermissions,
+      nativeCapabilities,
+      voiceCaptureStatus,
+      voiceConsentGranted
+    ]
+  )
 
   useEffect(() => {
     setSession(loadAssistantSession(storageKey))
@@ -132,7 +219,10 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
     persistAssistantSession(storageKey, session)
   }, [session, storageKey])
 
-  useEffect(() => () => abortRef.current?.abort(), [])
+  useEffect(() => () => {
+    abortRef.current?.abort()
+    stopLocalCapture()
+  }, [])
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -448,6 +538,31 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
     setAttachments((current) => current.filter((attachment) => attachment.id !== id))
   }
 
+  async function toggleLocalCapture() {
+    if (voiceCaptureStatus === 'listening') {
+      stopLocalCapture()
+      setVoiceCaptureStatus('idle')
+      return
+    }
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      setVoiceCaptureStatus('no-device')
+      return
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      voiceStreamRef.current = stream
+      setVoiceCaptureStatus('listening')
+    } catch (error) {
+      const name = error instanceof DOMException ? error.name : ''
+      setVoiceCaptureStatus(name === 'NotAllowedError' || name === 'SecurityError' ? 'permission-denied' : 'error')
+    }
+  }
+
+  function stopLocalCapture() {
+    voiceStreamRef.current?.getTracks().forEach((track) => track.stop())
+    voiceStreamRef.current = null
+  }
+
   return (
     <section className="aui-assistant" aria-labelledby="assistant-title">
       <header className="aui-assistant-header">
@@ -526,6 +641,14 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
           />
         </aside>
       </div>
+
+      <VoiceModePanel
+        client={client}
+        model={voiceModel}
+        captureStatus={voiceCaptureStatus}
+        onToggleCapture={() => void toggleLocalCapture()}
+        onToggleConsent={() => setVoiceConsentGranted((current) => !current)}
+      />
 
       <section className="aui-attachment-panel" aria-labelledby="assistant-context-title">
         <div className="aui-attachment-head">
@@ -667,6 +790,216 @@ export function AssistantView({ client, route, cancellationRoute, storageKey = d
           <span>Send</span>
         </button>
       </form>
+    </section>
+  )
+}
+
+export function buildAssistantVoiceModel(input: {
+  client: AuroraClient
+  route: RouteAvailability
+  voiceRoutes?: AssistantVoiceRoutes | undefined
+  nativePlatform?: string | undefined
+  nativeAvailable?: boolean | undefined
+  nativePermissions?: Array<{ name: string; granted: boolean }> | undefined
+  nativeCapabilities?: Array<{ name: string; enabled: boolean }> | undefined
+  captureStatus: VoiceCaptureStatus
+  consentGranted: boolean
+}): AssistantVoiceModel {
+  const transcription = input.voiceRoutes?.transcription ?? missingVoiceRoute('voice-transcription', 'Remote transcription', 'Transcription.Transcribe', 'raw-audio')
+  const wakeProcess = input.voiceRoutes?.wakeProcess ?? missingVoiceRoute('voice-wake-process', 'Wake audio processing', 'WakeWord.ProcessAudio', 'raw-audio')
+  const wakeControl = input.voiceRoutes?.wakeControl ?? missingVoiceRoute('voice-wake-control', 'Wake foreground control', 'WakeWord.Control', 'raw-audio')
+  const ttsSynthesize = input.voiceRoutes?.ttsSynthesize ?? missingVoiceRoute('voice-tts-synthesize', 'TTS synthesis', 'TTS.Synthesize', 'personal')
+  const ttsStop = input.voiceRoutes?.ttsStop ?? missingVoiceRoute('voice-tts-stop', 'TTS playback stop', 'TTS.Stop', 'personal')
+  const nativeCapture = nativeCaptureState(input.nativeAvailable ?? false, input.nativePlatform ?? 'not available', input.nativePermissions ?? [], input.nativeCapabilities ?? [])
+  const browserCaptureState = browserCaptureAvailability(input.client.transport.kind, input.captureStatus)
+  const remoteAudioRoute = remoteAudioRouteFor(transcription, ttsSynthesize, wakeProcess)
+
+  return {
+    captureStatus: input.captureStatus,
+    consentGranted: input.consentGranted,
+    privacyClass: 'raw-audio',
+    retentionPolicy: remoteAudioRoute.disabled ? 'not retained: route unavailable' : 'transient unless backend retention policy says otherwise',
+    sessionTtl: input.consentGranted ? 'current UI session' : 'consent not granted',
+    transport: input.client.transport.kind,
+    targetLabel: remoteAudioRoute.providerLabel,
+    chips: [
+      {
+        id: 'browser-capture',
+        label: 'Browser capture',
+        state: browserCaptureState.state,
+        privacyClass: 'raw-audio',
+        providerLabel: browserCaptureState.providerLabel,
+        detail: browserCaptureState.detail,
+        blockers: browserCaptureState.blockers,
+        evidence: [input.client.transport.kind, 'browser getUserMedia']
+      },
+      nativeCapture,
+      voiceChip('remote-processing', 'Remote processing', transcription, 'raw-audio', input.consentGranted
+        ? 'Remote STT route has UI session consent.'
+        : 'Remote STT route requires consent before audio leaves this device.'),
+      voiceChip('wake', 'Wake and background', wakeControl.disabled ? wakeProcess : wakeControl, 'raw-audio', wakeDetail(input.nativePlatform ?? 'not available', wakeControl, wakeProcess)),
+      voiceChip('tts', 'TTS synthesis', ttsSynthesize, 'personal', 'Batch synthesis is separate from playback hardware control.'),
+      voiceChip('playback', 'Local playback', ttsStop, 'personal', 'Playback stop/control is separate from remote synthesis.')
+    ],
+    controls: [
+      {
+        id: 'push-to-talk',
+        label: input.captureStatus === 'listening' ? 'Stop local capture' : 'Push to talk',
+        state: browserCaptureState.state,
+        enabled: browserCaptureState.state !== 'unsupported',
+        reason: browserCaptureState.detail,
+        route: null
+      },
+      {
+        id: 'remote-consent',
+        label: input.consentGranted ? 'Revoke audio consent' : 'Grant session consent',
+        state: remoteAudioRoute.disabled ? remoteAudioRoute.state : input.consentGranted ? 'available-local' : 'privacy-blocked',
+        enabled: !remoteAudioRoute.disabled || remoteAudioRoute.state === 'privacy-blocked',
+        reason: input.consentGranted
+          ? 'Consent can be revoked before starting another remote audio session.'
+          : 'Required before raw audio is routed to a remote peer/provider.',
+        route: remoteAudioRoute
+      },
+      voiceAction('remote-transcription', 'Start transcription', transcription, input.captureStatus, input.consentGranted),
+      voiceAction('wakeword', 'Wake foreground', wakeControl.disabled ? wakeProcess : wakeControl, input.captureStatus, input.consentGranted),
+      voiceAction('tts-synthesize', 'Synthesize speech', ttsSynthesize, input.captureStatus, input.consentGranted),
+      voiceAction('playback-stop', 'Stop playback', ttsStop, input.captureStatus, input.consentGranted)
+    ],
+    events: voiceEventRows(input.captureStatus, transcription),
+    routeSheetRoute: remoteAudioRoute,
+    remoteAudioRoute,
+    waveformBars: waveformBars(input.captureStatus)
+  }
+}
+
+function VoiceModePanel({
+  client,
+  model,
+  captureStatus,
+  onToggleCapture,
+  onToggleConsent
+}: {
+  client: AuroraClient
+  model: AssistantVoiceModel
+  captureStatus: VoiceCaptureStatus
+  onToggleCapture: () => void
+  onToggleConsent: () => void
+}) {
+  return (
+    <section className="aui-voice-panel" aria-labelledby="assistant-voice-title">
+      <header className="aui-voice-header">
+        <div>
+          <p className="aui-kicker">Voice</p>
+          <h2 id="assistant-voice-title">Voice modes</h2>
+        </div>
+        <div className="aui-assistant-badges" aria-label="Voice evidence">
+          <PrivacyBadge privacy={model.privacyClass} />
+          <EvidenceBadge label={model.transport} />
+          <EvidenceBadge label={model.consentGranted ? 'consent granted' : 'consent required'} />
+          <EvidenceBadge label={model.targetLabel} />
+        </div>
+      </header>
+
+      <div className="aui-voice-chip-grid" aria-label="Voice mode capability states">
+        {model.chips.map((chip) => (
+          <article key={chip.id} className="aui-voice-chip">
+            <header>
+              <strong>{chip.label}</strong>
+              <StatusBadge state={chip.state} />
+            </header>
+            <p>{chip.detail}</p>
+            <div className="aui-settings-inline">
+              <PrivacyBadge privacy={chip.privacyClass} />
+              <EvidenceBadge label={chip.providerLabel} />
+            </div>
+            <small>{chip.blockers.length > 0 ? chip.blockers.join(', ') : chip.evidence.join(', ')}</small>
+          </article>
+        ))}
+      </div>
+
+      <div className="aui-voice-body">
+        <section className="aui-voice-controls" aria-labelledby="voice-controls-title">
+          <h3 id="voice-controls-title">Session controls</h3>
+          <div className="aui-waveform" role="img" aria-label={`Capture state ${captureStatus}`}>
+            {model.waveformBars.map((height, index) => (
+              <span key={`${height}-${index}`} style={{ height: `${height}%` }} />
+            ))}
+          </div>
+          <div className="aui-voice-action-grid">
+            {model.controls.map((control) => {
+              const isCapture = control.id === 'push-to-talk'
+              const isConsent = control.id === 'remote-consent'
+              return (
+                <button
+                  key={control.id}
+                  type="button"
+                  disabled={!control.enabled}
+                  onClick={isCapture ? onToggleCapture : isConsent ? onToggleConsent : undefined}
+                >
+                  {isCapture ? <Mic size={16} aria-hidden /> : control.id.includes('tts') || control.id.includes('playback') ? <Volume2 size={16} aria-hidden /> : <Radio size={16} aria-hidden />}
+                  <span>{control.label}</span>
+                </button>
+              )
+            })}
+          </div>
+          <ul className="aui-voice-reasons" aria-live="polite">
+            {model.controls.map((control) => (
+              <li key={control.id}>
+                <StatusBadge state={control.state} />
+                <span>{control.reason}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <aside className="aui-voice-privacy" aria-label="Audio route privacy details">
+          <h3>Audio privacy</h3>
+          <dl>
+            <div><dt>Privacy class</dt><dd>{model.privacyClass}</dd></div>
+            <div><dt>Peer/provider</dt><dd>{model.targetLabel}</dd></div>
+            <div><dt>Transport</dt><dd>{model.transport}</dd></div>
+            <div><dt>Retention</dt><dd>{model.retentionPolicy}</dd></div>
+            <div><dt>Session TTL</dt><dd>{model.sessionTtl}</dd></div>
+          </dl>
+          <RouteSheet
+            client={client}
+            title="Audio route and consent"
+            description="Raw audio leaves the local device only when the selected route, consent, privacy indicator, and target policy allow it."
+            payload={{
+              audio_privacy_class: model.privacyClass,
+              capture_state: model.captureStatus,
+              retention_policy: model.retentionPolicy,
+              session_ttl: model.sessionTtl
+            }}
+            routeRequest={{
+              topic: model.routeSheetRoute.item.capabilityMethod
+                ? `${model.routeSheetRoute.item.capabilityModule}.${model.routeSheetRoute.item.capabilityMethod}`
+                : model.routeSheetRoute.item.capabilityModule,
+              method: model.routeSheetRoute.item.capabilityMethod ?? null,
+              include_candidates: true
+            }}
+            dataClasses={['raw-audio', model.routeSheetRoute.item.privacyClass]}
+            privacyClass="raw-audio"
+            consentGranted={model.consentGranted}
+            privacyIndicatorShown={model.captureStatus === 'listening' || model.consentGranted}
+            auditReceiptTarget={model.targetLabel}
+            requiresAdminAction={model.routeSheetRoute.requiresAdminAction}
+          />
+        </aside>
+      </div>
+
+      <section className="aui-voice-events" aria-labelledby="voice-events-title">
+        <h3 id="voice-events-title">Voice event stream</h3>
+        <ul>
+          {model.events.map((event) => (
+            <li key={event.id}>
+              <StatusBadge state={event.state} />
+              <strong>{event.label}</strong>
+              <span>{event.detail}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
     </section>
   )
 }
@@ -908,6 +1241,237 @@ function attachmentStateBadge(status: AttachmentTrayStatus) {
   if (status === 'uploading' || status === 'staged') return 'pending' as const
   if (status === 'unsupported') return 'unsupported' as const
   return 'denied' as const
+}
+
+function missingVoiceRoute(
+  id: string,
+  label: string,
+  capability: string,
+  privacyClass: VoiceCapabilityChip['privacyClass']
+): RouteAvailability {
+  const [capabilityModule, capabilityMethod] = capability.split('.')
+  return {
+    item: {
+      id,
+      label,
+      href: '/',
+      capabilityModule: capabilityModule ?? capability,
+      capabilityMethod: capabilityMethod ?? capability,
+      methodType: 'use' as const,
+      privacyClass,
+      fallbackState: 'unsupported' as const,
+      adminGated: false,
+      expectedTask: 'UIA-004'
+    },
+    state: 'unsupported',
+    explanation: `${capability} capability evidence is not available in the SDK snapshot.`,
+    providerLabel: 'UIA-004 pending',
+    blockers: ['capability_not_advertised'],
+    repairActions: [],
+    candidateProviders: [],
+    evidenceSources: ['missing voice route'],
+    selectorRequired: false,
+    approvalRequired: false,
+    routeable: false,
+    disabled: true,
+    requiresAdminAction: false
+  }
+}
+
+function nativeCaptureState(
+  nativeAvailable: boolean,
+  nativePlatform: string,
+  nativePermissions: Array<{ name: string; granted: boolean }>,
+  nativeCapabilities: Array<{ name: string; enabled: boolean }>
+): VoiceCapabilityChip {
+  const permission = nativePermissions.find((entry) => voiceNativeKey(entry.name))
+  const capability = nativeCapabilities.find((entry) => voiceNativeKey(entry.name))
+  const state = !nativeAvailable
+    ? 'unsupported'
+    : permission && !permission.granted
+      ? 'privacy-blocked'
+      : capability?.enabled
+        ? 'available-local'
+        : 'unsupported'
+  return {
+    id: 'native-capture',
+    label: 'Native capture',
+    state,
+    privacyClass: 'raw-audio',
+    providerLabel: nativeAvailable ? `native:${nativePlatform}` : 'native manifest missing',
+    detail: state === 'available-local'
+      ? 'SDK native manifest reports microphone or voice capture support.'
+      : state === 'privacy-blocked'
+        ? 'Native capture is blocked until the platform microphone permission is granted.'
+        : 'Tauri, Android, and iOS capture stay disabled until native manifest support lands.',
+    blockers: state === 'available-local' ? [] : [permission && !permission.granted ? `native permission missing: ${permission.name}` : 'native voice capture unavailable'],
+    evidence: nativeAvailable ? ['native-manifest'] : []
+  }
+}
+
+function voiceNativeKey(name: string): boolean {
+  const normalized = name.toLowerCase()
+  return normalized.includes('microphone') || normalized.includes('voice') || normalized.includes('audio')
+}
+
+function browserCaptureAvailability(
+  transportKind: string,
+  captureStatus: VoiceCaptureStatus
+): Pick<VoiceCapabilityChip, 'state' | 'providerLabel' | 'detail' | 'blockers'> {
+  if (transportKind === 'tauri-local' || transportKind === 'native-mobile') {
+    return {
+      state: 'unsupported',
+      providerLabel: transportKind,
+      detail: 'Native capture must come from the SDK native manifest for this transport.',
+      blockers: ['native_manifest_required']
+    }
+  }
+  if (captureStatus === 'listening') {
+    return {
+      state: 'available-local',
+      providerLabel: 'browser getUserMedia',
+      detail: 'Local browser microphone stream is active on this device.',
+      blockers: []
+    }
+  }
+  if (captureStatus === 'permission-denied') {
+    return {
+      state: 'denied',
+      providerLabel: 'browser getUserMedia',
+      detail: 'Browser microphone permission was denied.',
+      blockers: ['browser_microphone_permission_denied']
+    }
+  }
+  if (captureStatus === 'no-device') {
+    return {
+      state: 'unsupported',
+      providerLabel: 'browser getUserMedia',
+      detail: 'This runtime did not expose a browser microphone device API.',
+      blockers: ['browser_microphone_api_missing']
+    }
+  }
+  if (captureStatus === 'error') {
+    return {
+      state: 'degraded',
+      providerLabel: 'browser getUserMedia',
+      detail: 'Browser microphone capture failed; retry or inspect device settings.',
+      blockers: ['browser_microphone_error']
+    }
+  }
+  return {
+    state: 'pending',
+    providerLabel: 'browser getUserMedia',
+    detail: 'Local capture waits for the browser permission prompt.',
+    blockers: []
+  }
+}
+
+function voiceChip(
+  id: string,
+  label: string,
+  route: RouteAvailability,
+  privacyClass: VoiceCapabilityChip['privacyClass'],
+  detail: string
+): VoiceCapabilityChip {
+  return {
+    id,
+    label,
+    state: route.state,
+    privacyClass,
+    providerLabel: route.providerLabel,
+    detail,
+    blockers: route.blockers,
+    evidence: route.evidenceSources
+  }
+}
+
+function wakeDetail(nativePlatform: string, wakeControl: RouteAvailability, wakeProcess: RouteAvailability): string {
+  if (nativePlatform.toLowerCase().includes('ios')) {
+    return 'iOS wake/background assistant behavior remains foreground-only or app-owned unless native capability evidence proves otherwise.'
+  }
+  if (nativePlatform.toLowerCase().includes('android')) {
+    return 'Android wake/background behavior requires foreground service and native plugin evidence.'
+  }
+  if (!wakeControl.disabled) return 'Wake control is foreground-capable through backend route evidence.'
+  if (!wakeProcess.disabled) return 'Wake audio processing exists, but foreground/background control is not advertised.'
+  return 'Wakeword remains unsupported until backend and native capture capability evidence exists.'
+}
+
+function remoteAudioRouteFor(...routes: RouteAvailability[]): RouteAvailability {
+  return routes.find((route) => route.state === 'available-remote' || route.state === 'privacy-blocked') ??
+    routes.find((route) => !route.disabled) ??
+    routes[0]!
+}
+
+function voiceAction(
+  id: string,
+  label: string,
+  route: RouteAvailability,
+  captureStatus: VoiceCaptureStatus,
+  consentGranted: boolean
+): VoiceControlModel {
+  if (route.disabled) {
+    return {
+      id,
+      label,
+      state: route.state,
+      enabled: false,
+      reason: route.blockers.join(', ') || route.explanation,
+      route
+    }
+  }
+  if ((route.state === 'available-remote' || route.selectorRequired) && !consentGranted) {
+    return {
+      id,
+      label,
+      state: 'privacy-blocked',
+      enabled: false,
+      reason: 'Grant session consent before routing microphone/audio work to a remote peer.',
+      route
+    }
+  }
+  if ((id === 'remote-transcription' || id === 'wakeword') && captureStatus !== 'listening') {
+    return {
+      id,
+      label,
+      state: 'pending',
+      enabled: false,
+      reason: 'Start local capture before creating an audio session.',
+      route
+    }
+  }
+  return {
+    id,
+    label,
+    state: route.state,
+    enabled: false,
+    reason: 'Capability route is visible; typed audio session start/status SDK wiring is still required before dispatch.',
+    route
+  }
+}
+
+function voiceEventRows(captureStatus: VoiceCaptureStatus, transcription: RouteAvailability): VoiceEventRow[] {
+  const captureFailure: VoiceEventRow | null =
+    captureStatus === 'permission-denied'
+      ? { id: 'permission-loss', label: 'Local permission loss', state: 'denied', detail: 'Browser or native microphone permission was lost or denied.' }
+      : captureStatus === 'no-device' || captureStatus === 'error'
+        ? { id: 'capture-error', label: 'Capture error', state: captureStatus === 'no-device' ? 'unsupported' : 'degraded', detail: 'Local capture failed before audio could be routed.' }
+        : null
+  return [
+    { id: 'partial', label: 'Partial transcription', state: transcription.disabled ? 'unsupported' : 'pending', detail: 'Incremental text remains tied to backend stream events.' },
+    { id: 'final', label: 'Final transcription', state: transcription.disabled ? 'unsupported' : transcription.state, detail: 'Final text must come from Transcription backend evidence.' },
+    { id: 'timeout', label: 'Timeout', state: 'degraded', detail: 'Timeouts remain visible as retryable voice session outcomes.' },
+    { id: 'cancelled', label: 'Cancelled', state: 'pending', detail: 'Cancellation must revoke or stop the current audio session.' },
+    { id: 'remote-denied', label: 'Remote denial', state: 'denied', detail: 'Policy, selector, or peer denial is shown without silent fallback.' },
+    { id: 'peer-disconnect', label: 'Peer disconnect', state: 'stale', detail: 'Remote peer loss makes the current provider unselectable.' },
+    ...(captureFailure ? [captureFailure] : [])
+  ]
+}
+
+function waveformBars(captureStatus: VoiceCaptureStatus): number[] {
+  if (captureStatus === 'listening') return [24, 48, 72, 52, 84, 38, 64, 46, 76, 30, 58, 42]
+  if (captureStatus === 'permission-denied' || captureStatus === 'error') return [18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18]
+  return [12, 20, 14, 22, 16, 18, 12, 20, 14, 22, 16, 18]
 }
 
 function sourceLabel(source: AttachmentContextSourceChannel): string {

--- a/packages/aurora-ui/src/index.ts
+++ b/packages/aurora-ui/src/index.ts
@@ -1,5 +1,6 @@
 export * from './nav'
 export * from './assistant-view'
+export * from './memory-view'
 export * from './shell-data'
 export * from './shell'
 export * from './state-surface'

--- a/packages/aurora-ui/src/memory-view.tsx
+++ b/packages/aurora-ui/src/memory-view.tsx
@@ -1,0 +1,480 @@
+'use client'
+
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import { Download, RefreshCw, Search, Trash2, Upload } from 'lucide-react'
+import type {
+  AuroraClient,
+  AuroraError,
+  DBRAGNamespaceInfo,
+  DBRAGProvenanceItem,
+  NormalizedConversation,
+  RAGPolicyDecision
+} from '@aurora/client'
+import { normalizeConversationMessage, normalizeRagPrivacyClass } from '@aurora/client'
+import type { RouteAvailability } from './shell-data'
+import { EvidenceBadge, PrivacyBadge, StatusBadge } from './status-badges'
+
+export interface MemoryViewProps {
+  client: AuroraClient
+  route: RouteAvailability
+  initialModel?: MemoryViewModel | undefined
+  initialQuery?: string | undefined
+}
+
+export type MemoryLoadState = 'loading' | 'ready' | 'error'
+export type MemoryNamespaceKind =
+  | 'local-memory'
+  | 'local-rag'
+  | 'remote-peer'
+  | 'imported-snapshot'
+  | 'stale'
+  | 'denied'
+  | 'unavailable'
+
+export interface MemoryNamespaceView {
+  info: DBRAGNamespaceInfo
+  kind: MemoryNamespaceKind
+  label: string
+  selectable: boolean
+  stateCopy: string
+  repairCopy: string | null
+}
+
+export interface MemoryActionState {
+  supported: boolean
+  disabled: boolean
+  label: string
+  reason: string
+  requiresAdminAction: boolean
+}
+
+export interface MemoryViewModel {
+  loadState: MemoryLoadState
+  route: RouteAvailability
+  conversations: NormalizedConversation[]
+  namespaces: MemoryNamespaceView[]
+  selectedNamespace: MemoryNamespaceView | null
+  query: string
+  searchDecision: RAGPolicyDecision | 'not-requested'
+  searchItems: DBRAGProvenanceItem[]
+  denialReason: string | null
+  policyDecisionId: string | null
+  correlationId: string | null
+  error: string | null
+  actions: {
+    search: MemoryActionState
+    export: MemoryActionState
+    delete: MemoryActionState
+    importPreview: MemoryActionState
+  }
+}
+
+export interface BuildMemoryViewModelOptions {
+  namespace?: string | null
+  query?: string
+  limit?: number
+}
+
+export async function buildMemoryViewModel(
+  client: AuroraClient,
+  route: RouteAvailability,
+  options: BuildMemoryViewModelOptions = {}
+): Promise<MemoryViewModel> {
+  const query = options.query?.trim() ?? ''
+  const [messagesResult, namespacesResult] = await Promise.all([
+    client.memory.listMessages({ limit: 8 }),
+    client.memory.listNamespaces({ include_remote: true, include_unavailable: true })
+  ])
+
+  if (!messagesResult.ok) return errorModel(route, query, memoryErrorMessage(messagesResult.error))
+  if (!namespacesResult.ok) return errorModel(route, query, memoryErrorMessage(namespacesResult.error))
+
+  const namespaces = namespacesResult.data.namespaces.map((namespace) => namespaceView(namespace))
+  const requested = options.namespace
+    ? namespaces.find((namespace) => namespace.info.namespace === options.namespace) ?? null
+    : null
+  const selectedNamespace = requested ?? namespaces.find((namespace) => namespace.selectable) ?? namespaces[0] ?? null
+  let searchDecision: MemoryViewModel['searchDecision'] = 'not-requested'
+  let searchItems: DBRAGProvenanceItem[] = []
+  let denialReason: string | null = null
+  let policyDecisionId: string | null = null
+  let correlationId: string | null = null
+
+  if (selectedNamespace && query) {
+    const result = await client.memory.search({
+      namespace: selectedNamespace.info.namespace,
+      query,
+      limit: options.limit ?? 10,
+      mesh_selector: selectedNamespace.info.policy.explicit_selector_required
+        ? {
+            peer_id: selectedNamespace.info.provider_peer_id,
+            resource_namespace: selectedNamespace.info.namespace
+          }
+        : null
+    })
+    if (result.ok) {
+      searchDecision = result.data.decision
+      searchItems = result.data.items
+      denialReason = result.data.denial_reason
+      policyDecisionId = result.data.policy_decision_id
+      correlationId = result.data.correlation_id
+    } else {
+      return errorModel(route, query, memoryErrorMessage(result.error), namespaces, selectedNamespace)
+    }
+  }
+
+  const conversations = messagesResult.data.messages.map(normalizeConversationMessage)
+  return {
+    loadState: 'ready',
+    route,
+    conversations,
+    namespaces,
+    selectedNamespace,
+    query,
+    searchDecision,
+    searchItems,
+    denialReason,
+    policyDecisionId,
+    correlationId,
+    error: null,
+    actions: buildActionStates(route, selectedNamespace)
+  }
+}
+
+export function emptyMemoryViewModel(route: RouteAvailability, query = ''): MemoryViewModel {
+  return {
+    loadState: 'loading',
+    route,
+    conversations: [],
+    namespaces: [],
+    selectedNamespace: null,
+    query,
+    searchDecision: 'not-requested',
+    searchItems: [],
+    denialReason: null,
+    policyDecisionId: null,
+    correlationId: null,
+    error: null,
+    actions: buildActionStates(route, null)
+  }
+}
+
+export function MemoryView({ client, route, initialModel, initialQuery = '' }: MemoryViewProps) {
+  const [model, setModel] = useState<MemoryViewModel>(() => initialModel ?? emptyMemoryViewModel(route, initialQuery))
+  const [query, setQuery] = useState(initialModel?.query ?? initialQuery)
+  const [namespace, setNamespace] = useState(initialModel?.selectedNamespace?.info.namespace ?? '')
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const canSearch = model.actions.search.supported && !model.actions.search.disabled
+
+  useEffect(() => {
+    if (initialModel) return
+    void refresh({ namespace: null, query: initialQuery })
+  }, [initialModel, initialQuery])
+
+  async function refresh(options: BuildMemoryViewModelOptions = {}) {
+    setIsRefreshing(true)
+    setModel((current) => ({ ...current, loadState: 'loading' }))
+    const next = await buildMemoryViewModel(client, route, {
+      namespace: options.namespace ?? (namespace || null),
+      query: options.query ?? query
+    })
+    setModel(next)
+    setNamespace(next.selectedNamespace?.info.namespace ?? '')
+    setQuery(next.query)
+    setIsRefreshing(false)
+  }
+
+  function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!canSearch) return
+    void refresh({ namespace, query })
+  }
+
+  const selectedPrivacy = model.selectedNamespace
+    ? normalizeRagPrivacyClass(model.selectedNamespace.info.policy.privacy_class)
+    : route.item.privacyClass
+  const statusCopy = useMemo(() => memoryStatusCopy(model), [model])
+
+  return (
+    <section className="aui-memory" aria-labelledby="memory-title">
+      <header className="aui-memory-header">
+        <div>
+          <p className="aui-kicker">Memory</p>
+          <h1 id="memory-title">History and RAG provenance</h1>
+          <p>{statusCopy}</p>
+        </div>
+        <div className="aui-assistant-badges" aria-label="Memory backend evidence">
+          <StatusBadge state={route.state} />
+          <PrivacyBadge privacy={selectedPrivacy} />
+          <EvidenceBadge label={route.providerLabel} />
+          <EvidenceBadge label={client.transport.kind} />
+          {model.correlationId ? <EvidenceBadge label={`audit ${model.correlationId}`} /> : null}
+        </div>
+      </header>
+
+      <form className="aui-memory-search" onSubmit={onSubmit}>
+        <label htmlFor="memory-namespace">Namespace</label>
+        <select
+          id="memory-namespace"
+          value={namespace}
+          onChange={(event) => setNamespace(event.currentTarget.value)}
+          disabled={model.loadState === 'loading'}
+        >
+          {model.namespaces.length === 0 ? <option value="">No namespace reported</option> : null}
+          {model.namespaces.map((candidate) => (
+            <option key={candidate.info.namespace} value={candidate.info.namespace}>
+              {candidate.label}
+            </option>
+          ))}
+        </select>
+
+        <label htmlFor="memory-query">Search</label>
+        <input
+          id="memory-query"
+          value={query}
+          onChange={(event) => setQuery(event.currentTarget.value)}
+          disabled={!canSearch || model.loadState === 'loading'}
+          placeholder={canSearch ? 'Search memory and RAG...' : model.actions.search.reason}
+        />
+        <button type="submit" disabled={!canSearch || query.trim().length === 0 || model.loadState === 'loading'}>
+          <Search size={16} aria-hidden />
+          <span>Search</span>
+        </button>
+        <button type="button" disabled={isRefreshing} onClick={() => void refresh({ namespace, query })}>
+          <RefreshCw size={16} aria-hidden />
+          <span>Refresh</span>
+        </button>
+      </form>
+
+      {model.error ? <p className="aui-memory-alert" role="alert">{model.error}</p> : null}
+      {model.denialReason ? <p className="aui-memory-alert" role="alert">{model.denialReason}</p> : null}
+
+      <div className="aui-memory-grid">
+        <section className="aui-memory-panel" aria-labelledby="memory-namespaces-title">
+          <h2 id="memory-namespaces-title">Namespaces</h2>
+          <div className="aui-namespace-list">
+            {model.namespaces.map((candidate) => (
+              <button
+                key={candidate.info.namespace}
+                type="button"
+                className={candidate.info.namespace === model.selectedNamespace?.info.namespace ? 'active' : ''}
+                onClick={() => {
+                  setNamespace(candidate.info.namespace)
+                  void refresh({ namespace: candidate.info.namespace, query })
+                }}
+              >
+                <strong>{candidate.label}</strong>
+                <span>{candidate.stateCopy}</span>
+                {candidate.repairCopy ? <em>{candidate.repairCopy}</em> : null}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="aui-memory-panel" aria-labelledby="memory-results-title" aria-live="polite">
+          <h2 id="memory-results-title">Search results</h2>
+          {model.searchItems.length === 0 ? (
+            <div className="aui-memory-empty">
+              <strong>{model.searchDecision === 'not-requested' ? 'Search has not run' : 'No visible results'}</strong>
+              <span>{model.searchDecision === 'not-requested' ? 'Submit a query to ask the backend for provenance-backed records.' : model.denialReason ?? 'The backend returned no records for this namespace.'}</span>
+            </div>
+          ) : (
+            <div className="aui-memory-results">
+              {model.searchItems.map((item) => <MemoryResultCard key={`${item.namespace}:${item.key}`} item={item} />)}
+            </div>
+          )}
+        </section>
+
+        <section className="aui-memory-panel" aria-labelledby="memory-history-title">
+          <h2 id="memory-history-title">Conversation history</h2>
+          {model.conversations.length === 0 ? (
+            <div className="aui-memory-empty">
+              <strong>No conversations reported</strong>
+              <span>History remains empty until DB.GetMessages returns backend rows.</span>
+            </div>
+          ) : (
+            <div className="aui-conversation-list">
+              {model.conversations.map((message) => (
+                <article key={message.id}>
+                  <header>
+                    <strong>{message.role}</strong>
+                    <PrivacyBadge privacy={message.privacyClass} />
+                  </header>
+                  <p>{message.content}</p>
+                  <span>{message.createdAt ?? 'time not reported'} / {message.source}</span>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <aside className="aui-memory-panel" aria-labelledby="memory-actions-title">
+          <h2 id="memory-actions-title">Data controls</h2>
+          <MemoryActionButton icon="download" action={model.actions.export} />
+          <MemoryActionButton icon="trash" action={model.actions.delete} />
+          <MemoryActionButton icon="upload" action={model.actions.importPreview} />
+          <dl className="aui-memory-facts">
+            <div><dt>Policy</dt><dd>{model.selectedNamespace?.info.policy.sharing_mode ?? 'none'}</dd></div>
+            <div><dt>Provider</dt><dd>{model.selectedNamespace?.info.provider_peer_id ?? 'not reported'}</dd></div>
+            <div><dt>Source peer</dt><dd>{model.selectedNamespace?.info.source_peer_id ?? 'not reported'}</dd></div>
+            <div><dt>Policy decision</dt><dd>{model.policyDecisionId ?? 'pending search'}</dd></div>
+            <div><dt>Correlation</dt><dd>{model.correlationId ?? 'pending search'}</dd></div>
+          </dl>
+        </aside>
+      </div>
+    </section>
+  )
+}
+
+function MemoryResultCard({ item }: { item: DBRAGProvenanceItem }) {
+  const text = typeof item.value === 'string' ? item.value : JSON.stringify(item.value)
+  return (
+    <article className="aui-memory-result">
+      <header>
+        <strong>{item.key}</strong>
+        {item.redacted ? <span className="aui-badge aui-badge-privacy-blocked">redacted</span> : null}
+      </header>
+      <p>{text}</p>
+      <dl className="aui-memory-facts">
+        <div><dt>Namespace</dt><dd>{item.namespace}</dd></div>
+        <div><dt>Peer/provider</dt><dd>{item.provenance.source_peer_id}</dd></div>
+        <div><dt>Route path</dt><dd>{item.provenance.owner_peer_id === item.provenance.source_peer_id ? 'owner peer' : `${item.provenance.source_peer_id} -> ${item.provenance.owner_peer_id}`}</dd></div>
+        <div><dt>Citation</dt><dd>{item.provenance.record_id}</dd></div>
+        <div><dt>Policy</dt><dd>{item.provenance.policy_decision_id}</dd></div>
+        <div><dt>Audit</dt><dd>{item.provenance.correlation_id}</dd></div>
+        <div><dt>Tombstone</dt><dd>{item.provenance.tombstone ? item.provenance.delete_reason ?? 'deleted' : 'active'}</dd></div>
+      </dl>
+      {item.redaction_reasons.length > 0 ? <small>{item.redaction_reasons.join(', ')}</small> : null}
+    </article>
+  )
+}
+
+function MemoryActionButton({ action, icon }: { action: MemoryActionState; icon: 'download' | 'trash' | 'upload' }) {
+  const Icon = icon === 'download' ? Download : icon === 'trash' ? Trash2 : Upload
+  return (
+    <button className="aui-memory-action" type="button" disabled={action.disabled} title={action.reason}>
+      <Icon size={16} aria-hidden />
+      <span>{action.label}</span>
+    </button>
+  )
+}
+
+function namespaceView(info: DBRAGNamespaceInfo): MemoryNamespaceView {
+  const kind = namespaceKind(info)
+  const prefix = kind === 'local-memory'
+    ? 'Local memory'
+    : kind === 'local-rag'
+      ? 'Local RAG'
+      : kind === 'imported-snapshot'
+        ? 'Imported snapshot'
+        : kind === 'remote-peer'
+          ? 'Remote peer'
+          : kind
+  const selectable = info.availability === 'available' && info.policy.allowed_operations.includes('search')
+  return {
+    info,
+    kind,
+    label: `${prefix}: ${info.namespace}`,
+    selectable,
+    stateCopy: `${info.availability}; ${info.policy.sharing_mode}; ${info.policy.privacy_class}`,
+    repairCopy: namespaceRepairCopy(info)
+  }
+}
+
+function namespaceKind(info: DBRAGNamespaceInfo): MemoryNamespaceKind {
+  if (info.availability === 'stale') return 'stale'
+  if (info.availability === 'denied') return 'denied'
+  if (info.availability === 'unavailable') return 'unavailable'
+  if (info.namespace.startsWith('imports.') || info.namespace.includes('.import')) return 'imported-snapshot'
+  if (info.source_peer_id !== 'local-peer' || (info.provider_peer_id && info.provider_peer_id !== 'local-peer')) return 'remote-peer'
+  if (info.namespace.includes('rag')) return 'local-rag'
+  return 'local-memory'
+}
+
+function namespaceRepairCopy(info: DBRAGNamespaceInfo): string | null {
+  if (info.policy.denial_reason) return info.policy.denial_reason
+  if (info.availability === 'stale') return 'Refresh peer manifest before selecting this namespace.'
+  if (info.availability === 'denied') return 'Policy denied access to this namespace.'
+  if (info.policy.explicit_selector_required) return 'Explicit peer/resource selector required.'
+  if (info.embedding_model?.includes('legacy')) return 'Embedding compatibility must be checked before search.'
+  return null
+}
+
+function buildActionStates(route: RouteAvailability, namespace: MemoryNamespaceView | null): MemoryViewModel['actions'] {
+  const routeBlocked = route.disabled
+  const policy = namespace?.info.policy ?? null
+  return {
+    search: {
+      supported: Boolean(namespace),
+      disabled: routeBlocked || !namespace?.selectable,
+      label: 'Search',
+      reason: routeBlocked
+        ? `Route unavailable: ${route.blockers.join(', ') || route.state}`
+        : namespace?.selectable
+          ? 'Search uses DB.RAGSearchRemote through AuroraClient.'
+          : namespace?.repairCopy ?? 'Namespace is not selectable.'
+          ,
+      requiresAdminAction: false
+    },
+    export: actionState('Export snapshot', Boolean(policy?.export_supported), routeBlocked, Boolean(policy?.requires_admin_approval), policy?.denial_reason ?? null),
+    delete: actionState('Delete record', Boolean(policy?.delete_supported), routeBlocked, true, policy?.denial_reason ?? null),
+    importPreview: actionState('Import preview', Boolean(policy?.import_supported), routeBlocked, Boolean(policy?.requires_admin_approval), policy?.denial_reason ?? null)
+  }
+}
+
+function actionState(
+  label: string,
+  supported: boolean,
+  routeBlocked: boolean,
+  requiresAdminAction: boolean,
+  denialReason: string | null
+): MemoryActionState {
+  const reason = !supported
+    ? `${label} unsupported for this namespace.`
+    : routeBlocked
+      ? `${label} disabled until the memory route is available.`
+      : requiresAdminAction
+        ? `${label} requires AdminAction or data-sharing approval.`
+        : `${label} supported by backend policy.`
+  return {
+    supported,
+    disabled: !supported || routeBlocked || requiresAdminAction || Boolean(denialReason),
+    label,
+    reason: denialReason ?? reason,
+    requiresAdminAction
+  }
+}
+
+function errorModel(
+  route: RouteAvailability,
+  query: string,
+  error: string,
+  namespaces: MemoryNamespaceView[] = [],
+  selectedNamespace: MemoryNamespaceView | null = null
+): MemoryViewModel {
+  return {
+    ...emptyMemoryViewModel(route, query),
+    loadState: 'error',
+    namespaces,
+    selectedNamespace,
+    error,
+    actions: buildActionStates(route, selectedNamespace)
+  }
+}
+
+function memoryStatusCopy(model: MemoryViewModel): string {
+  if (model.loadState === 'loading') return 'Loading conversation and namespace evidence from AuroraClient.'
+  if (model.loadState === 'error') return model.error ?? 'Memory data could not be loaded.'
+  if (!model.selectedNamespace) return 'No memory namespace was reported by the backend.'
+  if (model.searchDecision === 'denied') return 'Backend policy denied this namespace search.'
+  if (model.searchDecision === 'unavailable') return 'Selected namespace is unavailable or stale.'
+  return 'Browse conversations, select a namespace, and inspect provenance before any data action.'
+}
+
+function memoryErrorMessage(error: AuroraError): string {
+  if (error.code === 'auth' || error.code === 'permission') return 'Memory request denied by authentication or permissions.'
+  if (error.code === 'unavailable_service' || error.code === 'unsupported_feature') return 'Memory and RAG contracts are unavailable in this backend.'
+  if (error.code === 'privacy_blocked') return 'Memory access is blocked until selector, consent, or policy approval exists.'
+  if (error.code === 'timeout') return 'Memory request timed out before backend evidence arrived.'
+  return error.message || 'Memory request failed.'
+}

--- a/packages/aurora-ui/src/nav.tsx
+++ b/packages/aurora-ui/src/nav.tsx
@@ -102,6 +102,69 @@ export const auroraAssistantCancellationItem = item(
   'UIA-002'
 )
 
+export const auroraAssistantVoiceItems = {
+  transcription: item(
+    'voice-transcription',
+    'Remote transcription',
+    '/',
+    Sparkles,
+    'Transcription',
+    'Transcribe',
+    'use',
+    'raw-audio',
+    'unsupported',
+    'UIA-004'
+  ),
+  wakeProcess: item(
+    'voice-wake-process',
+    'Wake audio processing',
+    '/',
+    Sparkles,
+    'WakeWord',
+    'ProcessAudio',
+    'use',
+    'raw-audio',
+    'unsupported',
+    'UIA-004'
+  ),
+  wakeControl: item(
+    'voice-wake-control',
+    'Wake foreground control',
+    '/',
+    Sparkles,
+    'WakeWord',
+    'Control',
+    'use',
+    'raw-audio',
+    'unsupported',
+    'UIA-004'
+  ),
+  ttsSynthesize: item(
+    'voice-tts-synthesize',
+    'TTS synthesis',
+    '/',
+    Sparkles,
+    'TTS',
+    'Synthesize',
+    'use',
+    'personal',
+    'unsupported',
+    'UIA-004'
+  ),
+  ttsStop: item(
+    'voice-tts-stop',
+    'TTS playback stop',
+    '/',
+    Sparkles,
+    'TTS',
+    'Stop',
+    'use',
+    'personal',
+    'unsupported',
+    'UIA-004'
+  )
+} as const
+
 export function getAuroraNavItem(id: string): AuroraNavItem | undefined {
   for (const section of auroraNavSections) {
     const match = section.items.find((item) => item.id === id)

--- a/packages/aurora-ui/src/shell-data.ts
+++ b/packages/aurora-ui/src/shell-data.ts
@@ -9,6 +9,7 @@ import type {
 } from '@aurora/client'
 import {
   auroraAssistantCancellationItem,
+  auroraAssistantVoiceItems,
   auroraNavSections,
   navItemSnapshot,
   type AuroraNavItem,
@@ -67,7 +68,16 @@ export interface AuroraShellSnapshot {
   nativeCapabilities: Array<{ name: string; enabled: boolean }>
   routes: RouteAvailability[]
   assistantCancellationRoute: RouteAvailability | null
+  assistantVoiceRoutes: AssistantVoiceRoutes
   error: string | null
+}
+
+export interface AssistantVoiceRoutes {
+  transcription: RouteAvailability
+  wakeProcess: RouteAvailability
+  wakeControl: RouteAvailability
+  ttsSynthesize: RouteAvailability
+  ttsStop: RouteAvailability
 }
 
 export const loadingShellSnapshot: AuroraShellSnapshot = {
@@ -87,6 +97,7 @@ export const loadingShellSnapshot: AuroraShellSnapshot = {
   nativeCapabilities: [],
   routes: [],
   assistantCancellationRoute: null,
+  assistantVoiceRoutes: emptyAssistantVoiceRoutes(),
   error: null
 }
 
@@ -115,6 +126,7 @@ export function snapshotFromGraph(
     graph.explain(featureIdForNavItem(auroraAssistantCancellationItem)),
     native
   )
+  const assistantVoiceRoutes = assistantVoiceRoutesFromGraph(graph, native)
   return {
     loadState: 'ready',
     nodeName: graph.localNodeName || 'Aurora node',
@@ -132,6 +144,7 @@ export function snapshotFromGraph(
     nativeCapabilities: nativeCapabilityEntries(native?.capabilities),
     routes,
     assistantCancellationRoute,
+    assistantVoiceRoutes,
     error: null
   }
 }
@@ -169,6 +182,7 @@ export function errorShellSnapshot(transportKind: string, error: unknown): Auror
     disabled: true,
     requiresAdminAction: false
   }
+  const assistantVoiceRoutes = errorAssistantVoiceRoutes()
   return {
     ...loadingShellSnapshot,
     loadState: 'error',
@@ -179,7 +193,77 @@ export function errorShellSnapshot(transportKind: string, error: unknown): Auror
     blockedCount: routes.length,
     error: errorMessage(error),
     routes,
-    assistantCancellationRoute
+    assistantCancellationRoute,
+    assistantVoiceRoutes
+  }
+}
+
+function assistantVoiceRoutesFromGraph(
+  graph: CapabilityGraph,
+  native: NativeCapabilityManifest | null
+): AssistantVoiceRoutes {
+  return {
+    transcription: routeAvailability(
+      auroraAssistantVoiceItems.transcription,
+      graph.explain(featureIdForNavItem(auroraAssistantVoiceItems.transcription)),
+      native
+    ),
+    wakeProcess: routeAvailability(
+      auroraAssistantVoiceItems.wakeProcess,
+      graph.explain(featureIdForNavItem(auroraAssistantVoiceItems.wakeProcess)),
+      native
+    ),
+    wakeControl: routeAvailability(
+      auroraAssistantVoiceItems.wakeControl,
+      graph.explain(featureIdForNavItem(auroraAssistantVoiceItems.wakeControl)),
+      native
+    ),
+    ttsSynthesize: routeAvailability(
+      auroraAssistantVoiceItems.ttsSynthesize,
+      graph.explain(featureIdForNavItem(auroraAssistantVoiceItems.ttsSynthesize)),
+      native
+    ),
+    ttsStop: routeAvailability(
+      auroraAssistantVoiceItems.ttsStop,
+      graph.explain(featureIdForNavItem(auroraAssistantVoiceItems.ttsStop)),
+      native
+    )
+  }
+}
+
+function emptyAssistantVoiceRoutes(): AssistantVoiceRoutes {
+  return unsupportedAssistantVoiceRoutes('pending SDK request')
+}
+
+function errorAssistantVoiceRoutes(): AssistantVoiceRoutes {
+  return unsupportedAssistantVoiceRoutes('AuroraClient error')
+}
+
+function unsupportedAssistantVoiceRoutes(evidence: string): AssistantVoiceRoutes {
+  return {
+    transcription: unsupportedVoiceRoute(auroraAssistantVoiceItems.transcription, evidence),
+    wakeProcess: unsupportedVoiceRoute(auroraAssistantVoiceItems.wakeProcess, evidence),
+    wakeControl: unsupportedVoiceRoute(auroraAssistantVoiceItems.wakeControl, evidence),
+    ttsSynthesize: unsupportedVoiceRoute(auroraAssistantVoiceItems.ttsSynthesize, evidence),
+    ttsStop: unsupportedVoiceRoute(auroraAssistantVoiceItems.ttsStop, evidence)
+  }
+}
+
+function unsupportedVoiceRoute(item: AuroraNavItem, evidence: string): RouteAvailability {
+  return {
+    item: navItemSnapshot(item),
+    state: item.fallbackState,
+    explanation: 'Voice capability state could not be loaded from AuroraClient.',
+    providerLabel: `${item.expectedTask} pending`,
+    blockers: ['sdk_error'],
+    repairActions: [repairAction('retry', 'Retry SDK request', '/', true, 'The shell needs a fresh AuroraClient response.')],
+    candidateProviders: [],
+    evidenceSources: [evidence],
+    selectorRequired: false,
+    approvalRequired: false,
+    routeable: false,
+    disabled: true,
+    requiresAdminAction: item.methodType === 'manage'
   }
 }
 

--- a/packages/aurora-ui/src/styles.css
+++ b/packages/aurora-ui/src/styles.css
@@ -288,6 +288,36 @@ button, input, select, textarea { font: inherit; }
 .aui-settings-facts dt { color: var(--aui-muted); font-size: .74rem; font-weight: 750; text-transform: uppercase; }
 .aui-settings-facts dd { margin: .18rem 0 0; overflow-wrap: anywhere; line-height: 1.4; }
 
+.aui-memory { display: grid; gap: 1rem; }
+.aui-memory-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.aui-memory-header h1 { margin: .15rem 0 0; font-size: clamp(1.65rem, 3vw, 2.45rem); line-height: 1.08; }
+.aui-memory-header p { max-width: 48rem; margin: .5rem 0 0; color: var(--aui-muted); line-height: 1.5; }
+.aui-memory-search { display: grid; grid-template-columns: minmax(12rem, .8fr) minmax(14rem, 1fr) auto auto; gap: .55rem; align-items: end; border: 1px solid var(--aui-border); border-radius: .5rem; background: var(--aui-surface); padding: .8rem; }
+.aui-memory-search label { grid-row: 1; color: var(--aui-muted); font-size: .75rem; font-weight: 750; text-transform: uppercase; }
+.aui-memory-search select, .aui-memory-search input { min-height: 2.55rem; min-width: 0; border: 1px solid var(--aui-border); border-radius: .45rem; padding: .55rem .65rem; background: var(--aui-surface); color: var(--aui-ink); }
+.aui-memory-search button, .aui-memory-action { display: inline-flex; align-items: center; justify-content: center; gap: .42rem; min-height: 2.55rem; border: 1px solid color-mix(in srgb, var(--aui-primary) 30%, var(--aui-border)); border-radius: .45rem; padding: .55rem .75rem; background: var(--aui-surface-2); color: var(--aui-primary); font-weight: 750; white-space: nowrap; }
+.aui-memory-search button[type="submit"] { background: var(--aui-primary); color: white; }
+.aui-memory-search button:disabled, .aui-memory-search input:disabled, .aui-memory-search select:disabled, .aui-memory-action:disabled { cursor: not-allowed; opacity: .58; }
+.aui-memory-alert { margin: 0; border: 1px solid color-mix(in srgb, var(--aui-danger) 35%, var(--aui-border)); border-radius: .5rem; background: color-mix(in srgb, var(--aui-danger) 8%, white); color: var(--aui-danger); padding: .8rem; }
+.aui-memory-grid { display: grid; grid-template-columns: minmax(15rem, .68fr) minmax(0, 1.35fr) minmax(18rem, .88fr); gap: .85rem; align-items: start; }
+.aui-memory-panel { display: grid; gap: .75rem; min-width: 0; border: 1px solid var(--aui-border); border-radius: .5rem; background: var(--aui-surface); padding: .9rem; }
+.aui-memory-panel h2 { margin: 0; font-size: 1rem; }
+.aui-namespace-list, .aui-memory-results, .aui-conversation-list { display: grid; gap: .55rem; }
+.aui-namespace-list button { display: grid; gap: .25rem; width: 100%; border: 1px solid var(--aui-border); border-radius: .45rem; background: var(--aui-surface); color: var(--aui-ink); padding: .65rem; text-align: left; }
+.aui-namespace-list button.active { border-color: color-mix(in srgb, var(--aui-primary) 45%, var(--aui-border)); background: color-mix(in srgb, var(--aui-primary) 7%, white); }
+.aui-namespace-list strong, .aui-namespace-list span, .aui-namespace-list em { min-width: 0; overflow-wrap: anywhere; }
+.aui-namespace-list span, .aui-namespace-list em { color: var(--aui-muted); font-size: .78rem; font-style: normal; line-height: 1.35; }
+.aui-memory-result, .aui-conversation-list article { display: grid; gap: .55rem; min-width: 0; border: 1px solid var(--aui-border); border-radius: .5rem; background: color-mix(in srgb, var(--aui-surface-2) 45%, white); padding: .75rem; }
+.aui-memory-result header, .aui-conversation-list header { display: flex; align-items: center; justify-content: space-between; gap: .6rem; }
+.aui-memory-result p, .aui-conversation-list p { margin: 0; overflow-wrap: anywhere; line-height: 1.48; }
+.aui-memory-result small, .aui-conversation-list span { color: var(--aui-muted); overflow-wrap: anywhere; }
+.aui-memory-empty { display: grid; min-height: 10rem; place-content: center; gap: .35rem; color: var(--aui-muted); text-align: center; }
+.aui-memory-empty strong { color: var(--aui-ink); }
+.aui-memory-facts { display: grid; gap: .48rem; margin: 0; }
+.aui-memory-facts div { display: grid; grid-template-columns: 7.5rem minmax(0, 1fr); gap: .5rem; }
+.aui-memory-facts dt { color: var(--aui-muted); font-size: .74rem; }
+.aui-memory-facts dd { margin: 0; overflow-wrap: anywhere; }
+
 @media (max-width: 1100px) {
   .aui-content-grid { grid-template-columns: minmax(0, 1fr); }
   .aui-activity { display: none; }
@@ -296,7 +326,7 @@ button, input, select, textarea { font: inherit; }
   .aui-voice-body { grid-template-columns: minmax(0, 1fr); }
   .aui-tool-layout { grid-template-columns: minmax(0, 1fr); }
   .aui-tool-summary { position: static; order: -1; }
-  .aui-settings-grid, .aui-route-defaults, .aui-settings-facts { grid-template-columns: minmax(0, 1fr); }
+  .aui-settings-grid, .aui-route-defaults, .aui-settings-facts, .aui-memory-grid { grid-template-columns: minmax(0, 1fr); }
 }
 
 @media (max-width: 860px) {
@@ -332,6 +362,11 @@ button, input, select, textarea { font: inherit; }
   .aui-settings-control, .aui-native-card { grid-template-columns: minmax(0, 1fr); }
   .aui-settings-control-icon { width: 2rem; height: 2rem; }
   .aui-settings-control button, .aui-native-card button { width: 100%; max-width: none; }
+  .aui-memory-header { display: grid; }
+  .aui-memory-search { grid-template-columns: minmax(0, 1fr); }
+  .aui-memory-search label { grid-row: auto; }
+  .aui-memory-search button { width: 100%; }
+  .aui-memory-facts div { grid-template-columns: minmax(0, 1fr); }
 }
 
 .aui-onboarding { display: grid; gap: 1rem; }

--- a/packages/aurora-ui/src/styles.css
+++ b/packages/aurora-ui/src/styles.css
@@ -181,6 +181,33 @@ button, input, select, textarea { font: inherit; }
 .aui-assistant-form .aui-secondary-button { border-color: var(--aui-border); background: var(--aui-surface-2); color: var(--aui-ink); }
 .aui-assistant-form button:disabled, .aui-assistant-form textarea:disabled { cursor: not-allowed; opacity: .58; }
 
+.aui-voice-panel { display: grid; gap: .85rem; border: 1px solid var(--aui-border); border-radius: .5rem; background: var(--aui-surface); padding: .9rem; }
+.aui-voice-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.aui-voice-header h2 { margin: .15rem 0 0; font-size: 1rem; }
+.aui-voice-chip-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(12.5rem, 1fr)); gap: .65rem; }
+.aui-voice-chip { display: grid; align-content: start; gap: .5rem; min-width: 0; border: 1px solid var(--aui-border); border-radius: .5rem; background: color-mix(in srgb, var(--aui-surface-2) 45%, white); padding: .7rem; }
+.aui-voice-chip header { display: flex; align-items: flex-start; justify-content: space-between; gap: .5rem; }
+.aui-voice-chip strong, .aui-voice-chip p, .aui-voice-chip small { min-width: 0; overflow-wrap: anywhere; }
+.aui-voice-chip p { margin: 0; color: var(--aui-muted); font-size: .84rem; line-height: 1.42; }
+.aui-voice-chip small { color: var(--aui-muted); font-size: .75rem; }
+.aui-voice-body { display: grid; grid-template-columns: minmax(0, 1fr) minmax(17rem, 24rem); gap: .85rem; align-items: start; }
+.aui-voice-controls, .aui-voice-privacy, .aui-voice-events { display: grid; gap: .75rem; min-width: 0; border: 1px solid var(--aui-border); border-radius: .5rem; background: color-mix(in srgb, var(--aui-surface-2) 35%, white); padding: .8rem; }
+.aui-voice-controls h3, .aui-voice-privacy h3, .aui-voice-events h3 { margin: 0; font-size: .96rem; }
+.aui-waveform { display: grid; grid-template-columns: repeat(12, 1fr); align-items: center; gap: .25rem; height: 5rem; min-width: 0; border: 1px solid var(--aui-border); border-radius: .5rem; padding: .55rem; background: var(--aui-surface); }
+.aui-waveform span { display: block; min-height: .35rem; border-radius: 999px; background: color-mix(in srgb, var(--aui-primary) 78%, white); }
+.aui-voice-action-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .45rem; }
+.aui-voice-action-grid button { display: inline-flex; align-items: center; justify-content: center; gap: .35rem; min-height: 2.55rem; min-width: 0; border: 1px solid color-mix(in srgb, var(--aui-primary) 28%, var(--aui-border)); border-radius: .45rem; padding: .5rem .55rem; background: var(--aui-surface); color: var(--aui-primary); font-size: .84rem; font-weight: 800; }
+.aui-voice-action-grid button span { min-width: 0; overflow-wrap: anywhere; }
+.aui-voice-action-grid button:disabled { cursor: not-allowed; opacity: .58; }
+.aui-voice-reasons, .aui-voice-events ul { display: grid; gap: .45rem; margin: 0; padding: 0; list-style: none; }
+.aui-voice-reasons li, .aui-voice-events li { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: .35rem .5rem; align-items: center; min-width: 0; border: 1px solid var(--aui-border); border-radius: .45rem; background: var(--aui-surface); padding: .5rem; }
+.aui-voice-reasons span, .aui-voice-events span, .aui-voice-events strong { min-width: 0; overflow-wrap: anywhere; }
+.aui-voice-reasons span, .aui-voice-events span { color: var(--aui-muted); font-size: .82rem; line-height: 1.35; }
+.aui-voice-events span { grid-column: 2; }
+.aui-voice-privacy dl { display: grid; gap: .5rem; margin: 0; }
+.aui-voice-privacy dt { color: var(--aui-muted); font-size: .73rem; font-weight: 750; text-transform: uppercase; }
+.aui-voice-privacy dd { margin: .15rem 0 0; overflow-wrap: anywhere; }
+
 .aui-tool-panel { display: grid; gap: 1rem; }
 .aui-tool-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
 .aui-tool-header h1 { margin: .15rem 0 0; font-size: clamp(1.65rem, 3vw, 2.45rem); line-height: 1.08; }
@@ -266,6 +293,7 @@ button, input, select, textarea { font: inherit; }
   .aui-activity { display: none; }
   .aui-assistant-grid { grid-template-columns: minmax(0, 1fr); }
   .aui-route-panel { order: -1; }
+  .aui-voice-body { grid-template-columns: minmax(0, 1fr); }
   .aui-tool-layout { grid-template-columns: minmax(0, 1fr); }
   .aui-tool-summary { position: static; order: -1; }
   .aui-settings-grid, .aui-route-defaults, .aui-settings-facts { grid-template-columns: minmax(0, 1fr); }
@@ -281,6 +309,9 @@ button, input, select, textarea { font: inherit; }
   .aui-topbar { padding-inline: .75rem; }
   .aui-assistant-header { display: grid; }
   .aui-assistant-badges { justify-content: flex-start; }
+  .aui-voice-header { display: grid; }
+  .aui-voice-action-grid { grid-template-columns: minmax(0, 1fr); }
+  .aui-voice-action-grid button { width: 100%; }
   .aui-stream-banner { align-items: flex-start; flex-wrap: wrap; }
   .aui-stream-banner button { margin-left: 0; }
   .aui-attachment-head { display: grid; }

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -17,6 +17,7 @@ import {
 import {
   AppShell,
   AssistantView,
+  MemoryView,
   OnboardingView,
   RouteSheet,
   buildOnboardingViewModel,
@@ -35,6 +36,7 @@ import {
   ToolApprovalPanel,
   assistantErrorMessage,
   buildAssistantVoiceModel,
+  buildMemoryViewModel,
   buildShellSnapshot,
   buildSettingsPermissionsModel,
   errorShellSnapshot,
@@ -810,6 +812,92 @@ describe('Aurora production shell', () => {
     expect(markup).toContain('Assistant route preview')
     expect(markup).toContain('The SDK evaluates where this prompt can run before dispatch.')
     expect(markup).toContain('Loading route policy from AuroraClient')
+  })
+
+  it('renders memory namespaces, conversation history, provenance, and AdminAction-gated controls', async () => {
+    const client = new AuroraClient({ transport: new MockAuroraTransport() })
+    const snapshot = await buildShellSnapshot(client)
+    const memoryRoute = enabledRoute(route(snapshot, 'memory'))
+    const model = await buildMemoryViewModel(client, memoryRoute, {
+      namespace: 'peer-studio-gpu.memories',
+      query: 'mesh pairing'
+    })
+    const markup = renderToStaticMarkup(<MemoryView client={client} route={memoryRoute} initialModel={model} />)
+
+    expect(model.selectedNamespace?.kind).toBe('remote-peer')
+    expect(model.searchDecision).toBe('allowed')
+    expect(model.searchItems[0]?.provenance.source_peer_id).toBe('peer-studio-gpu')
+    expect(markup).toContain('Remote peer: peer-studio-gpu.memories')
+    expect(markup).toContain('Search hit for &quot;mesh pairing&quot;')
+    expect(markup).toContain('redacted')
+    expect(markup).toContain('corr-memory-remote')
+    expect(markup).toContain('Conversation history')
+    expect(markup).toContain('Summarize recent mesh pairing failures')
+    expect(markup).toContain('Export snapshot unsupported')
+    expect(markup).toContain('Delete record unsupported')
+  })
+
+  it('keeps local export/import/delete controls disabled behind AdminAction policy', async () => {
+    const client = new AuroraClient({ transport: new MockAuroraTransport() })
+    const snapshot = await buildShellSnapshot(client)
+    const memoryRoute = enabledRoute(route(snapshot, 'memory'))
+    const memoryModel = await buildMemoryViewModel(client, memoryRoute, {
+      namespace: 'main.memories',
+      query: 'recent'
+    })
+    const ragModel = await buildMemoryViewModel(client, memoryRoute, {
+      namespace: 'main.rag',
+      query: 'context'
+    })
+
+    expect(memoryModel.actions.export.supported).toBe(true)
+    expect(memoryModel.actions.export.disabled).toBe(true)
+    expect(memoryModel.actions.export.reason).toContain('AdminAction')
+    expect(memoryModel.actions.delete.supported).toBe(true)
+    expect(memoryModel.actions.delete.disabled).toBe(true)
+    expect(memoryModel.actions.delete.reason).toContain('AdminAction')
+    expect(ragModel.actions.importPreview.supported).toBe(true)
+    expect(ragModel.actions.importPreview.disabled).toBe(true)
+    expect(ragModel.actions.importPreview.reason).toContain('AdminAction')
+  })
+
+  it('shows denied and stale memory namespace states without labeling them local', async () => {
+    const client = new AuroraClient({ transport: new MockAuroraTransport() })
+    const snapshot = await buildShellSnapshot(client)
+    const memoryRoute = enabledRoute(route(snapshot, 'memory'))
+    const denied = await buildMemoryViewModel(client, memoryRoute, {
+      namespace: 'peer-denied.secret',
+      query: 'secrets'
+    })
+    const stale = await buildMemoryViewModel(client, memoryRoute, {
+      namespace: 'peer-cabin-node.archive',
+      query: 'archive'
+    })
+
+    expect(denied.selectedNamespace?.kind).toBe('denied')
+    expect(denied.searchDecision).toBe('denied')
+    expect(denied.denialReason).toContain('denied')
+    expect(stale.selectedNamespace?.kind).toBe('stale')
+    expect(stale.searchDecision).toBe('unavailable')
+
+    const markup = renderToStaticMarkup(<MemoryView client={client} route={memoryRoute} initialModel={denied} />)
+    expect(markup).toContain('denied: peer-denied.secret')
+    expect(markup).not.toContain('Local memory: peer-denied.secret')
+    expect(markup).toContain('remote namespace denied by policy')
+  })
+
+  it('keeps memory SDK errors visible as route-scoped disabled state', async () => {
+    const transport = new MockAuroraTransport().fail('DB.RAGListNamespaces', 'permission', 'DB permission denied')
+    const client = new AuroraClient({ transport })
+    const snapshot = await buildShellSnapshot(client)
+    const memoryRoute = enabledRoute(route(snapshot, 'memory'))
+    const model = await buildMemoryViewModel(client, memoryRoute, { query: 'anything' })
+    const markup = renderToStaticMarkup(<MemoryView client={client} route={memoryRoute} initialModel={model} />)
+
+    expect(model.loadState).toBe('error')
+    expect(model.error).toContain('denied')
+    expect(markup).toContain('Memory request denied by authentication or permissions')
+    expect(markup).toContain('No namespace reported')
   })
 })
 

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -34,6 +34,7 @@ import {
   submitToolDenialAction,
   ToolApprovalPanel,
   assistantErrorMessage,
+  buildAssistantVoiceModel,
   buildShellSnapshot,
   buildSettingsPermissionsModel,
   errorShellSnapshot,
@@ -209,10 +210,23 @@ describe('Aurora production shell', () => {
       routeable: true
     }
     const markup = renderToStaticMarkup(
-      <AssistantView client={new AuroraClient({ transport: new MockAuroraTransport() })} route={enabledRoute} />
+      <AssistantView
+        client={new AuroraClient({ transport: new MockAuroraTransport() })}
+        route={enabledRoute}
+        voiceRoutes={snapshot.assistantVoiceRoutes}
+        nativeAvailable={snapshot.nativeAvailable}
+        nativePlatform={snapshot.nativePlatform}
+        nativePermissions={snapshot.nativePermissions}
+        nativeCapabilities={snapshot.nativeCapabilities}
+      />
     )
 
     expect(markup).toContain('Text chat')
+    expect(markup).toContain('Voice modes')
+    expect(markup).toContain('Browser capture')
+    expect(markup).toContain('Native capture')
+    expect(markup).toContain('Audio route and consent')
+    expect(markup).toContain('Voice event stream')
     expect(markup).toContain('local / Orchestrator.ExternalUserInput')
     expect(markup).toContain('model pending')
     expect(markup).toContain('personal')
@@ -227,10 +241,130 @@ describe('Aurora production shell', () => {
     expect(markup).toContain('0 context ready')
 
     const disabledMarkup = renderToStaticMarkup(
-      <AssistantView client={new AuroraClient({ transport: new MockAuroraTransport() })} route={assistantRoute} />
+      <AssistantView
+        client={new AuroraClient({ transport: new MockAuroraTransport() })}
+        route={assistantRoute}
+        voiceRoutes={snapshot.assistantVoiceRoutes}
+      />
     )
     expect(disabledMarkup).toContain('Assistant send is disabled')
     expect(disabledMarkup).toContain('Assistant capability is unavailable')
+  })
+
+  it('builds assistant voice routes from capability graph and native manifest evidence', async () => {
+    const transport = new MockAuroraTransport()
+    transport.register('Gateway.GetCapabilityCatalog', () => voiceModeCatalog())
+    transport.register('Native.GetCapabilityManifest', () => ({
+      platform: 'tauri-desktop',
+      permissions: { microphone: true },
+      capabilities: { voiceCapture: true }
+    }))
+    const client = new AuroraClient({ transport })
+    const snapshot = await buildShellSnapshot(client)
+
+    expect(snapshot.assistantVoiceRoutes.transcription.state).toBe('available-local')
+    expect(snapshot.assistantVoiceRoutes.ttsSynthesize.state).toBe('available-remote')
+    expect(snapshot.assistantVoiceRoutes.wakeControl.state).toBe('available-local')
+
+    const model = buildAssistantVoiceModel({
+      client,
+      route: enabledRoute(route(snapshot, 'assistant')),
+      voiceRoutes: snapshot.assistantVoiceRoutes,
+      nativeAvailable: snapshot.nativeAvailable,
+      nativePlatform: snapshot.nativePlatform,
+      nativePermissions: snapshot.nativePermissions,
+      nativeCapabilities: snapshot.nativeCapabilities,
+      captureStatus: 'listening',
+      consentGranted: true
+    })
+
+    expect(model.chips.find((chip) => chip.id === 'native-capture')?.state).toBe('available-local')
+    expect(model.chips.find((chip) => chip.id === 'remote-processing')?.state).toBe('available-local')
+    expect(model.controls.find((control) => control.id === 'remote-transcription')?.reason).toContain('typed audio session')
+    expect(model.events.map((event) => event.id)).toEqual(expect.arrayContaining(['partial', 'final', 'timeout', 'cancelled', 'remote-denied', 'peer-disconnect']))
+  })
+
+  it('keeps remote STT consent-gated, denial visible, and revoked consent blocking dispatch', async () => {
+    const transport = new MockAuroraTransport()
+    transport.register('Gateway.GetCapabilityCatalog', () => voiceModeCatalog('remote-stt'))
+    const client = new AuroraClient({ transport })
+    const snapshot = await buildShellSnapshot(client)
+    const assistantRoute = enabledRoute(route(snapshot, 'assistant'))
+
+    const noConsent = buildAssistantVoiceModel({
+      client,
+      route: assistantRoute,
+      voiceRoutes: snapshot.assistantVoiceRoutes,
+      captureStatus: 'listening',
+      consentGranted: false
+    })
+    expect(noConsent.controls.find((control) => control.id === 'remote-transcription')?.state).toBe('privacy-blocked')
+    expect(noConsent.controls.find((control) => control.id === 'remote-transcription')?.reason).toContain('Grant session consent')
+
+    const granted = buildAssistantVoiceModel({
+      client,
+      route: assistantRoute,
+      voiceRoutes: snapshot.assistantVoiceRoutes,
+      captureStatus: 'listening',
+      consentGranted: true
+    })
+    expect(granted.sessionTtl).toBe('current UI session')
+
+    const revoked = buildAssistantVoiceModel({
+      client,
+      route: assistantRoute,
+      voiceRoutes: snapshot.assistantVoiceRoutes,
+      captureStatus: 'listening',
+      consentGranted: false
+    })
+    expect(revoked.sessionTtl).toBe('consent not granted')
+
+    const deniedTransport = new MockAuroraTransport()
+    deniedTransport.register('Gateway.GetCapabilityCatalog', () => voiceModeCatalog('remote-denied'))
+    const deniedSnapshot = await buildShellSnapshot(new AuroraClient({ transport: deniedTransport }))
+    expect(deniedSnapshot.assistantVoiceRoutes.transcription.state).toBe('denied')
+  })
+
+  it('covers peer disconnect, local permission loss, and mobile foreground-only voice limits', async () => {
+    const staleTransport = new MockAuroraTransport()
+    staleTransport.register('Gateway.GetCapabilityCatalog', () => voiceModeCatalog('stale-remote'))
+    const staleClient = new AuroraClient({ transport: staleTransport })
+    const staleSnapshot = await buildShellSnapshot(staleClient)
+    const staleModel = buildAssistantVoiceModel({
+      client: staleClient,
+      route: enabledRoute(route(staleSnapshot, 'assistant')),
+      voiceRoutes: staleSnapshot.assistantVoiceRoutes,
+      captureStatus: 'permission-denied',
+      consentGranted: true
+    })
+
+    expect(staleSnapshot.assistantVoiceRoutes.transcription.state).toBe('stale')
+    expect(staleModel.events.find((event) => event.id === 'peer-disconnect')?.state).toBe('stale')
+    expect(staleModel.events.find((event) => event.id === 'permission-loss')?.state).toBe('denied')
+
+    const mobileTransport = new MockAuroraTransport()
+    mobileTransport.register('Gateway.GetCapabilityCatalog', () => voiceModeCatalog())
+    mobileTransport.register('Native.GetCapabilityManifest', () => ({
+      platform: 'ios',
+      permissions: { microphone: false },
+      capabilities: { voiceCapture: false }
+    }))
+    const mobileClient = new AuroraClient({ transport: mobileTransport })
+    const mobileSnapshot = await buildShellSnapshot(mobileClient)
+    const mobileModel = buildAssistantVoiceModel({
+      client: mobileClient,
+      route: enabledRoute(route(mobileSnapshot, 'assistant')),
+      voiceRoutes: mobileSnapshot.assistantVoiceRoutes,
+      nativeAvailable: mobileSnapshot.nativeAvailable,
+      nativePlatform: mobileSnapshot.nativePlatform,
+      nativePermissions: mobileSnapshot.nativePermissions,
+      nativeCapabilities: mobileSnapshot.nativeCapabilities,
+      captureStatus: 'idle',
+      consentGranted: false
+    })
+
+    expect(mobileModel.chips.find((chip) => chip.id === 'native-capture')?.state).toBe('privacy-blocked')
+    expect(mobileModel.chips.find((chip) => chip.id === 'wake')?.detail).toContain('foreground-only')
   })
 
   it('maps assistant attachment drafts to backend context payloads and statuses', () => {
@@ -726,6 +860,139 @@ function enabledRoute(match: ReturnType<typeof route>) {
     blockers: [],
     routeable: true
   }
+}
+
+function voiceModeCatalog(variant: 'local' | 'remote-stt' | 'remote-denied' | 'stale-remote' = 'local'): CapabilityCatalogResponse {
+  const catalog = cloneFixture(capabilityCatalogFixture)
+  const baseProvider = catalog.providers[0]!
+  const baseAction = catalog.actions[0]!
+  const localTranscription = provider(baseProvider, {
+    provider_id: 'local:Transcription',
+    module: 'Transcription',
+    service_instance_id: 'transcription-local',
+    reason: 'Local transcription provider is available.'
+  })
+  const remoteTranscription = provider(baseProvider, {
+    provider_id: 'mesh:studio:Transcription',
+    peer_id: 'studio-peer',
+    provider_kind: 'remote',
+    node_name: 'Studio node',
+    module: 'Transcription',
+    service_instance_id: 'transcription-studio',
+    reason: 'Remote transcription provider is eligible.'
+  })
+  const deniedTranscription = provider(remoteTranscription, {
+    eligible: false,
+    reason_code: 'policy_denied',
+    reason: 'Remote transcription denied by peer policy.',
+    policy: {
+      ...remoteTranscription.policy,
+      denial_reasons: ['policy_denied'],
+      mesh_visible: true,
+      trust_tier: 'paired'
+    }
+  })
+  const staleTranscription = provider(remoteTranscription, {
+    eligible: false,
+    status: 'stale',
+    reason_code: 'peer_disconnect',
+    reason: 'Remote transcription peer disconnected.',
+    freshness: {
+      ...remoteTranscription.freshness,
+      stale: true,
+      last_probe_age_s: 900
+    }
+  })
+  const wake = provider(baseProvider, {
+    provider_id: 'local:WakeWord',
+    module: 'WakeWord',
+    service_instance_id: 'wake-local',
+    reason: 'Foreground wake control is available locally.'
+  })
+  const ttsRemote = provider(baseProvider, {
+    provider_id: 'mesh:kitchen:TTS',
+    peer_id: 'kitchen-peer',
+    provider_kind: 'remote',
+    node_name: 'Kitchen node',
+    module: 'TTS',
+    service_instance_id: 'tts-kitchen',
+    reason: 'Remote TTS synthesis provider is eligible.'
+  })
+  const transcriptionProvider = variant === 'remote-stt'
+    ? remoteTranscription
+    : variant === 'remote-denied'
+      ? deniedTranscription
+      : variant === 'stale-remote'
+        ? staleTranscription
+        : localTranscription
+
+  catalog.providers = [transcriptionProvider, wake, ttsRemote]
+  catalog.actions = [
+    action(baseAction, transcriptionProvider, {
+      action_id: `${transcriptionProvider.provider_id}:Transcribe`,
+      method: 'Transcribe',
+      bindability: variant === 'remote-denied' ? 'denied' : variant === 'stale-remote' ? 'unavailable' : 'available',
+      policy: {
+        ...transcriptionProvider.policy,
+        required_permissions: ['Transcription.use'],
+        resource_scope: 'raw-audio',
+        mesh_visible: transcriptionProvider.provider_kind !== 'local',
+        trust_tier: transcriptionProvider.provider_kind === 'local' ? 'local' : 'paired'
+      },
+      freshness: transcriptionProvider.freshness
+    }),
+    action(baseAction, wake, {
+      action_id: 'local:WakeWord:ProcessAudio',
+      method: 'ProcessAudio',
+      policy: {
+        ...wake.policy,
+        required_permissions: ['WakeWord.use'],
+        resource_scope: 'raw-audio'
+      }
+    }),
+    action(baseAction, wake, {
+      action_id: 'local:WakeWord:Control',
+      method: 'Control',
+      policy: {
+        ...wake.policy,
+        required_permissions: ['WakeWord.use'],
+        resource_scope: 'raw-audio'
+      }
+    }),
+    action(baseAction, ttsRemote, {
+      action_id: 'mesh:kitchen:TTS:Synthesize',
+      method: 'Synthesize',
+      policy: {
+        ...ttsRemote.policy,
+        required_permissions: ['TTS.use'],
+        mesh_visible: true,
+        trust_tier: 'paired'
+      }
+    }),
+    action(baseAction, ttsRemote, {
+      action_id: 'mesh:kitchen:TTS:Stop',
+      method: 'Stop',
+      policy: {
+        ...ttsRemote.policy,
+        required_permissions: ['TTS.use'],
+        mesh_visible: true,
+        trust_tier: 'paired'
+      }
+    })
+  ]
+  catalog.provider_index = {
+    Transcription: [transcriptionProvider.provider_id],
+    WakeWord: [wake.provider_id],
+    TTS: [ttsRemote.provider_id]
+  }
+  catalog.action_index = {
+    'Transcription.Transcribe': [`${transcriptionProvider.provider_id}:Transcribe`],
+    'WakeWord.ProcessAudio': ['local:WakeWord:ProcessAudio'],
+    'WakeWord.Control': ['local:WakeWord:Control'],
+    'TTS.Synthesize': ['mesh:kitchen:TTS:Synthesize'],
+    'TTS.Stop': ['mesh:kitchen:TTS:Stop']
+  }
+  return catalog
 }
 
 function stateMatrixCatalog(): CapabilityCatalogResponse {


### PR DESCRIPTION
## Summary
- Add AuroraClient memory SDK surface for conversation history, RAG namespace listing/search/provenance, and AdminAction-gated export/import/delete calls.
- Add the `/memory` web route and `MemoryView` UI with local/remote/denied/stale namespace states, conversation history, provenance/correlation evidence, and disabled mutation controls until AdminAction is available.
- Extend SDK/UI mock fixtures and tests for remote provenance, denied/stale namespaces, local AdminAction gating, and SDK error states.

## Verification
- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client build`
- `pnpm --filter @aurora/client test`
- `pnpm --filter @aurora/ui typecheck`
- `pnpm --filter @aurora/ui test`
- `pnpm --filter @aurora/ui build`
- `pnpm --filter @aurora/web typecheck`
- `pnpm --filter @aurora/web test`
- `pnpm --filter @aurora/web build`
- `git diff --check`

## Notes
- Playwright visual regression is not available in this checkout; `pnpm exec playwright --version` reports no installed Playwright binary/package.
- The UI remains SDK-only and does not fake service, peer, memory, or RAG state outside backend/fixture evidence.
