### PR TITLE
TAURI-005: Implement desktop native permission bridge

### DIFF
--- a/apps/aurora-tauri/SECURITY.md
+++ b/apps/aurora-tauri/SECURITY.md
@@ -16,8 +16,13 @@ TAURI-002 and TAURI-004 expose only the minimum command and capability surface n
 | `aurora_sidecar_status` | Reports local sidecar process and Gateway health. | `aurora-sidecar-status` | Includes pid/running/mode/loopback/health evidence and redacted token-storage facts; does not include the token value. |
 | `aurora_log_tail` | Reports whether a local sidecar log tail is available. | `aurora-log-tail` | Does not read arbitrary files; returns unavailable until a supervised log source is exposed. |
 | `aurora_secure_storage_get`, `aurora_secure_storage_set`, `aurora_secure_storage_delete` | SDK secure-storage helper surface. | `aurora-secure-storage` | Persists only validated Aurora credential keys in the platform keychain. Does not grant filesystem, shell, process, or web-storage access. |
+| `aurora_native_permission_status` | Reports the shell native permission/capability matrix, denied defaults, and privacy classes. | `aurora-native-permissions` | Evidence only; grants no OS permission by itself. |
+| `aurora_tray_status` | Reports system tray availability. | `aurora-tray` | Tray is created in Rust with Show Aurora and Quit actions; no shell/process access is exposed to the webview. |
+| `aurora_notification_status`, `aurora_notification_send` | Reports notification availability and returns structured denied responses for sends. | `aurora-notifications` | Notification delivery is denied by default until a permission-request UX exists. |
+| `aurora_dialog_status` | Reports dialog availability. | `aurora-dialogs` | Native open/save dialogs are denied by default until scoped picker UX exists. |
 | `aurora_local_file_read`, `aurora_local_file_write`, `aurora_local_file_pick` | SDK local-file helper surface. | `aurora-local-file` | Returns `native_permission_missing`; no filesystem plugin or file scope is granted. |
 | `aurora_secure_file_handle_open` | Future secure file-handle surface. | `aurora-secure-file-handle` | Returns `native_permission_missing`; scoped handle design is deferred. |
+| `aurora_audio_bridge_status` | Reports raw-audio bridge readiness and required consent/backend evidence. | `aurora-audio-bridge` | Microphone capture, live audio streaming, and playback control are denied by default. |
 | `aurora_shutdown` | Stops managed sidecar if present, then exits the shell cleanly. | `aurora-shutdown` | Does not terminate non-managed external Aurora processes. |
 
 ## Capability File
@@ -27,6 +32,7 @@ TAURI-002 and TAURI-004 expose only the minimum command and capability surface n
 - `core:app:default`
 - `core:event:default`
 - `core:window:default`
+- Aurora native permission, tray, notification, dialog, and audio status commands
 - the Aurora app-command permissions listed above
 
 ## Denied By Default
@@ -44,6 +50,8 @@ The shell does not grant broad Tauri or plugin permissions for:
 - WebRTC/native networking outside the SDK/Gateway bridge
 
 Secure credential storage is enabled only through the narrow Aurora keychain command surface. The native manifest reports broad filesystem, secure file handles, shell/process spawning, audio, clipboard, notifications, dialogs, and updater surfaces as unavailable where they are part of planned future Aurora surfaces. Follow-up tasks must add explicit permissions, UX, and tests before enabling them.
+
+TAURI-005 adds the core Tauri tray feature and an Aurora-owned native status bridge. It intentionally does not grant notification delivery, native dialogs, arbitrary file reads/writes, microphone capture, live audio streaming, or playback control. Those surfaces report denied defaults through `Native.GetCapabilityManifest`, `aurora_native_permission_status`, and the per-feature status commands until downstream UI/backend tasks provide scoped consent, target selection, retention/audit language, and tests.
 
 ## Token And Origin Handling
 

--- a/apps/aurora-tauri/src-tauri/Cargo.toml
+++ b/apps/aurora-tauri/src-tauri/Cargo.toml
@@ -22,6 +22,6 @@ keyring = { version = "3.6", default-features = false, features = ["apple-native
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tauri = { version = "2.9.5", features = [] }
+tauri = { version = "2.9.5", features = ["tray-icon"] }
 thiserror = "2.0"
 url = "2.5"

--- a/apps/aurora-tauri/src-tauri/capabilities/aurora-main.json
+++ b/apps/aurora-tauri/src-tauri/capabilities/aurora-main.json
@@ -17,8 +17,13 @@
     "aurora-sidecar-stop",
     "aurora-log-tail",
     "aurora-secure-storage",
+    "aurora-native-permissions",
+    "aurora-tray",
+    "aurora-notifications",
+    "aurora-dialogs",
     "aurora-local-file",
     "aurora-secure-file-handle",
+    "aurora-audio-bridge",
     "aurora-shutdown"
   ]
 }

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-audio-bridge.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-audio-bridge.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-audio-bridge"
+description = "Allow audio bridge status checks for raw-audio permission UX without granting microphone capture, live streaming, or playback control."
+commands.allow = ["aurora_audio_bridge_status"]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-dialogs.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-dialogs.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-dialogs"
+description = "Allow dialog capability status checks without granting native open/save dialogs by default."
+commands.allow = ["aurora_dialog_status"]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-native-permissions.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-native-permissions.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-native-permissions"
+description = "Allow the frontend SDK adapter to read the Aurora desktop native permission and capability status without granting denied OS surfaces."
+commands.allow = ["aurora_native_permission_status"]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-notifications.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-notifications.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-notifications"
+description = "Allow notification status checks and structured denied send responses without granting notification delivery by default."
+commands.allow = ["aurora_notification_status", "aurora_notification_send"]

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-tray.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-tray.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-tray"
+description = "Allow the frontend SDK adapter to read system tray availability. Tray menu actions are handled in Rust and do not expose shell/process access."
+commands.allow = ["aurora_tray_status"]

--- a/apps/aurora-tauri/src-tauri/src/lib.rs
+++ b/apps/aurora-tauri/src-tauri/src/lib.rs
@@ -8,7 +8,11 @@ use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, State};
+use tauri::{
+    menu::{Menu, MenuItem},
+    tray::TrayIconBuilder,
+    AppHandle, Manager, State,
+};
 use thiserror::Error;
 use url::Url;
 
@@ -106,6 +110,36 @@ struct NativeCapabilityManifest {
     platform: String,
     permissions: BTreeMap<String, bool>,
     capabilities: BTreeMap<String, bool>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NativePermissionStatus {
+    platform: String,
+    permissions: BTreeMap<String, bool>,
+    capabilities: BTreeMap<String, bool>,
+    denied_by_default: Vec<String>,
+    privacy_classes: Vec<String>,
+    evidence_source: String,
+    secrets_redacted: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeFeatureStatus {
+    available: bool,
+    permission: String,
+    capability: String,
+    source: String,
+    reason: Option<String>,
+    details: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeNotificationRequest {
+    title: String,
+    body: String,
 }
 
 struct SidecarState {
@@ -410,6 +444,96 @@ async fn native_capabilities() -> Result<NativeCapabilityManifest, AuroraCommand
 }
 
 #[tauri::command]
+async fn aurora_native_permission_status() -> Result<NativePermissionStatus, AuroraCommandError> {
+    let manifest = native_capability_manifest();
+    Ok(NativePermissionStatus {
+        platform: manifest.platform,
+        permissions: manifest.permissions,
+        capabilities: manifest.capabilities,
+        denied_by_default: vec![
+            "aurora.shell".to_string(),
+            "aurora.processSpawn".to_string(),
+            "aurora.localFileRead".to_string(),
+            "aurora.localFileWrite".to_string(),
+            "aurora.notificationsSend".to_string(),
+            "aurora.dialogOpen".to_string(),
+            "aurora.audioCapture".to_string(),
+            "aurora.audioPlayback".to_string(),
+        ],
+        privacy_classes: vec![
+            "personal".to_string(),
+            "credential".to_string(),
+            "raw-audio".to_string(),
+        ],
+        evidence_source: "tauri-capability-manifest".to_string(),
+        secrets_redacted: true,
+    })
+}
+
+#[tauri::command]
+async fn aurora_tray_status() -> Result<NativeFeatureStatus, AuroraCommandError> {
+    let mut details = BTreeMap::new();
+    details.insert("menuItems".to_string(), json!(["show", "quit"]));
+    details.insert("backendTruthRequired".to_string(), json!(false));
+    Ok(NativeFeatureStatus {
+        available: true,
+        permission: "aurora.trayStatus".to_string(),
+        capability: "desktop.tray".to_string(),
+        source: "tauri-core-tray-icon".to_string(),
+        reason: None,
+        details,
+    })
+}
+
+#[tauri::command]
+async fn aurora_notification_status() -> Result<NativeFeatureStatus, AuroraCommandError> {
+    denied_native_feature_status(
+        "aurora.notificationsSend",
+        "native.notifications",
+        "notification delivery is disabled until UI-004 defines the OS permission request and consent UX",
+    )
+}
+
+#[tauri::command]
+async fn aurora_notification_send(
+    request: NativeNotificationRequest,
+) -> Result<NativeFeatureStatus, AuroraCommandError> {
+    let _ = (request.title, request.body);
+    Err(native_permission_missing("aurora.notificationsSend"))
+}
+
+#[tauri::command]
+async fn aurora_dialog_status() -> Result<NativeFeatureStatus, AuroraCommandError> {
+    denied_native_feature_status(
+        "aurora.dialogOpen",
+        "native.dialogs",
+        "dialog plugin access is disabled until file/attachment UX defines scoped picker behavior",
+    )
+}
+
+#[tauri::command]
+async fn aurora_audio_bridge_status() -> Result<NativeFeatureStatus, AuroraCommandError> {
+    let mut status = denied_native_feature_status(
+        "aurora.audioCapture",
+        "native.audio",
+        "raw-audio capture/playback requires backend audio events, explicit target, visible privacy state, and consent",
+    )?;
+    status
+        .details
+        .insert("privacyClass".to_string(), json!("raw-audio"));
+    status
+        .details
+        .insert("backendEvidenceRequired".to_string(), json!(true));
+    status
+        .details
+        .insert("captureEnabled".to_string(), json!(false));
+    status
+        .details
+        .insert("playbackControlEnabled".to_string(), json!(false));
+    Ok(status)
+}
+
+#[tauri::command]
 async fn aurora_log_tail(
     request: Option<LogTailRequest>,
 ) -> Result<LogTailResult, AuroraCommandError> {
@@ -584,9 +708,18 @@ fn native_capability_manifest() -> NativeCapabilityManifest {
     permissions.insert("aurora.shutdown".to_string(), true);
     permissions.insert("aurora.logTail".to_string(), true);
     permissions.insert("aurora.secureStorage".to_string(), true);
+    permissions.insert("aurora.nativePermissionStatus".to_string(), true);
+    permissions.insert("aurora.trayStatus".to_string(), true);
+    permissions.insert("aurora.notificationsStatus".to_string(), true);
+    permissions.insert("aurora.notificationsSend".to_string(), false);
+    permissions.insert("aurora.dialogStatus".to_string(), true);
+    permissions.insert("aurora.dialogOpen".to_string(), false);
     permissions.insert("aurora.localFileRead".to_string(), false);
     permissions.insert("aurora.localFileWrite".to_string(), false);
     permissions.insert("aurora.secureFileHandle".to_string(), false);
+    permissions.insert("aurora.audioBridgeStatus".to_string(), true);
+    permissions.insert("aurora.audioCapture".to_string(), false);
+    permissions.insert("aurora.audioPlayback".to_string(), false);
     permissions.insert("aurora.shell".to_string(), false);
     permissions.insert("aurora.processSpawn".to_string(), false);
 
@@ -595,16 +728,40 @@ fn native_capability_manifest() -> NativeCapabilityManifest {
     capabilities.insert("desktop.localSidecarHealth".to_string(), true);
     capabilities.insert("desktop.logTail".to_string(), false);
     capabilities.insert("desktop.localSidecarSupervision".to_string(), true);
+    capabilities.insert("desktop.tray".to_string(), true);
     capabilities.insert("native.secureCredentialStorage".to_string(), true);
+    capabilities.insert("native.permissionsManifest".to_string(), true);
+    capabilities.insert("native.notifications".to_string(), false);
+    capabilities.insert("native.dialogs".to_string(), false);
     capabilities.insert("native.secureFileHandles".to_string(), false);
     capabilities.insert("native.filesystem".to_string(), false);
     capabilities.insert("native.audio".to_string(), false);
+    capabilities.insert("native.audioCapture".to_string(), false);
+    capabilities.insert("native.audioPlayback".to_string(), false);
 
     NativeCapabilityManifest {
         platform: "tauri-desktop".to_string(),
         permissions,
         capabilities,
     }
+}
+
+fn denied_native_feature_status(
+    permission: &str,
+    capability: &str,
+    reason: &str,
+) -> Result<NativeFeatureStatus, AuroraCommandError> {
+    let mut details = BTreeMap::new();
+    details.insert("enabledByDefault".to_string(), json!(false));
+    details.insert("secretsRedacted".to_string(), json!(true));
+    Ok(NativeFeatureStatus {
+        available: false,
+        permission: permission.to_string(),
+        capability: capability.to_string(),
+        source: "tauri-capability-manifest".to_string(),
+        reason: Some(reason.to_string()),
+        details,
+    })
 }
 
 fn secure_storage_entry(key: &str) -> Result<keyring::Entry, AuroraCommandError> {
@@ -937,6 +1094,10 @@ pub fn run() {
     let sidecar_state: SharedSidecarState = Arc::new(Mutex::new(SidecarState::new()));
     tauri::Builder::default()
         .manage(sidecar_state.clone())
+        .setup(|app| {
+            install_tray(app.handle())?;
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             aurora_request,
             aurora_command,
@@ -947,6 +1108,12 @@ pub fn run() {
             aurora_sidecar_status,
             aurora_native_capability_manifest,
             native_capabilities,
+            aurora_native_permission_status,
+            aurora_tray_status,
+            aurora_notification_status,
+            aurora_notification_send,
+            aurora_dialog_status,
+            aurora_audio_bridge_status,
             aurora_log_tail,
             aurora_secure_storage_get,
             aurora_secure_storage_set,
@@ -966,6 +1133,31 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running Aurora Tauri shell");
+}
+
+fn install_tray(app: &AppHandle) -> tauri::Result<()> {
+    let show = MenuItem::with_id(app, "show", "Show Aurora", true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&show, &quit])?;
+    let mut builder = TrayIconBuilder::with_id("aurora-main")
+        .tooltip("Aurora")
+        .menu(&menu)
+        .show_menu_on_left_click(true)
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "show" => {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            }
+            "quit" => app.exit(0),
+            _ => {}
+        });
+    if let Some(icon) = app.default_window_icon() {
+        builder = builder.icon(icon.clone());
+    }
+    builder.build(app)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -998,6 +1190,36 @@ mod tests {
             manifest.capabilities.get("native.secureFileHandles"),
             Some(&false)
         );
+        assert_eq!(manifest.capabilities.get("desktop.tray"), Some(&true));
+        assert_eq!(
+            manifest.permissions.get("aurora.notificationsSend"),
+            Some(&false)
+        );
+        assert_eq!(manifest.permissions.get("aurora.dialogOpen"), Some(&false));
+        assert_eq!(
+            manifest.permissions.get("aurora.audioCapture"),
+            Some(&false)
+        );
+        assert_eq!(
+            manifest.capabilities.get("native.notifications"),
+            Some(&false)
+        );
+        assert_eq!(manifest.capabilities.get("native.dialogs"), Some(&false));
+        assert_eq!(manifest.capabilities.get("native.audio"), Some(&false));
+    }
+
+    #[test]
+    fn native_permission_status_lists_denied_sensitive_surfaces() {
+        let manifest = native_capability_manifest();
+        let denied: Vec<String> = manifest
+            .permissions
+            .iter()
+            .filter_map(|(key, allowed)| if *allowed { None } else { Some(key.clone()) })
+            .collect();
+        assert!(denied.contains(&"aurora.notificationsSend".to_string()));
+        assert!(denied.contains(&"aurora.dialogOpen".to_string()));
+        assert!(denied.contains(&"aurora.audioCapture".to_string()));
+        assert!(denied.contains(&"aurora.localFileRead".to_string()));
     }
 
     #[test]

--- a/apps/aurora-tauri/src/aurora-client.test.tsx
+++ b/apps/aurora-tauri/src/aurora-client.test.tsx
@@ -17,6 +17,7 @@ describe('Aurora Tauri runtime wrapper', () => {
     expect(runtime.mode).toBe('mock')
     expect(runtime.client.transport.kind).toBe('mock')
     await expect(runtime.sidecarStatus()).resolves.toBeNull()
+    await expect(runtime.nativePermissionStatus()).resolves.toBeNull()
     await expect(runtime.shutdown()).resolves.toBeUndefined()
   })
 
@@ -38,6 +39,8 @@ describe('Aurora Tauri runtime wrapper', () => {
 
     expect(markup).toContain('Native boundary')
     expect(markup).toContain('Runtime mode')
+    expect(markup).toContain('Audio bridge')
+    expect(markup).toContain('Denied native defaults')
     expect(markup).toContain('mock')
     expect(markup).toContain('not used in thin mode')
   })

--- a/apps/aurora-tauri/src/aurora-client.ts
+++ b/apps/aurora-tauri/src/aurora-client.ts
@@ -3,6 +3,8 @@ import {
   HttpGatewayTransport,
   MockAuroraTransport,
   TauriLocalTransport,
+  type TauriNativeFeatureStatus,
+  type TauriNativePermissionStatus,
   type TauriSidecarStatus
 } from '@aurora/client'
 import { invoke } from '@tauri-apps/api/core'
@@ -13,6 +15,11 @@ export interface AuroraTauriRuntime {
   sidecarStatus: () => Promise<TauriSidecarStatus | null>
   startSidecar: () => Promise<TauriSidecarStatus | null>
   stopSidecar: () => Promise<TauriSidecarStatus | null>
+  nativePermissionStatus: () => Promise<TauriNativePermissionStatus | null>
+  trayStatus: () => Promise<TauriNativeFeatureStatus | null>
+  notificationStatus: () => Promise<TauriNativeFeatureStatus | null>
+  dialogStatus: () => Promise<TauriNativeFeatureStatus | null>
+  audioBridgeStatus: () => Promise<TauriNativeFeatureStatus | null>
   shutdown: () => Promise<void>
 }
 
@@ -25,6 +32,11 @@ export function createAuroraTauriRuntime(): AuroraTauriRuntime {
       sidecarStatus: () => transport.getSidecarStatus(),
       startSidecar: () => transport.startSidecar(),
       stopSidecar: () => transport.stopSidecar(),
+      nativePermissionStatus: () => transport.getNativePermissionStatus(),
+      trayStatus: () => transport.getTrayStatus(),
+      notificationStatus: () => transport.getNotificationStatus(),
+      dialogStatus: () => transport.getDialogStatus(),
+      audioBridgeStatus: () => transport.getAudioBridgeStatus(),
       shutdown: () => invoke<void>('aurora_shutdown')
     }
   }
@@ -42,6 +54,11 @@ export function createAuroraTauriRuntime(): AuroraTauriRuntime {
       sidecarStatus: async () => null,
       startSidecar: async () => null,
       stopSidecar: async () => null,
+      nativePermissionStatus: async () => null,
+      trayStatus: async () => null,
+      notificationStatus: async () => null,
+      dialogStatus: async () => null,
+      audioBridgeStatus: async () => null,
       shutdown: async () => undefined
     }
   }
@@ -52,6 +69,11 @@ export function createAuroraTauriRuntime(): AuroraTauriRuntime {
     sidecarStatus: async () => null,
     startSidecar: async () => null,
     stopSidecar: async () => null,
+    nativePermissionStatus: async () => null,
+    trayStatus: async () => null,
+    notificationStatus: async () => null,
+    dialogStatus: async () => null,
+    audioBridgeStatus: async () => null,
     shutdown: async () => undefined
   }
 }

--- a/apps/aurora-tauri/src/tauri-app.tsx
+++ b/apps/aurora-tauri/src/tauri-app.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useMemo, useState } from 'react'
 import { AppShell, RouteMatrix, StateSurface, buildShellSnapshot, loadingShellSnapshot } from '@aurora/ui'
 import type { AuroraShellSnapshot } from '@aurora/ui'
-import type { TauriSidecarStatus } from '@aurora/client'
+import type { TauriNativeFeatureStatus, TauriNativePermissionStatus, TauriSidecarStatus } from '@aurora/client'
 import { createAuroraTauriRuntime } from './aurora-client'
 
 export function AuroraTauriApp() {
   const runtime = useMemo(() => createAuroraTauriRuntime(), [])
   const [snapshot, setSnapshot] = useState<AuroraShellSnapshot>(loadingShellSnapshot)
   const [sidecar, setSidecar] = useState<TauriSidecarStatus | null>(null)
+  const [nativePermissions, setNativePermissions] = useState<TauriNativePermissionStatus | null>(null)
+  const [nativeFeatures, setNativeFeatures] = useState<Record<string, TauriNativeFeatureStatus | null>>({})
 
   useEffect(() => {
     let cancelled = false
@@ -21,13 +23,20 @@ export function AuroraTauriApp() {
               details: {}
             }))
           : null
-      const [nextSnapshot, nextSidecar] = await Promise.all([
+      const [nextSnapshot, nextSidecar, nextNativePermissions, tray, notifications, dialogs, audio] = await Promise.all([
         buildShellSnapshot(runtime.client),
-        localSidecar ? Promise.resolve(localSidecar) : runtime.sidecarStatus().catch(() => null)
+        localSidecar ? Promise.resolve(localSidecar) : runtime.sidecarStatus().catch(() => null),
+        runtime.nativePermissionStatus().catch(() => null),
+        runtime.trayStatus().catch(() => null),
+        runtime.notificationStatus().catch(() => null),
+        runtime.dialogStatus().catch(() => null),
+        runtime.audioBridgeStatus().catch(() => null)
       ])
       if (!cancelled) {
         setSnapshot(nextSnapshot)
         setSidecar(nextSidecar)
+        setNativePermissions(nextNativePermissions)
+        setNativeFeatures({ tray, notifications, dialogs, audio })
       }
     }
     void load()
@@ -58,6 +67,11 @@ export function AuroraTauriApp() {
             <div><dt>SDK transport</dt><dd>{snapshot.transportKind}</dd></div>
             <div><dt>Sidecar supervisor</dt><dd>{sidecar?.running ? 'running' : localMode ? 'stopped or unavailable' : 'not used in thin mode'}</dd></div>
             <div><dt>Native manifest</dt><dd>{snapshot.nativeAvailable ? snapshot.nativePlatform : 'unavailable'}</dd></div>
+            <div><dt>Tray</dt><dd>{nativeFeatureLabel(nativeFeatures.tray)}</dd></div>
+            <div><dt>Notifications</dt><dd>{nativeFeatureLabel(nativeFeatures.notifications)}</dd></div>
+            <div><dt>Dialogs</dt><dd>{nativeFeatureLabel(nativeFeatures.dialogs)}</dd></div>
+            <div><dt>Audio bridge</dt><dd>{nativeFeatureLabel(nativeFeatures.audio)}</dd></div>
+            <div><dt>Denied native defaults</dt><dd>{nativePermissions?.deniedByDefault.join(', ') ?? 'not available'}</dd></div>
           </dl>
           <button className="ata-secondary" type="button" onClick={() => void runtime.shutdown()}>
             Shut down shell
@@ -67,4 +81,10 @@ export function AuroraTauriApp() {
       </div>
     </AppShell>
   )
+}
+
+function nativeFeatureLabel(feature: TauriNativeFeatureStatus | null | undefined): string {
+  if (!feature) return 'not available'
+  if (feature.available) return `${feature.capability} available`
+  return `${feature.capability} denied by default`
 }

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -2949,9 +2949,18 @@ export const nativeCapabilityManifestFixture: NativeCapabilityManifest = {
     'aurora.shutdown': true,
     'aurora.logTail': true,
     'aurora.secureStorage': true,
+    'aurora.nativePermissionStatus': true,
+    'aurora.trayStatus': true,
+    'aurora.notificationsStatus': true,
+    'aurora.notificationsSend': false,
+    'aurora.dialogStatus': true,
+    'aurora.dialogOpen': false,
     'aurora.localFileRead': false,
     'aurora.localFileWrite': false,
     'aurora.secureFileHandle': false,
+    'aurora.audioBridgeStatus': true,
+    'aurora.audioCapture': false,
+    'aurora.audioPlayback': false,
     'aurora.shell': false,
     'aurora.processSpawn': false
   },
@@ -2960,10 +2969,16 @@ export const nativeCapabilityManifestFixture: NativeCapabilityManifest = {
     'desktop.localSidecarHealth': true,
     'desktop.logTail': false,
     'desktop.localSidecarSupervision': true,
+    'desktop.tray': true,
     'native.secureCredentialStorage': true,
+    'native.permissionsManifest': true,
+    'native.notifications': false,
+    'native.dialogs': false,
     'native.secureFileHandles': false,
     'native.filesystem': false,
-    'native.audio': false
+    'native.audio': false,
+    'native.audioCapture': false,
+    'native.audioPlayback': false
   }
 }
 

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -185,6 +185,9 @@ export type {
   TauriLogTailRequest,
   TauriLogTailResult,
   TauriLocalTransportOptions,
+  TauriNativeFeatureStatus,
+  TauriNativePermissionStatus,
+  TauriNotificationRequest,
   TauriSidecarStatus
 } from './tauri.js'
 export type {

--- a/packages/aurora-sdk/src/tauri.ts
+++ b/packages/aurora-sdk/src/tauri.ts
@@ -17,6 +17,12 @@ export interface TauriCommandNames {
   sidecarStop: string
   sidecarStatus: string
   nativeCapabilityManifest: string
+  nativePermissionStatus: string
+  trayStatus: string
+  notificationStatus: string
+  notificationSend: string
+  dialogStatus: string
+  audioBridgeStatus: string
   logTail: string
   secureStorageGet: string
   secureStorageSet: string
@@ -60,6 +66,30 @@ export interface TauriLogTailResult {
 
 export interface TauriSidecarSession {
   token: string
+}
+
+export interface TauriNativePermissionStatus {
+  platform: string
+  permissions: Record<string, boolean>
+  capabilities: Record<string, boolean>
+  deniedByDefault: string[]
+  privacyClasses: string[]
+  evidenceSource: string
+  secretsRedacted: boolean
+}
+
+export interface TauriNativeFeatureStatus {
+  available: boolean
+  permission: string
+  capability: string
+  source: string
+  reason?: string | null
+  details?: JsonObject
+}
+
+export interface TauriNotificationRequest {
+  title: string
+  body: string
 }
 
 export interface SecureStorageGetResult {
@@ -115,6 +145,12 @@ const DEFAULT_COMMANDS: TauriCommandNames = {
   sidecarStop: 'aurora_sidecar_stop',
   sidecarStatus: 'aurora_sidecar_status',
   nativeCapabilityManifest: 'aurora_native_capability_manifest',
+  nativePermissionStatus: 'aurora_native_permission_status',
+  trayStatus: 'aurora_tray_status',
+  notificationStatus: 'aurora_notification_status',
+  notificationSend: 'aurora_notification_send',
+  dialogStatus: 'aurora_dialog_status',
+  audioBridgeStatus: 'aurora_audio_bridge_status',
   logTail: 'aurora_log_tail',
   secureStorageGet: 'aurora_secure_storage_get',
   secureStorageSet: 'aurora_secure_storage_set',
@@ -179,6 +215,30 @@ export class TauriLocalTransport implements AuroraTransport {
 
   getNativeCapabilityManifest(): Promise<NativeCapabilityManifest> {
     return this.invokeCommand<NativeCapabilityManifest>(this.commands.nativeCapabilityManifest)
+  }
+
+  getNativePermissionStatus(): Promise<TauriNativePermissionStatus> {
+    return this.invokeCommand<TauriNativePermissionStatus>(this.commands.nativePermissionStatus)
+  }
+
+  getTrayStatus(): Promise<TauriNativeFeatureStatus> {
+    return this.invokeCommand<TauriNativeFeatureStatus>(this.commands.trayStatus)
+  }
+
+  getNotificationStatus(): Promise<TauriNativeFeatureStatus> {
+    return this.invokeCommand<TauriNativeFeatureStatus>(this.commands.notificationStatus)
+  }
+
+  sendNotification(request: TauriNotificationRequest): Promise<TauriNativeFeatureStatus> {
+    return this.invokeCommand<TauriNativeFeatureStatus>(this.commands.notificationSend, { request })
+  }
+
+  getDialogStatus(): Promise<TauriNativeFeatureStatus> {
+    return this.invokeCommand<TauriNativeFeatureStatus>(this.commands.dialogStatus)
+  }
+
+  getAudioBridgeStatus(): Promise<TauriNativeFeatureStatus> {
+    return this.invokeCommand<TauriNativeFeatureStatus>(this.commands.audioBridgeStatus)
   }
 
   getLogTail(request: TauriLogTailRequest = {}): Promise<TauriLogTailResult> {

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -2304,6 +2304,33 @@ describe('AuroraClient', () => {
             return { running: true, mode: 'sidecar', pid: 42 }
           case 'aurora_native_capability_manifest':
             return nativeCapabilityManifestFixture
+          case 'aurora_native_permission_status':
+            return {
+              platform: 'tauri-desktop',
+              permissions: nativeCapabilityManifestFixture.permissions,
+              capabilities: nativeCapabilityManifestFixture.capabilities,
+              deniedByDefault: ['aurora.notificationsSend', 'aurora.audioCapture'],
+              privacyClasses: ['personal', 'credential', 'raw-audio'],
+              evidenceSource: 'tauri-capability-manifest',
+              secretsRedacted: true
+            }
+          case 'aurora_tray_status':
+            return { available: true, permission: 'aurora.trayStatus', capability: 'desktop.tray', source: 'tauri-core-tray-icon' }
+          case 'aurora_notification_status':
+            return { available: false, permission: 'aurora.notificationsSend', capability: 'native.notifications', source: 'tauri-capability-manifest', reason: 'disabled' }
+          case 'aurora_notification_send':
+            throw { detail: { code: 'native_permission_missing', message: 'native permission missing' } }
+          case 'aurora_dialog_status':
+            return { available: false, permission: 'aurora.dialogOpen', capability: 'native.dialogs', source: 'tauri-capability-manifest', reason: 'disabled' }
+          case 'aurora_audio_bridge_status':
+            return {
+              available: false,
+              permission: 'aurora.audioCapture',
+              capability: 'native.audio',
+              source: 'tauri-capability-manifest',
+              reason: 'raw-audio requires consent',
+              details: { privacyClass: 'raw-audio', backendEvidenceRequired: true }
+            }
           case 'aurora_log_tail':
             return { available: false, source: 'aurora-sidecar', lines: [], truncated: false }
           case 'aurora_secure_storage_get':
@@ -2331,6 +2358,31 @@ describe('AuroraClient', () => {
     await expect(transport.startSidecar()).resolves.toEqual(expect.objectContaining({ running: true }))
     await expect(transport.stopSidecar()).resolves.toEqual(expect.objectContaining({ running: false }))
     await expect(transport.getNativeCapabilityManifest()).resolves.toEqual(nativeCapabilityManifestFixture)
+    await expect(transport.getNativePermissionStatus()).resolves.toEqual(
+      expect.objectContaining({
+        deniedByDefault: expect.arrayContaining(['aurora.notificationsSend', 'aurora.audioCapture']),
+        privacyClasses: expect.arrayContaining(['raw-audio']),
+        secretsRedacted: true
+      })
+    )
+    await expect(transport.getTrayStatus()).resolves.toEqual(
+      expect.objectContaining({ available: true, capability: 'desktop.tray' })
+    )
+    await expect(transport.getNotificationStatus()).resolves.toEqual(
+      expect.objectContaining({ available: false, permission: 'aurora.notificationsSend' })
+    )
+    await expect(transport.sendNotification({ title: 'Aurora', body: 'Ready' })).rejects.toMatchObject({
+      code: 'native_permission_missing'
+    })
+    await expect(transport.getDialogStatus()).resolves.toEqual(
+      expect.objectContaining({ available: false, capability: 'native.dialogs' })
+    )
+    await expect(transport.getAudioBridgeStatus()).resolves.toEqual(
+      expect.objectContaining({
+        available: false,
+        details: expect.objectContaining({ privacyClass: 'raw-audio', backendEvidenceRequired: true })
+      })
+    )
     await expect(transport.getLogTail({ lines: 10 })).resolves.toEqual({
       available: false,
       source: 'aurora-sidecar',
@@ -2365,6 +2417,12 @@ describe('AuroraClient', () => {
       'aurora_sidecar_start',
       'aurora_sidecar_stop',
       'aurora_native_capability_manifest',
+      'aurora_native_permission_status',
+      'aurora_tray_status',
+      'aurora_notification_status',
+      'aurora_notification_send',
+      'aurora_dialog_status',
+      'aurora_audio_bridge_status',
       'aurora_log_tail',
       'aurora_secure_storage_get',
       'aurora_secure_storage_set',
@@ -2376,12 +2434,13 @@ describe('AuroraClient', () => {
     ])
     expect(calls[2]?.args).toEqual({ commandToken: { token: 'session-token' } })
     expect(calls[3]?.args).toEqual({ commandToken: { token: 'session-token' } })
-    expect(calls[5]?.args).toEqual({ request: { lines: 10 } })
-    expect(calls[6]?.args).toEqual({ key: 'session' })
-    expect(calls[7]?.args).toEqual({ key: 'session', value: 'token-ref' })
-    expect(calls[9]?.args).toEqual({ path: '/tmp/a.txt', options: {} })
-    expect(calls[10]?.args).toEqual({ path: '/tmp/a.txt', data: 'hello', options: {} })
-    expect(calls[12]?.args).toEqual({ options: { mode: 'read' } })
+    expect(calls[8]?.args).toEqual({ request: { title: 'Aurora', body: 'Ready' } })
+    expect(calls[11]?.args).toEqual({ request: { lines: 10 } })
+    expect(calls[12]?.args).toEqual({ key: 'session' })
+    expect(calls[13]?.args).toEqual({ key: 'session', value: 'token-ref' })
+    expect(calls[15]?.args).toEqual({ path: '/tmp/a.txt', options: {} })
+    expect(calls[16]?.args).toEqual({ path: '/tmp/a.txt', data: 'hello', options: {} })
+    expect(calls[18]?.args).toEqual({ options: { mode: 'read' } })
   })
 
   it('classifies Tauri auth, permission, validation, timeout, unavailable, unsupported, privacy, native permission, and transport-loss failures', async () => {


### PR DESCRIPTION
## Summary

- Adds the TAURI-005 native permission/status bridge for tray, notifications, dialogs, secure files, and raw-audio readiness.
- Creates the Tauri system tray in Rust with Show Aurora and Quit actions.
- Keeps notifications, native dialogs, arbitrary file reads/writes, microphone capture, live audio streaming, and playback control denied by default with explicit SDK-visible status.
- Extends `TauriLocalTransport`, fixtures, tests, and the Tauri wrapper evidence panel without adding direct screen-level `invoke` calls.
- Updates `apps/aurora-tauri/SECURITY.md` with every exposed command/capability and denied default.

## Validation

- `cargo fmt --check` passed in `apps/aurora-tauri/src-tauri`.
- `pnpm --filter @aurora/client build` passed.
- `pnpm --filter @aurora/client test` passed: 88 tests.
- `pnpm --filter @aurora/ui build` passed.
- `pnpm --filter @aurora/tauri-ui test` passed: 4 tests.
- `pnpm --filter @aurora/tauri-ui build` passed.

## Known environment limit

- `cargo check` could not complete in this runtime because Linux system packages for Tauri/WebKit GTK are missing before this crate compiles: `glib-2.0`, `gio-2.0`, and `gobject-2.0` were not found by `pkg-config`.
- Linux smoke launch was not run for the same system dependency/display limitation.

## Security notes

- No broad shell, process, filesystem, notification, dialog, or raw-audio permission is granted.
- Sensitive native surfaces report denied defaults through `Native.GetCapabilityManifest`, `aurora_native_permission_status`, and feature-specific status commands.
- Sidecar command token/origin handling remains unchanged.
