### PR TITLE
ADM-013: Wire deployment topology dashboard

### DIFF
--- a/packages/aurora-sdk/src/capabilities.ts
+++ b/packages/aurora-sdk/src/capabilities.ts
@@ -165,6 +165,8 @@ export function buildAdminOverviewManifest(input: AdminOverviewManifestInput): A
     generatedAt: input.generatedAt ?? input.capabilityCatalog?.generated_at ?? new Date().toISOString(),
     registryDigest: input.registry.digest,
     serviceMode: servicesInput.mode,
+    deploymentTopology: input.deploymentTopology ?? null,
+    deploymentTopologyError: input.deploymentTopologyError ?? null,
     services: serviceSummaries.sort((a, b) => a.module.localeCompare(b.module)),
     methods,
     gatewayBuiltins: [...(input.gatewayBuiltins ?? [])].sort((a, b) => a.routePath.localeCompare(b.routePath)),

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -714,6 +714,7 @@ export class AssistantClient {
 
 export interface AdminOverviewManifestOptions {
   gatewayBuiltins?: GatewayBuiltinRouteDescriptor[]
+  deploymentTopology?: DeploymentTopologyResponse | null
   nativeManifest?: NativeCapabilityManifest | null
   peers?: PeerSummary[]
   generatedAt?: string
@@ -840,15 +841,52 @@ export class AdminOverviewClient {
   constructor(private readonly client: AuroraClient) {}
 
   async getManifest(options: AdminOverviewManifestOptions = {}): Promise<AdminOverviewManifest> {
-    const [registry, services, capabilityCatalog] = await Promise.all([
+    const [registry, services, capabilityCatalog, topologyResult] = await Promise.all([
       this.client.registry.getRegistry(),
       this.client.registry.listServices(),
-      this.client.capabilities.listCatalog({ include_internal: true, include_unavailable: true })
+      this.client.capabilities.listCatalog({ include_internal: true, include_unavailable: true }),
+      options.deploymentTopology !== undefined
+        ? Promise.resolve<AuroraResponse<DeploymentTopologyResponse>>(
+            options.deploymentTopology
+              ? {
+                  ok: true,
+                  data: options.deploymentTopology,
+                  audit: createAuditReceipt(options.deploymentTopology, {
+                    method: GATEWAY_METHODS.getDeploymentTopology,
+                    busTopic: GATEWAY_METHODS.getDeploymentTopology,
+                    transport: this.client.transport.kind
+                  })
+                }
+              : {
+                  ok: false,
+                  error: new AuroraError({
+                    code: 'unsupported_feature',
+                    message: 'Deployment topology evidence was not provided',
+                    method: GATEWAY_METHODS.getDeploymentTopology,
+                    busTopic: GATEWAY_METHODS.getDeploymentTopology
+                  }),
+                  audit: createAuditReceipt(null, {
+                    method: GATEWAY_METHODS.getDeploymentTopology,
+                    busTopic: GATEWAY_METHODS.getDeploymentTopology,
+                    transport: this.client.transport.kind,
+                    status: 'unsupported_feature'
+                  })
+                }
+          )
+        : this.client.requestResult<DeploymentTopologyResponse>(
+            GATEWAY_METHODS.getDeploymentTopology,
+            undefined,
+            {
+              path: routePath('Gateway', 'GetDeploymentTopology')
+            }
+          )
     ])
     const input: AdminOverviewManifestInput = {
       registry,
       services,
-      capabilityCatalog
+      capabilityCatalog,
+      deploymentTopology: topologyResult.ok ? topologyResult.data : null,
+      deploymentTopologyError: topologyResult.ok ? null : topologyResult.error.message
     }
     if (options.gatewayBuiltins !== undefined) input.gatewayBuiltins = options.gatewayBuiltins
     if (options.nativeManifest !== undefined) input.nativeManifest = options.nativeManifest

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -1218,6 +1218,8 @@ export interface AdminOverviewServiceSummary {
 export interface AdminOverviewManifestInput {
   registry: GetRegistryResponse
   services?: GetServicesResponse | ServiceInfo[]
+  deploymentTopology?: DeploymentTopologyResponse | null
+  deploymentTopologyError?: string | null
   capabilityCatalog?: CapabilityCatalogResponse | null
   gatewayBuiltins?: GatewayBuiltinRouteDescriptor[]
   nativeManifest?: NativeCapabilityManifest | null
@@ -1229,6 +1231,8 @@ export interface AdminOverviewManifest {
   generatedAt: string
   registryDigest: string
   serviceMode: string
+  deploymentTopology: DeploymentTopologyResponse | null
+  deploymentTopologyError: string | null
   services: AdminOverviewServiceSummary[]
   methods: MethodDescriptor[]
   gatewayBuiltins: GatewayBuiltinRouteDescriptor[]

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -18,10 +18,12 @@ import {
   buildCapabilityGraph,
   capabilityGraphCatalogFixture,
   capabilityCatalogFixture,
+  cloneFixture,
   compareRegistryFixtureToBackendInventory,
   createAuditReceipt,
   createAuroraEvent,
   defaultMockAuroraFixtures,
+  deploymentTopologyFixture,
   describeBackendInventory,
   describeRegistry,
   evaluateRoutePolicy,
@@ -554,6 +556,8 @@ describe('AuroraClient', () => {
         evidenceSource: 'not-provided'
       })
     )
+    expect(manifest.deploymentTopology).toBeNull()
+    expect(manifest.deploymentTopologyError).toBeNull()
     expect(manifest.privacy).toEqual({
       secretsRedacted: true,
       nativeStateInvented: false,
@@ -566,6 +570,7 @@ describe('AuroraClient', () => {
       .register('Gateway.GetRegistry', gatewayRegistryFixture)
       .register('Gateway.GetServices', gatewayServicesFixture)
       .register('Gateway.GetCapabilityCatalog', capabilityCatalogFixture)
+      .register('Gateway.GetDeploymentTopology', deploymentTopologyFixture)
     const client = new AuroraClient({ transport })
 
     const manifest = await client.adminOverview.getManifest({
@@ -578,7 +583,64 @@ describe('AuroraClient', () => {
       '/api/admin/peers',
       '/api/health'
     ])
+    expect(manifest.deploymentTopology?.bus_backend).toBe('LocalBus')
+    expect(manifest.deploymentTopology?.mode_capability_degradations).toContain('thread_mode_no_process_controls')
     expect(manifest.native.availability).toBe('unsupported')
+  })
+
+  it('keeps admin overview usable when deployment topology is unavailable', async () => {
+    const transport = new MockAuroraTransport()
+      .register('Gateway.GetRegistry', gatewayRegistryFixture)
+      .register('Gateway.GetServices', gatewayServicesFixture)
+      .register('Gateway.GetCapabilityCatalog', capabilityCatalogFixture)
+      .lose('Gateway.GetDeploymentTopology', 'deployment topology unavailable')
+    const client = new AuroraClient({ transport })
+
+    const manifest = await client.adminOverview.getManifest()
+
+    expect(manifest.services.length).toBeGreaterThan(0)
+    expect(manifest.deploymentTopology).toBeNull()
+    expect(manifest.deploymentTopologyError).toBe('deployment topology unavailable')
+  })
+
+  it('accepts process-mode deployment topology evidence in admin overview fixtures', () => {
+    const topology = cloneFixture(deploymentTopologyFixture)
+    topology.architecture_mode = 'processes'
+    topology.runtime_mode = 'server-process'
+    topology.bus_backend = 'BullMQBus'
+    topology.redis_url_redacted = 'redis://[redacted]@redis:6379/0'
+    topology.redis_reachable = true
+    topology.bullmq_queue_health = {
+      ...topology.bullmq_queue_health,
+      backend: 'BullMQBus',
+      redis_url_redacted: 'redis://[redacted]@redis:6379/0',
+      redis_reachable: true,
+      bullmq_available: true,
+      queue_depth: 0,
+      status: 'healthy',
+      degraded_reasons: []
+    }
+    topology.mode_capability_degradations = []
+    topology.container_topology_hints = {
+      orchestrator: 'docker-compose',
+      compose_file: 'docker-compose.process.yml',
+      redis_service: 'redis',
+      gateway_service: 'gateway-service',
+      config_service: 'config-service',
+      notes: ['process mode runs one container per Aurora service']
+    }
+
+    const manifest = buildAdminOverviewManifest({
+      registry: gatewayRegistryFixture,
+      services: { ...gatewayServicesFixture, mode: 'processes' },
+      capabilityCatalog: capabilityCatalogFixture,
+      deploymentTopology: topology
+    })
+
+    expect(manifest.serviceMode).toBe('processes')
+    expect(manifest.deploymentTopology?.bus_backend).toBe('BullMQBus')
+    expect(manifest.deploymentTopology?.redis_url_redacted).toContain('[redacted]')
+    expect(manifest.deploymentTopology?.mode_capability_degradations).toEqual([])
   })
 
   it('preloads deterministic mock fixtures for offline SDK development', async () => {

--- a/packages/aurora-ui/src/admin-overview-view.tsx
+++ b/packages/aurora-ui/src/admin-overview-view.tsx
@@ -4,6 +4,7 @@ import type {
   AuroraClient,
   AvailabilityState,
   CapabilitySummary,
+  DeploymentTopologyResponse,
   MethodDescriptor
 } from '@aurora/client'
 import { EvidenceBadge, PrivacyBadge, StatusBadge } from './status-badges'
@@ -71,6 +72,7 @@ export function AdminOverviewContent({ manifest, transportKind, error }: AdminOv
 
       <div className="aui-admin-grid">
         <PosturePanel manifest={manifest} posture={posture} />
+        <DeploymentTopologyPanel manifest={manifest} transportKind={transportKind} />
         <ServiceHealthPanel services={manifest.services} />
         <CapabilityGapPanel gaps={gaps} internalOnly={manifest.internalOnly} />
         <ActivityPanel items={activity} />
@@ -140,6 +142,7 @@ function AdminOverviewHeader({
 }
 
 function PosturePanel({ manifest, posture }: { manifest: AdminOverviewManifest; posture: AvailabilityState }) {
+  const topology = manifest.deploymentTopology
   return (
     <section className="aui-admin-panel" aria-labelledby="deployment-posture-title">
       <div className="aui-admin-panel-header">
@@ -151,12 +154,127 @@ function PosturePanel({ manifest, posture }: { manifest: AdminOverviewManifest; 
       </div>
       <dl className="aui-admin-facts">
         <div><dt>Service mode</dt><dd>{manifest.serviceMode}</dd></div>
+        <div><dt>Runtime</dt><dd>{topology ? deploymentModeLabel(topology) : 'BE-016 topology unavailable'}</dd></div>
         <div><dt>Registry digest</dt><dd>{manifest.registryDigest || 'not reported'}</dd></div>
         <div><dt>Services</dt><dd>{manifest.totals.services}</dd></div>
         <div><dt>Methods</dt><dd>{manifest.totals.externalMethods} external / {manifest.totals.internalMethods} internal</dd></div>
         <div><dt>Peers</dt><dd>{manifest.totals.peers}</dd></div>
         <div><dt>Native</dt><dd>{manifest.native.availability} via {manifest.native.evidenceSource}</dd></div>
       </dl>
+    </section>
+  )
+}
+
+function DeploymentTopologyPanel({
+  manifest,
+  transportKind
+}: {
+  manifest: AdminOverviewManifest
+  transportKind: string
+}) {
+  const topology = manifest.deploymentTopology
+  const topologyState = deploymentTopologyState(topology, manifest.deploymentTopologyError)
+  const staleServices = topology?.service_process_topology.filter((service) => service.stale) ?? []
+  const visibleServices = topology?.service_process_topology.slice(0, 6) ?? []
+  const degradedReasons = sortedUnique([
+    ...(topology?.mode_capability_degradations ?? []),
+    ...(topology?.bullmq_queue_health.degraded_reasons ?? [])
+  ])
+  const controlsSupported = supportsProcessControls(manifest)
+
+  return (
+    <section className="aui-admin-panel" aria-labelledby="deployment-topology-title">
+      <div className="aui-admin-panel-header">
+        <div>
+          <p className="aui-kicker">Runtime topology</p>
+          <h2 id="deployment-topology-title">Deployment topology</h2>
+        </div>
+        <StatusBadge state={topologyState} />
+      </div>
+
+      {topology ? (
+        <>
+          <dl className="aui-admin-facts">
+            <div><dt>Client boundary</dt><dd>{clientBoundaryLabel(transportKind, topology)}</dd></div>
+            <div><dt>Architecture</dt><dd>{topology.architecture_mode} / {topology.runtime_mode}</dd></div>
+            <div><dt>Bus backend</dt><dd>{topology.bus_backend}</dd></div>
+            <div><dt>Redis</dt><dd>{redisHealthLabel(topology)}</dd></div>
+            <div><dt>BullMQ</dt><dd>{busHealthLabel(topology)}</dd></div>
+            <div><dt>Registry freshness</dt><dd>{staleServices.length > 0 ? `${staleServices.length} stale services` : 'fresh topology evidence'}</dd></div>
+            <div><dt>Container hints</dt><dd>{containerHintLabel(topology)}</dd></div>
+            <div><dt>Redaction</dt><dd>{topology.secrets_redacted ? 'secrets redacted by backend' : 'redaction not confirmed'}</dd></div>
+          </dl>
+
+          {degradedReasons.length > 0 ? (
+            <ul className="aui-admin-gap-list" aria-label="Deployment degraded reasons">
+              {degradedReasons.map((reason) => (
+                <li key={reason}>
+                  <div>
+                    <strong>{reason}</strong>
+                    <small>{degradedReasonCopy(reason)}</small>
+                  </div>
+                  <StatusBadge state="degraded" />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="aui-admin-empty">
+              <h3>No topology degradation reported</h3>
+              <p>BE-016 did not report Redis, BullMQ, process registry, or mesh topology degradation in this snapshot.</p>
+            </div>
+          )}
+
+          {visibleServices.length > 0 ? (
+            <div className="aui-table-wrap">
+              <table className="aui-admin-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Service</th>
+                    <th scope="col">Topology</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Hint</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleServices.map((service) => (
+                    <tr key={`${service.module}:${service.instance_id ?? service.topology}`}>
+                      <th scope="row">{service.module}</th>
+                      <td>{service.topology}</td>
+                      <td>{service.stale ? 'stale' : service.status}</td>
+                      <td>{service.container_hint ?? service.process_hint ?? 'not reported'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <div className="aui-admin-empty" role="status">
+          <h3>Deployment topology unavailable</h3>
+          <p>{manifest.deploymentTopologyError ?? 'Gateway.GetDeploymentTopology did not return BE-016 evidence.'}</p>
+          <a className="aui-action-chip" href="/diagnostics">Open diagnostics</a>
+        </div>
+      )}
+
+      <div className="aui-admin-action-list" aria-label="Deployment topology links and controls">
+        <a className="aui-action-chip" href="/diagnostics">Diagnostics export</a>
+        <a className="aui-action-chip" href="/admin/services">Services and contracts</a>
+        <a className="aui-action-chip" href="/admin/config">Config reload impact</a>
+        <a className="aui-action-chip" href="https://github.com/joaojhgs/aurora/blob/main/README.process-mode.md">Process runbook</a>
+        <button
+          type="button"
+          className="aui-action-chip"
+          disabled={!controlsSupported}
+          title={
+            controlsSupported
+              ? 'BE-015 process controls are present, but this overview remains read-only.'
+              : 'Process restart/control requires BE-015 capability and AdminAction wiring.'
+          }
+        >
+          Process controls {controlsSupported ? 'read-only here' : 'unsupported'}
+        </button>
+      </div>
     </section>
   )
 }
@@ -282,11 +400,104 @@ function ActivityPanel({ items }: { items: ActivityItem[] }) {
 }
 
 function deploymentPosture(manifest: AdminOverviewManifest): AvailabilityState {
+  if (manifest.deploymentTopologyError) return 'degraded'
+  if (manifest.deploymentTopology?.bullmq_queue_health.status === 'degraded') return 'degraded'
+  if (manifest.deploymentTopology?.mode_capability_degradations.length) return 'degraded'
   if (manifest.totals.services === 0) return 'unsupported'
   if (manifest.unavailable.some((capability) => capability.availability === 'denied')) return 'denied'
   if (manifest.unavailable.some((capability) => capability.availability === 'stale')) return 'stale'
   if (manifest.unavailable.length > 0 || manifest.internalOnly.length > 0) return 'degraded'
   return 'available-local'
+}
+
+function deploymentTopologyState(
+  topology: DeploymentTopologyResponse | null,
+  error: string | null
+): AvailabilityState {
+  if (error || !topology) return 'unsupported'
+  if (
+    topology.redis_reachable === false ||
+    topology.bullmq_queue_health.status === 'degraded' ||
+    topology.bullmq_queue_health.degraded_reasons.length > 0 ||
+    topology.mode_capability_degradations.length > 0 ||
+    topology.service_process_topology.some((service) => service.stale) ||
+    topology.mesh_peer_topology_trusted === false
+  ) {
+    return 'degraded'
+  }
+  if (topology.runtime_mode.includes('mesh') || topology.architecture_mode.includes('mesh')) {
+    return topology.mesh_peer_topology_trusted ? 'available-remote' : 'privacy-blocked'
+  }
+  if (topology.runtime_mode.includes('thin')) return 'unsupported'
+  return 'available-local'
+}
+
+function deploymentModeLabel(topology: DeploymentTopologyResponse): string {
+  const mode = topology.architecture_mode.toLowerCase()
+  const runtime = topology.runtime_mode.toLowerCase()
+  if (runtime.includes('desktop-local') || runtime.includes('sidecar')) return 'desktop local sidecar'
+  if (runtime.includes('desktop-thin') || runtime.includes('server-thin')) return 'server thin client'
+  if (runtime.includes('mesh') || mode.includes('mesh')) return 'mesh peer-only shell'
+  if (mode.includes('process')) return 'server process-mode deployment'
+  if (mode.includes('thread')) return 'local thread-mode app'
+  return `${topology.architecture_mode} / ${topology.runtime_mode}`
+}
+
+function clientBoundaryLabel(transportKind: string, topology: DeploymentTopologyResponse): string {
+  if (transportKind === 'tauri') return `Desktop local through SDK; ${deploymentModeLabel(topology)}`
+  if (transportKind === 'mesh') return `Mesh transport through SDK; ${deploymentModeLabel(topology)}`
+  if (transportKind === 'http') return `Server web/thin client through Gateway; ${deploymentModeLabel(topology)}`
+  if (transportKind === 'mock') return `Fixture transport; ${deploymentModeLabel(topology)}`
+  return `${transportKind} transport; ${deploymentModeLabel(topology)}`
+}
+
+function redisHealthLabel(topology: DeploymentTopologyResponse): string {
+  if (topology.redis_reachable === true) return `${topology.redis_url_redacted ?? 'redacted Redis URL'} reachable`
+  if (topology.redis_reachable === false) return 'unreachable; check Redis service and REDIS_URL redaction'
+  return topology.architecture_mode === 'threads' ? 'not required for thread mode' : 'not reported'
+}
+
+function busHealthLabel(topology: DeploymentTopologyResponse): string {
+  const health = topology.bullmq_queue_health
+  const parts = [health.backend, health.status]
+  if (health.queue_depth !== null) parts.push(`queue depth ${health.queue_depth}`)
+  if (!health.queue_lag_known) parts.push('queue lag unknown')
+  return parts.join(' / ')
+}
+
+function containerHintLabel(topology: DeploymentTopologyResponse): string {
+  const hints = topology.container_topology_hints
+  const services = [
+    hints.orchestrator,
+    hints.compose_file,
+    hints.redis_service,
+    hints.gateway_service,
+    hints.config_service
+  ].filter(Boolean)
+  return services.join(' / ') || 'not reported'
+}
+
+function degradedReasonCopy(reason: string): string {
+  const normalized = reason.toLowerCase()
+  if (normalized.includes('redis_unreachable')) return 'Open diagnostics, verify Redis is running, and confirm the redacted REDIS_URL target.'
+  if (normalized.includes('bullmq_queue_lag_unknown')) return 'BullMQ queue lag is unavailable; use diagnostics before trusting process-mode throughput.'
+  if (normalized.includes('process_registry_stale')) return 'Service registry heartbeat is stale; inspect services/contracts before taking action.'
+  if (normalized.includes('thread_mode_no_process_controls')) return 'Thread mode runs in one Python process; process restart controls are intentionally disabled.'
+  if (normalized.includes('mesh_peer_topology_untrusted')) return 'Remote peer topology is not trusted; require authenticated peer evidence before displaying details.'
+  return 'Inspect diagnostics and the process-mode runbook before taking operator action.'
+}
+
+function supportsProcessControls(manifest: AdminOverviewManifest): boolean {
+  return manifest.methods.some((method) =>
+    method.busTopic === 'Supervisor.RestartService' &&
+    method.methodType === 'manage' &&
+    method.availableOverHttp &&
+    !manifest.deploymentTopology?.mode_capability_degradations.includes('thread_mode_no_process_controls')
+  )
+}
+
+function sortedUnique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b))
 }
 
 function capabilityGaps(manifest: AdminOverviewManifest): CapabilitySummary[] {

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -10,6 +10,7 @@ import {
   capabilityCatalogFixture,
   capabilityGraphCatalogFixture,
   cloneFixture,
+  deploymentTopologyFixture,
   evaluateRoutePolicy,
   gatewayRegistryFixture,
   modelRuntimeCatalogFixture,
@@ -21,6 +22,7 @@ import {
   type CapabilityActionInfo,
   type CapabilityCatalogResponse,
   type CapabilityProviderInfo,
+  type DeploymentTopologyResponse,
   type GetRegistryResponse,
   type GetServicesResponse,
   type PendingPairingEntry
@@ -1380,6 +1382,10 @@ describe('Aurora production shell', () => {
     expect(markup).toContain('Manage/admin-critical operations')
     expect(markup).toContain('privacy-blocked')
     expect(markup).toContain('secrets redacted')
+    expect(markup).toContain('Deployment topology')
+    expect(markup).toContain('local thread-mode app')
+    expect(markup).toContain('thread_mode_no_process_controls')
+    expect(markup).toContain('Process controls unsupported')
   })
 
   it('keeps denied, stale, empty, and internal-only admin states visible with repair links', () => {
@@ -1394,6 +1400,71 @@ describe('Aurora production shell', () => {
     expect(markup).toContain('Config.Get')
     expect(markup).toContain('DB.RAGSearch')
     expect(markup).toContain('AdminAction draft/confirm/audit is required')
+  })
+
+  it('renders process-mode deployment topology with Redis and BullMQ evidence', () => {
+    const manifest = adminOverviewStateMatrixManifest(processTopologyFixture())
+    const markup = renderToStaticMarkup(<AdminOverviewContent manifest={manifest} transportKind="http" />)
+
+    expect(markup).toContain('server process-mode deployment')
+    expect(markup).toContain('BullMQBus')
+    expect(markup).toContain('redis://[redacted]@redis:6379/0 reachable')
+    expect(markup).toContain('docker-compose.process.yml')
+    expect(markup).toContain('Diagnostics export')
+    expect(markup).toContain('Services and contracts')
+    expect(markup).not.toContain('redis://:password')
+  })
+
+  it('renders Redis-down process topology as degraded with actionable repair copy', () => {
+    const topology = processTopologyFixture({
+      redis_reachable: false,
+      bullmq_queue_health: {
+        ...processTopologyFixture().bullmq_queue_health,
+        redis_reachable: false,
+        status: 'degraded',
+        degraded_reasons: ['redis_unreachable', 'bullmq_queue_lag_unknown'],
+        error: 'Redis connection failed'
+      },
+      mode_capability_degradations: ['redis_unreachable', 'bullmq_queue_lag_unknown']
+    })
+    const manifest = adminOverviewStateMatrixManifest(topology)
+    const markup = renderToStaticMarkup(<AdminOverviewContent manifest={manifest} transportKind="http" />)
+
+    expect(markup).toContain('degraded')
+    expect(markup).toContain('redis_unreachable')
+    expect(markup).toContain('verify Redis is running')
+    expect(markup).toContain('bullmq_queue_lag_unknown')
+  })
+
+  it('renders mesh peer-only topology as privacy-blocked until peer topology is trusted', () => {
+    const topology = topologyFixture({
+      architecture_mode: 'mesh',
+      runtime_mode: 'mesh-peer-only',
+      bus_backend: 'MeshBus',
+      mesh_peer_topology_trusted: false,
+      mode_capability_degradations: ['mesh_peer_topology_untrusted'],
+      service_process_topology: []
+    })
+    const manifest = adminOverviewStateMatrixManifest(topology)
+    const markup = renderToStaticMarkup(<AdminOverviewContent manifest={manifest} transportKind="mesh" />)
+
+    expect(markup).toContain('mesh peer-only shell')
+    expect(markup).toContain('privacy-blocked')
+    expect(markup).toContain('mesh_peer_topology_untrusted')
+    expect(markup).toContain('require authenticated peer evidence')
+  })
+
+  it('renders missing deployment topology without inventing process health', () => {
+    const manifest = {
+      ...adminOverviewStateMatrixManifest(null),
+      deploymentTopologyError: 'deployment topology unavailable'
+    }
+    const markup = renderToStaticMarkup(<AdminOverviewContent manifest={manifest} transportKind="http" />)
+
+    expect(markup).toContain('Deployment topology unavailable')
+    expect(markup).toContain('deployment topology unavailable')
+    expect(markup).toContain('BE-016 topology unavailable')
+    expect(markup).toContain('Open diagnostics')
   })
 
   it('renders admin SDK errors as unavailable disabled state without inventing service health', async () => {
@@ -2389,7 +2460,9 @@ function action(
   }
 }
 
-function adminOverviewStateMatrixManifest(): AdminOverviewManifest {
+function adminOverviewStateMatrixManifest(
+  deploymentTopology: DeploymentTopologyResponse | null = deploymentTopologyFixture
+): AdminOverviewManifest {
   const catalog = stateMatrixCatalog()
   const services: GetServicesResponse = {
     mode: 'processes',
@@ -2430,8 +2503,81 @@ function adminOverviewStateMatrixManifest(): AdminOverviewManifest {
     registry: gatewayRegistryFixture,
     services,
     capabilityCatalog: catalog,
+    deploymentTopology,
     generatedAt: '2026-06-19T00:00:00Z'
   })
+}
+
+function topologyFixture(
+  overrides: Partial<DeploymentTopologyResponse> = {}
+): DeploymentTopologyResponse {
+  return {
+    ...cloneFixture(deploymentTopologyFixture),
+    ...overrides
+  }
+}
+
+function processTopologyFixture(
+  overrides: Partial<DeploymentTopologyResponse> = {}
+): DeploymentTopologyResponse {
+  const topology = topologyFixture({
+    architecture_mode: 'processes',
+    runtime_mode: 'server-process',
+    bus_backend: 'BullMQBus',
+    redis_url_redacted: 'redis://[redacted]@redis:6379/0',
+    redis_reachable: true,
+    bullmq_queue_health: {
+      backend: 'BullMQBus',
+      redis_url_redacted: 'redis://[redacted]@redis:6379/0',
+      redis_reachable: true,
+      bullmq_available: true,
+      queue_lag_known: true,
+      queue_depth: 0,
+      published: 42,
+      delivered: 42,
+      retries: 0,
+      dead_letters: 0,
+      status: 'healthy',
+      degraded_reasons: [],
+      error: null
+    },
+    service_process_topology: [
+      {
+        module: 'Gateway',
+        status: 'healthy',
+        topology: 'container',
+        instance_id: 'gateway-1',
+        container_hint: 'gateway-service',
+        process_hint: null,
+        last_seen: '2026-06-19T00:00:00Z',
+        stale: false
+      },
+      {
+        module: 'Config',
+        status: 'healthy',
+        topology: 'container',
+        instance_id: 'config-1',
+        container_hint: 'config-service',
+        process_hint: null,
+        last_seen: '2026-06-19T00:00:00Z',
+        stale: false
+      }
+    ],
+    container_topology_hints: {
+      orchestrator: 'docker-compose',
+      compose_file: 'docker-compose.process.yml',
+      redis_service: 'redis',
+      gateway_service: 'gateway-service',
+      config_service: 'config-service',
+      notes: ['process mode runs one container per Aurora service']
+    },
+    mode_capability_degradations: [],
+    mesh_peer_topology_trusted: null
+  })
+  return {
+    ...topology,
+    ...overrides
+  }
 }
 
 function allowedRouteEvaluation() {


### PR DESCRIPTION
## Summary
- Carry BE-016 deployment topology evidence through the admin overview SDK manifest.
- Render an admin deployment topology panel with runtime mode, bus/Redis/BullMQ health, process/container hints, degraded reason copy, diagnostics/runbook links, and disabled process controls without BE-015 evidence.
- Add fixture coverage for thread, process, Redis-down, mesh peer-only, and topology-unavailable states.

## Validation
- `pnpm --filter @aurora/client test`
- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client build`
- `pnpm --filter @aurora/ui test`
- `pnpm --filter @aurora/ui typecheck`
- `pnpm --filter @aurora/ui build`
- `pnpm --filter @aurora/web typecheck`
- `pnpm --filter @aurora/web test`
- `pnpm --filter @aurora/web build`
- `curl -sf http://127.0.0.1:3001/admin`

## Notes
- Docker process-mode smoke was attempted with `docker compose -f docker-compose.process.yml ps`, including an escalated retry, but the runtime cannot access `/var/run/docker.sock`.
- Local dev server for inspection: `http://127.0.0.1:3001/admin`.
