### PR TITLE
PER-206: Add iOS native build baseline metadata

### DIFF
--- a/.github/workflows/tauri-ios.yml
+++ b/.github/workflows/tauri-ios.yml
@@ -1,0 +1,66 @@
+name: Tauri iOS Baseline
+
+on:
+  pull_request:
+    paths:
+      - "apps/aurora-tauri/**"
+      - "packages/aurora-sdk/**"
+      - "packages/aurora-ui/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/tauri-ios.yml"
+  workflow_dispatch:
+
+jobs:
+  macos-tauri-ios:
+    name: macOS Xcode Tauri iOS init and build
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          xcodebuild -version
+          xcrun simctl list runtimes
+
+      - name: Set up Rust with iOS targets
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install CocoaPods
+        run: |
+          if ! command -v pod >/dev/null 2>&1; then
+            brew install cocoapods
+          fi
+          pod --version
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Tauri workspace dependencies
+        run: |
+          pnpm --filter @aurora/client build
+          pnpm --filter @aurora/ui build
+
+      - name: Build Tauri frontend bundle
+        run: pnpm --filter @aurora/tauri-ui build
+
+      - name: Initialize Tauri iOS project
+        run: pnpm --filter @aurora/tauri-ui tauri ios init
+
+      - name: Build Tauri iOS app
+        run: pnpm --filter @aurora/tauri-ui tauri ios build

--- a/.github/workflows/tauri-ios.yml
+++ b/.github/workflows/tauri-ios.yml
@@ -63,4 +63,8 @@ jobs:
         run: pnpm --filter @aurora/tauri-ui tauri ios init
 
       - name: Build Tauri iOS app
+        env:
+          CODE_SIGN_IDENTITY: ""
+          CODE_SIGNING_ALLOWED: "NO"
+          CODE_SIGNING_REQUIRED: "NO"
         run: pnpm --filter @aurora/tauri-ui tauri ios build

--- a/.github/workflows/tauri-ios.yml
+++ b/.github/workflows/tauri-ios.yml
@@ -62,9 +62,9 @@ jobs:
       - name: Initialize Tauri iOS project
         run: pnpm --filter @aurora/tauri-ui tauri ios init
 
-      - name: Build Tauri iOS app
+      - name: Build Tauri iOS simulator app
         env:
           CODE_SIGN_IDENTITY: ""
           CODE_SIGNING_ALLOWED: "NO"
           CODE_SIGNING_REQUIRED: "NO"
-        run: pnpm --filter @aurora/tauri-ui tauri ios build
+        run: pnpm --filter @aurora/tauri-ui tauri ios build --target aarch64-sim

--- a/.github/workflows/tauri-ios.yml
+++ b/.github/workflows/tauri-ios.yml
@@ -67,4 +67,4 @@ jobs:
           CODE_SIGN_IDENTITY: ""
           CODE_SIGNING_ALLOWED: "NO"
           CODE_SIGNING_REQUIRED: "NO"
-        run: pnpm --filter @aurora/tauri-ui tauri ios build --target aarch64-sim
+        run: pnpm --filter @aurora/tauri-ui tauri ios build --target aarch64-sim --config src-tauri/tauri.ios.conf.json

--- a/apps/aurora-tauri/README.md
+++ b/apps/aurora-tauri/README.md
@@ -73,6 +73,8 @@ pnpm --filter @aurora/tauri-ui tauri ios build
 
 The `Tauri iOS Baseline` GitHub Actions workflow runs this baseline on macOS with Xcode, CocoaPods, and the required Rust iOS targets. Use that workflow's `macOS Xcode Tauri iOS init and build` job as IOS-001 build evidence for pull requests. The CI baseline builds the unsigned iOS simulator target with `pnpm --filter @aurora/tauri-ui tauri ios build --target aarch64-sim`; the default device/archive build requires Apple signing credentials and remains a separate App Store/TestFlight release dry-run gate once Apple team credentials and native iOS targets are ready.
 
+The iOS baseline uses `src-tauri/tauri.ios.conf.json` and the `aurora-ios-baseline` capability so mobile builds do not request desktop-only updater permissions. Desktop builds continue to use `aurora-main` and the signed updater configuration.
+
 After IOS-002/IOS-003/IOS-004 add the Swift plugin and Xcode-managed App Intent/share/widget targets, the macOS check must also smoke-test simulator/device invocation of one App Intent or Shortcut and one share/deep-link flow. Do not duplicate Aurora orchestration logic in Swift; native entrypoints bridge to the SDK/backend.
 
 ## Scope Boundary

--- a/apps/aurora-tauri/README.md
+++ b/apps/aurora-tauri/README.md
@@ -71,7 +71,7 @@ pnpm --filter @aurora/tauri-ui tauri ios init
 pnpm --filter @aurora/tauri-ui tauri ios build
 ```
 
-The `Tauri iOS Baseline` GitHub Actions workflow runs this baseline on macOS with Xcode, CocoaPods, and the required Rust iOS targets. Use that workflow's `macOS Xcode Tauri iOS init and build` job as IOS-001 build evidence for pull requests.
+The `Tauri iOS Baseline` GitHub Actions workflow runs this baseline on macOS with Xcode, CocoaPods, and the required Rust iOS targets. Use that workflow's `macOS Xcode Tauri iOS init and build` job as IOS-001 build evidence for pull requests. The CI baseline disables Xcode code signing for the build step; App Store/TestFlight signing remains a separate release dry-run gate once Apple team credentials and native iOS targets are ready.
 
 After IOS-002/IOS-003/IOS-004 add the Swift plugin and Xcode-managed App Intent/share/widget targets, the macOS check must also smoke-test simulator/device invocation of one App Intent or Shortcut and one share/deep-link flow. Do not duplicate Aurora orchestration logic in Swift; native entrypoints bridge to the SDK/backend.
 

--- a/apps/aurora-tauri/README.md
+++ b/apps/aurora-tauri/README.md
@@ -71,7 +71,7 @@ pnpm --filter @aurora/tauri-ui tauri ios init
 pnpm --filter @aurora/tauri-ui tauri ios build
 ```
 
-The `Tauri iOS Baseline` GitHub Actions workflow runs this baseline on macOS with Xcode, CocoaPods, and the required Rust iOS targets. Use that workflow's `macOS Xcode Tauri iOS init and build` job as IOS-001 build evidence for pull requests. The CI baseline builds the unsigned iOS simulator target with `pnpm --filter @aurora/tauri-ui tauri ios build --target aarch64-sim`; the default device/archive build requires Apple signing credentials and remains a separate App Store/TestFlight release dry-run gate once Apple team credentials and native iOS targets are ready.
+The `Tauri iOS Baseline` GitHub Actions workflow runs this baseline on macOS with Xcode, CocoaPods, and the required Rust iOS targets. Use that workflow's `macOS Xcode Tauri iOS init and build` job as IOS-001 build evidence for pull requests. The CI baseline builds the unsigned iOS simulator target with `pnpm --filter @aurora/tauri-ui tauri ios build --target aarch64-sim --config src-tauri/tauri.ios.conf.json`; the default device/archive build requires Apple signing credentials and remains a separate App Store/TestFlight release dry-run gate once Apple team credentials and native iOS targets are ready.
 
 The iOS baseline uses `src-tauri/tauri.ios.conf.json` and the `aurora-ios-baseline` capability so mobile builds do not request desktop-only updater permissions. Desktop builds continue to use `aurora-main` and the signed updater configuration.
 

--- a/apps/aurora-tauri/README.md
+++ b/apps/aurora-tauri/README.md
@@ -71,6 +71,8 @@ pnpm --filter @aurora/tauri-ui tauri ios init
 pnpm --filter @aurora/tauri-ui tauri ios build
 ```
 
+The `Tauri iOS Baseline` GitHub Actions workflow runs this baseline on macOS with Xcode, CocoaPods, and the required Rust iOS targets. Use that workflow's `macOS Xcode Tauri iOS init and build` job as IOS-001 build evidence for pull requests.
+
 After IOS-002/IOS-003/IOS-004 add the Swift plugin and Xcode-managed App Intent/share/widget targets, the macOS check must also smoke-test simulator/device invocation of one App Intent or Shortcut and one share/deep-link flow. Do not duplicate Aurora orchestration logic in Swift; native entrypoints bridge to the SDK/backend.
 
 ## Scope Boundary

--- a/apps/aurora-tauri/README.md
+++ b/apps/aurora-tauri/README.md
@@ -73,7 +73,7 @@ pnpm --filter @aurora/tauri-ui tauri ios build
 
 The `Tauri iOS Baseline` GitHub Actions workflow runs this baseline on macOS with Xcode, CocoaPods, and the required Rust iOS targets. Use that workflow's `macOS Xcode Tauri iOS init and build` job as IOS-001 build evidence for pull requests. The CI baseline builds the unsigned iOS simulator target with `pnpm --filter @aurora/tauri-ui tauri ios build --target aarch64-sim --config src-tauri/tauri.ios.conf.json`; the default device/archive build requires Apple signing credentials and remains a separate App Store/TestFlight release dry-run gate once Apple team credentials and native iOS targets are ready.
 
-The iOS baseline uses `src-tauri/tauri.ios.conf.json` and the `aurora-ios-baseline` capability so mobile builds do not request desktop-only updater permissions. Desktop builds continue to use `aurora-main` and the signed updater configuration.
+The iOS baseline uses `src-tauri/tauri.ios.conf.json` and the `aurora-ios-baseline` capability so mobile builds do not request desktop-only updater permissions. Desktop builds continue to use `aurora-main` plus the desktop-only `aurora-desktop-updater` capability from the Linux, macOS, and Windows platform config files.
 
 After IOS-002/IOS-003/IOS-004 add the Swift plugin and Xcode-managed App Intent/share/widget targets, the macOS check must also smoke-test simulator/device invocation of one App Intent or Shortcut and one share/deep-link flow. Do not duplicate Aurora orchestration logic in Swift; native entrypoints bridge to the SDK/backend.
 

--- a/apps/aurora-tauri/README.md
+++ b/apps/aurora-tauri/README.md
@@ -71,7 +71,7 @@ pnpm --filter @aurora/tauri-ui tauri ios init
 pnpm --filter @aurora/tauri-ui tauri ios build
 ```
 
-The `Tauri iOS Baseline` GitHub Actions workflow runs this baseline on macOS with Xcode, CocoaPods, and the required Rust iOS targets. Use that workflow's `macOS Xcode Tauri iOS init and build` job as IOS-001 build evidence for pull requests. The CI baseline disables Xcode code signing for the build step; App Store/TestFlight signing remains a separate release dry-run gate once Apple team credentials and native iOS targets are ready.
+The `Tauri iOS Baseline` GitHub Actions workflow runs this baseline on macOS with Xcode, CocoaPods, and the required Rust iOS targets. Use that workflow's `macOS Xcode Tauri iOS init and build` job as IOS-001 build evidence for pull requests. The CI baseline builds the unsigned iOS simulator target with `pnpm --filter @aurora/tauri-ui tauri ios build --target aarch64-sim`; the default device/archive build requires Apple signing credentials and remains a separate App Store/TestFlight release dry-run gate once Apple team credentials and native iOS targets are ready.
 
 After IOS-002/IOS-003/IOS-004 add the Swift plugin and Xcode-managed App Intent/share/widget targets, the macOS check must also smoke-test simulator/device invocation of one App Intent or Shortcut and one share/deep-link flow. Do not duplicate Aurora orchestration logic in Swift; native entrypoints bridge to the SDK/backend.
 

--- a/apps/aurora-tauri/README.md
+++ b/apps/aurora-tauri/README.md
@@ -54,6 +54,25 @@ cd apps/aurora-tauri/src-tauri && cargo check
 cd apps/aurora-tauri/src-tauri && cargo test
 ```
 
+## iOS Baseline
+
+IOS-001 establishes the Tauri iOS build baseline and native-manifest contract. The manifest exposes iOS invocation states through `Native.GetCapabilityManifest` as evidence, not as executable backend truth:
+
+- `Siri/Shortcuts/App Intents integration`: planned App Intents for concrete Aurora actions.
+- `Shortcuts invocation path`: supported platform path once the iOS plugin and Xcode targets exist.
+- `Share, widgets, and deep links`: planned app-owned intake surfaces.
+- `Siri replacement`: unsupported. Aurora must not claim it can replace Siri as the default iOS assistant.
+
+Linux can run the TypeScript/Rust manifest checks, but cannot satisfy the iOS build acceptance gate. macOS/Xcode verification must run:
+
+```bash
+pnpm --filter @aurora/tauri-ui build
+pnpm --filter @aurora/tauri-ui tauri ios init
+pnpm --filter @aurora/tauri-ui tauri ios build
+```
+
+After IOS-002/IOS-003/IOS-004 add the Swift plugin and Xcode-managed App Intent/share/widget targets, the macOS check must also smoke-test simulator/device invocation of one App Intent or Shortcut and one share/deep-link flow. Do not duplicate Aurora orchestration logic in Swift; native entrypoints bridge to the SDK/backend.
+
 ## Scope Boundary
 
 The frontend must use `AuroraClient`; screens must not call Tauri `invoke` except through the SDK transport adapter or this package's runtime bootstrap. Secure credential storage is enabled through the narrow Aurora keychain command surface only. File access, native audio, event subscription streaming, and broad shell/fs permissions remain disabled or explicitly unsupported until their dedicated follow-up tasks.

--- a/apps/aurora-tauri/SECURITY.md
+++ b/apps/aurora-tauri/SECURITY.md
@@ -9,7 +9,7 @@ TAURI-002, TAURI-004, and TAURI-006 expose only the minimum command and capabili
 | `aurora_command` | Proxies typed `AuroraClient` requests to the configured Aurora Gateway. | `aurora-command` | Allows loopback HTTP(S) by default. Remote Gateway origins require `AURORA_TAURI_ALLOW_REMOTE_GATEWAY=1`. Only `content-type`, `x-correlation-id`, and `x-request-id` frontend headers are forwarded. Gateway bearer tokens are read from process environment, not web storage. |
 | `aurora_request` | Compatibility alias for the prior SDK request bridge. | `aurora-request` | Delegates to `aurora_command`; retained for migration only. |
 | `aurora_subscribe` | Declares the SDK event subscription bridge. | `aurora-subscribe` | Returns `unsupported_feature` until BE-003 defines the unified backend event stream contract. |
-| `aurora_native_capability_manifest`, `native_capabilities` | Returns Tauri shell capability evidence to the SDK. | `aurora-native-capability-manifest` | Reports allowed and denied native capabilities without secrets. |
+| `aurora_native_capability_manifest`, `native_capabilities` | Returns Tauri shell capability evidence to the SDK. | `aurora-native-capability-manifest` | Reports allowed and denied native capabilities without secrets, including iOS App Intents/Shortcuts/share/deep-link baseline metadata and the unsupported Siri replacement limitation. |
 | `aurora_sidecar_session` | Returns an in-memory command token to the SDK adapter. | `aurora-sidecar-session` | Token is not written to web storage or rendered by UI. It is used only by the Tauri transport adapter. |
 | `aurora_sidecar_start` | Starts the Rust-supervised Python sidecar in thread mode. | `aurora-sidecar-start` | Disabled in desktop-thin mode. Requires loopback Gateway origin and sidecar session token. |
 | `aurora_sidecar_stop` | Stops the Rust-supervised Python sidecar. | `aurora-sidecar-stop` | Requires sidecar session token. Used by shutdown and explicit stop paths. |
@@ -54,6 +54,8 @@ The shell does not grant broad Tauri or plugin permissions for:
 Secure credential storage is enabled only through the narrow Aurora keychain command surface. The native manifest reports broad filesystem, secure file handles, shell/process spawning, audio, clipboard, notifications, dialogs, and updater surfaces as unavailable where they are part of planned future Aurora surfaces. Follow-up tasks must add explicit permissions, UX, and tests before enabling them.
 
 TAURI-005 adds the core Tauri tray feature and an Aurora-owned native status bridge. It intentionally does not grant notification delivery, native dialogs, arbitrary file reads/writes, microphone capture, live audio streaming, or playback control. Those surfaces report denied defaults through `Native.GetCapabilityManifest`, `aurora_native_permission_status`, and the per-feature status commands until downstream UI/backend tasks provide scoped consent, target selection, retention/audit language, and tests.
+
+IOS-001 adds evidence-only iOS invocation metadata to the same native manifest. It does not grant iOS App Intent, widget, share extension, deep-link, SiriKit, microphone, or background execution powers by itself. Future iOS targets must stay Xcode-managed, scoped to concrete Aurora actions and privacy labels, and must use "Siri/Shortcuts/App Intents integration" wording rather than claiming Aurora can replace Siri.
 
 ## Token And Origin Handling
 

--- a/apps/aurora-tauri/SECURITY.md
+++ b/apps/aurora-tauri/SECURITY.md
@@ -25,11 +25,11 @@ TAURI-002, TAURI-004, and TAURI-006 expose only the minimum command and capabili
 | `aurora_audio_bridge_status` | Reports raw-audio bridge readiness and required consent/backend evidence. | `aurora-audio-bridge` | Microphone capture, live audio streaming, and playback control are denied by default. |
 | `aurora_shutdown` | Stops managed sidecar if present, then exits the shell cleanly. | `aurora-shutdown` | Does not terminate non-managed external Aurora processes. |
 
-The Tauri updater plugin is also granted through `updater:default`. It validates signed updater artifacts against the configured public key and does not expose filesystem, shell, process-spawn, or arbitrary network powers to Aurora screens.
+The Tauri updater plugin is also granted on desktop through `updater:default`. It validates signed updater artifacts against the configured public key and does not expose filesystem, shell, process-spawn, or arbitrary network powers to Aurora screens. The IOS-001 baseline uses `aurora-ios-baseline` and does not grant updater permissions because the updater plugin is desktop-only in this shell.
 
 ## Capability File
 
-`src-tauri/capabilities/aurora-main.json` is the only enabled capability in `tauri.conf.json`. It grants:
+`src-tauri/capabilities/aurora-main.json` is the enabled desktop capability in `tauri.conf.json`. It grants:
 
 - `core:app:default`
 - `core:event:default`
@@ -37,6 +37,8 @@ The Tauri updater plugin is also granted through `updater:default`. It validates
 - Aurora native permission, tray, notification, dialog, and audio status commands
 - `updater:default`
 - the Aurora app-command permissions listed above
+
+`src-tauri/tauri.ios.conf.json` switches iOS builds to `src-tauri/capabilities/aurora-ios-baseline.json`, which grants the same Aurora bridge/status command permissions but omits desktop-only `updater:default`.
 
 ## Denied By Default
 

--- a/apps/aurora-tauri/SECURITY.md
+++ b/apps/aurora-tauri/SECURITY.md
@@ -25,7 +25,7 @@ TAURI-002, TAURI-004, and TAURI-006 expose only the minimum command and capabili
 | `aurora_audio_bridge_status` | Reports raw-audio bridge readiness and required consent/backend evidence. | `aurora-audio-bridge` | Microphone capture, live audio streaming, and playback control are denied by default. |
 | `aurora_shutdown` | Stops managed sidecar if present, then exits the shell cleanly. | `aurora-shutdown` | Does not terminate non-managed external Aurora processes. |
 
-The Tauri updater plugin is also granted on desktop through the separate `aurora-desktop-updater` capability with `updater:default`. It validates signed updater artifacts against the configured public key and does not expose filesystem, shell, process-spawn, or arbitrary network powers to Aurora screens. The IOS-001 baseline uses `aurora-ios-baseline` and does not grant updater permissions because the updater plugin is desktop-only in this shell.
+The Tauri updater plugin is also granted on desktop through the separate `aurora-desktop-updater` capability with `updater:default`. It validates signed updater artifacts against the configured public key and does not expose filesystem, shell, process-spawn, or arbitrary network powers to Aurora screens. The IOS-001 baseline uses `aurora-ios-baseline` and does not grant updater permissions because the updater plugin is only installed at runtime on desktop in this shell.
 
 ## Capability File
 

--- a/apps/aurora-tauri/SECURITY.md
+++ b/apps/aurora-tauri/SECURITY.md
@@ -25,20 +25,19 @@ TAURI-002, TAURI-004, and TAURI-006 expose only the minimum command and capabili
 | `aurora_audio_bridge_status` | Reports raw-audio bridge readiness and required consent/backend evidence. | `aurora-audio-bridge` | Microphone capture, live audio streaming, and playback control are denied by default. |
 | `aurora_shutdown` | Stops managed sidecar if present, then exits the shell cleanly. | `aurora-shutdown` | Does not terminate non-managed external Aurora processes. |
 
-The Tauri updater plugin is also granted on desktop through `updater:default`. It validates signed updater artifacts against the configured public key and does not expose filesystem, shell, process-spawn, or arbitrary network powers to Aurora screens. The IOS-001 baseline uses `aurora-ios-baseline` and does not grant updater permissions because the updater plugin is desktop-only in this shell.
+The Tauri updater plugin is also granted on desktop through the separate `aurora-desktop-updater` capability with `updater:default`. It validates signed updater artifacts against the configured public key and does not expose filesystem, shell, process-spawn, or arbitrary network powers to Aurora screens. The IOS-001 baseline uses `aurora-ios-baseline` and does not grant updater permissions because the updater plugin is desktop-only in this shell.
 
 ## Capability File
 
-`src-tauri/capabilities/aurora-main.json` is the enabled desktop capability in `tauri.conf.json`. It grants:
+`src-tauri/capabilities/aurora-main.json` is the shared shell capability in `tauri.conf.json`. It grants:
 
 - `core:app:default`
 - `core:event:default`
 - `core:window:default`
 - Aurora native permission, tray, notification, dialog, and audio status commands
-- `updater:default`
 - the Aurora app-command permissions listed above
 
-`src-tauri/tauri.ios.conf.json` switches iOS builds to `src-tauri/capabilities/aurora-ios-baseline.json`, which grants the same Aurora bridge/status command permissions but omits desktop-only `updater:default`.
+`src-tauri/tauri.linux.conf.json`, `src-tauri/tauri.macos.conf.json`, and `src-tauri/tauri.windows.conf.json` add `src-tauri/capabilities/aurora-desktop-updater.json` for desktop updater access. `src-tauri/tauri.ios.conf.json` switches iOS builds to `src-tauri/capabilities/aurora-ios-baseline.json`, which grants the same Aurora bridge/status command permissions but omits desktop-only `updater:default`.
 
 ## Denied By Default
 

--- a/apps/aurora-tauri/src-tauri/Cargo.toml
+++ b/apps/aurora-tauri/src-tauri/Cargo.toml
@@ -23,8 +23,6 @@ reqwest = { version = "0.12.24", default-features = false, features = ["json", "
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri = { version = "2.9.5", features = ["tray-icon"] }
+tauri-plugin-updater = "2.9.0"
 thiserror = "2.0"
 url = "2.5"
-
-[target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
-tauri-plugin-updater = "2.9.0"

--- a/apps/aurora-tauri/src-tauri/capabilities/aurora-desktop-updater.json
+++ b/apps/aurora-tauri/src-tauri/capabilities/aurora-desktop-updater.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "aurora-desktop-updater",
+  "description": "Desktop-only Aurora signed updater capability. Kept outside the shared shell capability so iOS builds do not validate the desktop-only updater plugin permission.",
+  "windows": ["main"],
+  "permissions": ["updater:default"]
+}

--- a/apps/aurora-tauri/src-tauri/capabilities/aurora-ios-baseline.json
+++ b/apps/aurora-tauri/src-tauri/capabilities/aurora-ios-baseline.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "aurora-ios-baseline",
+  "description": "IOS-001 baseline capability for the Tauri iOS shell. Grants the Aurora bridge and native manifest commands but omits desktop-only updater permissions.",
+  "windows": ["main"],
+  "permissions": [
+    "core:app:default",
+    "core:event:default",
+    "core:window:default",
+    "aurora-command",
+    "aurora-request",
+    "aurora-subscribe",
+    "aurora-native-capability-manifest",
+    "aurora-sidecar-status",
+    "aurora-sidecar-session",
+    "aurora-sidecar-start",
+    "aurora-sidecar-stop",
+    "aurora-log-tail",
+    "aurora-secure-storage",
+    "aurora-native-permissions",
+    "aurora-tray",
+    "aurora-notifications",
+    "aurora-dialogs",
+    "aurora-local-file",
+    "aurora-secure-file-handle",
+    "aurora-audio-bridge",
+    "aurora-shutdown"
+  ]
+}

--- a/apps/aurora-tauri/src-tauri/capabilities/aurora-main.json
+++ b/apps/aurora-tauri/src-tauri/capabilities/aurora-main.json
@@ -1,13 +1,12 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "aurora-main",
-  "description": "Main Aurora desktop shell capability. Grants only the TAURI-004 SDK bridge, native manifest, sidecar health, log-tail status, explicit denied native helper commands, shutdown, and minimal window/app/event primitives.",
+  "description": "Main Aurora shell capability. Grants only the TAURI-004 SDK bridge, native manifest, sidecar health, log-tail status, explicit denied native helper commands, shutdown, and minimal window/app/event primitives.",
   "windows": ["main"],
   "permissions": [
     "core:app:default",
     "core:event:default",
     "core:window:default",
-    "updater:default",
     "aurora-command",
     "aurora-request",
     "aurora-subscribe",

--- a/apps/aurora-tauri/src-tauri/src/lib.rs
+++ b/apps/aurora-tauri/src-tauri/src/lib.rs
@@ -8,11 +8,13 @@ use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+#[cfg(desktop)]
 use tauri::{
     menu::{Menu, MenuItem},
     tray::TrayIconBuilder,
-    AppHandle, Manager, State,
+    AppHandle,
 };
+use tauri::{Manager, State};
 use thiserror::Error;
 use url::Url;
 
@@ -1205,6 +1207,7 @@ pub fn run() {
     tauri::Builder::default()
         .manage(sidecar_state.clone())
         .setup(|app| {
+            #[cfg(desktop)]
             install_tray(app.handle())?;
             #[cfg(desktop)]
             app.handle()
@@ -1248,6 +1251,7 @@ pub fn run() {
         .expect("error while running Aurora Tauri shell");
 }
 
+#[cfg(desktop)]
 fn install_tray(app: &AppHandle) -> tauri::Result<()> {
     let show = MenuItem::with_id(app, "show", "Show Aurora", true, None::<&str>)?;
     let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;

--- a/apps/aurora-tauri/src-tauri/src/lib.rs
+++ b/apps/aurora-tauri/src-tauri/src/lib.rs
@@ -12,9 +12,9 @@ use std::time::{Duration, Instant};
 use tauri::{
     menu::{Menu, MenuItem},
     tray::TrayIconBuilder,
-    AppHandle,
+    Manager,
 };
-use tauri::{Manager, State};
+use tauri::{AppHandle, State};
 use thiserror::Error;
 use url::Url;
 

--- a/apps/aurora-tauri/src-tauri/src/lib.rs
+++ b/apps/aurora-tauri/src-tauri/src/lib.rs
@@ -109,10 +109,39 @@ struct SidecarSession {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct NativeCapabilityManifest {
     platform: String,
     permissions: BTreeMap<String, bool>,
     capabilities: BTreeMap<String, bool>,
+    mobile_integrations: Vec<NativeMobileIntegration>,
+    platform_limitations: Vec<NativePlatformLimitation>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeMobileIntegration {
+    platform: String,
+    id: String,
+    label: String,
+    support: String,
+    capability: String,
+    permission: Option<String>,
+    privacy_class: String,
+    evidence_source: String,
+    user_copy: String,
+    verifier: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NativePlatformLimitation {
+    platform: String,
+    id: String,
+    label: String,
+    reason: String,
+    user_copy: String,
+    evidence_source: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -758,7 +787,73 @@ fn native_capability_manifest() -> NativeCapabilityManifest {
         platform: "tauri-desktop".to_string(),
         permissions,
         capabilities,
+        mobile_integrations: ios_mobile_integrations(),
+        platform_limitations: ios_platform_limitations(),
     }
+}
+
+fn ios_mobile_integrations() -> Vec<NativeMobileIntegration> {
+    vec![
+        NativeMobileIntegration {
+            platform: "ios".to_string(),
+            id: "appIntents".to_string(),
+            label: "Siri/Shortcuts/App Intents integration".to_string(),
+            support: "planned".to_string(),
+            capability: "ios.appIntents".to_string(),
+            permission: Some("aurora.ios.appIntents".to_string()),
+            privacy_class: "personal".to_string(),
+            evidence_source: "IOS-001-baseline".to_string(),
+            user_copy: "Scoped App Intents are planned for concrete Aurora actions; this baseline does not ship an executable intent.".to_string(),
+            verifier: "tauri ios build plus simulator/device App Intent invocation on macOS/Xcode".to_string(),
+        },
+        NativeMobileIntegration {
+            platform: "ios".to_string(),
+            id: "shortcuts".to_string(),
+            label: "Shortcuts invocation path".to_string(),
+            support: "supported-path".to_string(),
+            capability: "ios.shortcuts".to_string(),
+            permission: Some("aurora.ios.shortcuts".to_string()),
+            privacy_class: "personal".to_string(),
+            evidence_source: "IOS-001-baseline".to_string(),
+            user_copy: "Aurora may expose app-owned Shortcuts/App Intents flows after the iOS plugin and Xcode targets exist.".to_string(),
+            verifier: "simulator/device shortcut invocation through Xcode-managed iOS target".to_string(),
+        },
+        NativeMobileIntegration {
+            platform: "ios".to_string(),
+            id: "shareWidgetDeepLinks".to_string(),
+            label: "Share, widgets, and deep links".to_string(),
+            support: "planned".to_string(),
+            capability: "ios.shareWidgetDeepLinks".to_string(),
+            permission: Some("aurora.ios.shareWidgetDeepLinks".to_string()),
+            privacy_class: "personal".to_string(),
+            evidence_source: "IOS-001-baseline".to_string(),
+            user_copy: "Share extensions, widgets, and deep links stay scoped to app-owned intake surfaces.".to_string(),
+            verifier: "Xcode extension target smoke and Tauri mobile file-association check".to_string(),
+        },
+        NativeMobileIntegration {
+            platform: "ios".to_string(),
+            id: "siriReplacement".to_string(),
+            label: "Siri replacement".to_string(),
+            support: "unsupported".to_string(),
+            capability: "ios.siriReplacement".to_string(),
+            permission: None,
+            privacy_class: "public".to_string(),
+            evidence_source: "Apple-platform-policy".to_string(),
+            user_copy: "iOS does not allow Aurora to replace Siri as the default assistant.".to_string(),
+            verifier: "copy and capability review; no executable route should be exposed".to_string(),
+        },
+    ]
+}
+
+fn ios_platform_limitations() -> Vec<NativePlatformLimitation> {
+    vec![NativePlatformLimitation {
+        platform: "ios".to_string(),
+        id: "noSiriReplacement".to_string(),
+        label: "No Siri replacement".to_string(),
+        reason: "Apple permits app-owned App Intents, Shortcuts, widgets, share extensions, and deep links, not replacing Siri as the system assistant.".to_string(),
+        user_copy: "Use Siri/Shortcuts/App Intents integration; do not claim Aurora replaces Siri.".to_string(),
+        evidence_source: "Apple App Intents and SiriKit extension documentation".to_string(),
+    }]
 }
 
 fn denied_native_feature_status(
@@ -1233,6 +1328,28 @@ mod tests {
         );
         assert_eq!(manifest.capabilities.get("native.dialogs"), Some(&false));
         assert_eq!(manifest.capabilities.get("native.audio"), Some(&false));
+        assert!(manifest
+            .mobile_integrations
+            .iter()
+            .any(|integration| integration.id == "appIntents"
+                && integration.support == "planned"
+                && integration.label.contains("Siri/Shortcuts/App Intents")));
+        assert!(manifest
+            .mobile_integrations
+            .iter()
+            .any(|integration| integration.id == "shortcuts"
+                && integration.support == "supported-path"));
+        assert!(manifest
+            .mobile_integrations
+            .iter()
+            .any(|integration| integration.id == "siriReplacement"
+                && integration.support == "unsupported"
+                && integration.user_copy.contains("does not allow")));
+        assert!(manifest
+            .platform_limitations
+            .iter()
+            .any(|limitation| limitation.id == "noSiriReplacement"
+                && limitation.user_copy.contains("do not claim")));
     }
 
     #[test]

--- a/apps/aurora-tauri/src-tauri/tauri.ios.conf.json
+++ b/apps/aurora-tauri/src-tauri/tauri.ios.conf.json
@@ -1,0 +1,7 @@
+{
+  "app": {
+    "security": {
+      "capabilities": ["aurora-ios-baseline"]
+    }
+  }
+}

--- a/apps/aurora-tauri/src-tauri/tauri.linux.conf.json
+++ b/apps/aurora-tauri/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,7 @@
+{
+  "app": {
+    "security": {
+      "capabilities": ["aurora-main", "aurora-desktop-updater"]
+    }
+  }
+}

--- a/apps/aurora-tauri/src-tauri/tauri.macos.conf.json
+++ b/apps/aurora-tauri/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,7 @@
+{
+  "app": {
+    "security": {
+      "capabilities": ["aurora-main", "aurora-desktop-updater"]
+    }
+  }
+}

--- a/apps/aurora-tauri/src-tauri/tauri.windows.conf.json
+++ b/apps/aurora-tauri/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,7 @@
+{
+  "app": {
+    "security": {
+      "capabilities": ["aurora-main", "aurora-desktop-updater"]
+    }
+  }
+}

--- a/apps/aurora-tauri/src/aurora-client.test.tsx
+++ b/apps/aurora-tauri/src/aurora-client.test.tsx
@@ -40,6 +40,8 @@ describe('Aurora Tauri runtime wrapper', () => {
     expect(markup).toContain('Native boundary')
     expect(markup).toContain('Runtime mode')
     expect(markup).toContain('Audio bridge')
+    expect(markup).toContain('Siri/Shortcuts/App Intents integration')
+    expect(markup).toContain('no Siri replacement claim')
     expect(markup).toContain('Denied native defaults')
     expect(markup).toContain('mock')
     expect(markup).toContain('not used in thin mode')

--- a/apps/aurora-tauri/src/tauri-app.tsx
+++ b/apps/aurora-tauri/src/tauri-app.tsx
@@ -71,6 +71,7 @@ export function AuroraTauriApp() {
             <div><dt>Notifications</dt><dd>{nativeFeatureLabel(nativeFeatures.notifications)}</dd></div>
             <div><dt>Dialogs</dt><dd>{nativeFeatureLabel(nativeFeatures.dialogs)}</dd></div>
             <div><dt>Audio bridge</dt><dd>{nativeFeatureLabel(nativeFeatures.audio)}</dd></div>
+            <div><dt>iOS invocation</dt><dd>Siri/Shortcuts/App Intents integration; no Siri replacement claim.</dd></div>
             <div><dt>Denied native defaults</dt><dd>{nativePermissions?.deniedByDefault.join(', ') ?? 'not available'}</dd></div>
           </dl>
           <button className="ata-secondary" type="button" onClick={() => void runtime.shutdown()}>

--- a/packages/aurora-sdk/src/capabilities.ts
+++ b/packages/aurora-sdk/src/capabilities.ts
@@ -17,6 +17,7 @@ import type {
   GetServicesResponse,
   MethodDescriptor,
   NativeCapabilityManifest,
+  NativeIntegrationSupport,
   NativeCapabilityState,
   PrivacyClass,
   ServiceInfo
@@ -315,8 +316,8 @@ function candidatesFromNativeManifest(
   manifest: NativeCapabilityManifest | null | undefined
 ): CapabilityProviderCandidate[] {
   if (!manifest) return []
-  return Object.entries(manifest.capabilities)
-    .map(([capability, enabled]) => {
+  return [
+    ...Object.entries(manifest.capabilities).map(([capability, enabled]) => {
       const featureId = `native:${manifest.platform}:${capability}`
       const missingPermissions = Object.entries(manifest.permissions)
         .filter(([, granted]) => !granted)
@@ -358,8 +359,60 @@ function candidatesFromNativeManifest(
         source: 'native-manifest',
         raw: null
       } satisfies CapabilityProviderCandidate
+    }),
+    ...(manifest.mobileIntegrations ?? []).map((integration) => {
+      const featureId = `native:${integration.platform}:${integration.id}`
+      const availability = availabilityForNativeIntegration(integration.support)
+      const disabledReasons =
+        availability === 'available-local'
+          ? []
+          : [`${integration.label}: ${integration.userCopy}`]
+      return {
+        id: `${featureId}@native:${integration.platform}`,
+        featureId,
+        providerIdentity: `native:${integration.platform}`,
+        providerId: `native:${integration.platform}`,
+        providerKind: 'native',
+        peerId: null,
+        serviceInstanceId: null,
+        module: 'Native',
+        method: integration.capability,
+        busTopic: null,
+        toolId: null,
+        resourceId: null,
+        availability,
+        selectable: availability === 'available-local',
+        selected: false,
+        trustTier: 'device',
+        routeability: integration.support,
+        freshness: emptyFreshness(integration.evidenceSource),
+        requiredPermissions: integration.permission ? [integration.permission] : [],
+        privacyClass: integration.privacyClass,
+        disabledReasons,
+        requiredAction: requiredActionForNativeIntegration(integration.support),
+        selector: { platform: integration.platform, capability: integration.capability },
+        source: 'native-manifest',
+        raw: null
+      } satisfies CapabilityProviderCandidate
     })
+  ]
     .sort((a, b) => a.featureId.localeCompare(b.featureId))
+}
+
+function availabilityForNativeIntegration(support: NativeIntegrationSupport): AvailabilityState {
+  if (support === 'supported') return 'available-local'
+  if (support === 'supported-path') return 'degraded'
+  if (support === 'planned') return 'pending'
+  if (support === 'blocked') return 'privacy-blocked'
+  return 'unsupported'
+}
+
+function requiredActionForNativeIntegration(support: NativeIntegrationSupport): string | null {
+  if (support === 'supported') return null
+  if (support === 'supported-path') return 'verify platform path in macOS/Xcode simulator or device'
+  if (support === 'planned') return 'implement scoped iOS plugin, App Intent, or extension task'
+  if (support === 'blocked') return 'satisfy platform entitlement, consent, or permission requirement'
+  return 'do not claim this platform capability'
 }
 
 function nodeFromCandidates(

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -2967,6 +2967,8 @@ export const nativeCapabilityManifestFixture: NativeCapabilityManifest = {
   capabilities: {
     'desktop.thinGateway': true,
     'desktop.localSidecarHealth': true,
+    'desktop.signedUpdater': true,
+    'desktop.bundledSidecarPolicy': true,
     'desktop.logTail': false,
     'desktop.localSidecarSupervision': true,
     'desktop.tray': true,
@@ -2979,7 +2981,67 @@ export const nativeCapabilityManifestFixture: NativeCapabilityManifest = {
     'native.audio': false,
     'native.audioCapture': false,
     'native.audioPlayback': false
-  }
+  },
+  mobileIntegrations: [
+    {
+      platform: 'ios',
+      id: 'appIntents',
+      label: 'Siri/Shortcuts/App Intents integration',
+      support: 'planned',
+      capability: 'ios.appIntents',
+      permission: 'aurora.ios.appIntents',
+      privacyClass: 'personal',
+      evidenceSource: 'IOS-001-baseline',
+      userCopy: 'Scoped App Intents are planned for concrete Aurora actions; this baseline does not ship an executable intent.',
+      verifier: 'tauri ios build plus simulator/device App Intent invocation on macOS/Xcode'
+    },
+    {
+      platform: 'ios',
+      id: 'shortcuts',
+      label: 'Shortcuts invocation path',
+      support: 'supported-path',
+      capability: 'ios.shortcuts',
+      permission: 'aurora.ios.shortcuts',
+      privacyClass: 'personal',
+      evidenceSource: 'IOS-001-baseline',
+      userCopy: 'Aurora may expose app-owned Shortcuts/App Intents flows after the iOS plugin and Xcode targets exist.',
+      verifier: 'simulator/device shortcut invocation through Xcode-managed iOS target'
+    },
+    {
+      platform: 'ios',
+      id: 'shareWidgetDeepLinks',
+      label: 'Share, widgets, and deep links',
+      support: 'planned',
+      capability: 'ios.shareWidgetDeepLinks',
+      permission: 'aurora.ios.shareWidgetDeepLinks',
+      privacyClass: 'personal',
+      evidenceSource: 'IOS-001-baseline',
+      userCopy: 'Share extensions, widgets, and deep links stay scoped to app-owned intake surfaces.',
+      verifier: 'Xcode extension target smoke and Tauri mobile file-association check'
+    },
+    {
+      platform: 'ios',
+      id: 'siriReplacement',
+      label: 'Siri replacement',
+      support: 'unsupported',
+      capability: 'ios.siriReplacement',
+      permission: null,
+      privacyClass: 'public',
+      evidenceSource: 'Apple-platform-policy',
+      userCopy: 'iOS does not allow Aurora to replace Siri as the default assistant.',
+      verifier: 'copy and capability review; no executable route should be exposed'
+    }
+  ],
+  platformLimitations: [
+    {
+      platform: 'ios',
+      id: 'noSiriReplacement',
+      label: 'No Siri replacement',
+      reason: 'Apple permits app-owned App Intents, Shortcuts, widgets, share extensions, and deep links, not replacing Siri as the system assistant.',
+      userCopy: 'Use Siri/Shortcuts/App Intents integration; do not claim Aurora replaces Siri.',
+      evidenceSource: 'Apple App Intents and SiriKit extension documentation'
+    }
+  ]
 }
 
 const idleModelProgress = (operationType: string) => ({

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -1561,4 +1561,30 @@ export interface NativeCapabilityManifest {
   platform: 'tauri-desktop' | 'android' | 'ios' | string
   permissions: Record<string, boolean>
   capabilities: Record<string, boolean>
+  mobileIntegrations?: NativeMobileIntegration[]
+  platformLimitations?: NativePlatformLimitation[]
+}
+
+export type NativeIntegrationSupport = 'supported' | 'supported-path' | 'planned' | 'unsupported' | 'blocked'
+
+export interface NativeMobileIntegration {
+  platform: 'android' | 'ios' | string
+  id: string
+  label: string
+  support: NativeIntegrationSupport
+  capability: string
+  permission: string | null
+  privacyClass: PrivacyClass
+  evidenceSource: string
+  userCopy: string
+  verifier: string
+}
+
+export interface NativePlatformLimitation {
+  platform: 'android' | 'ios' | string
+  id: string
+  label: string
+  reason: string
+  userCopy: string
+  evidenceSource: string
 }

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -450,6 +450,67 @@ describe('AuroraClient', () => {
     )
   })
 
+  it('models iOS invocation through App Intents and Shortcuts without a Siri replacement claim', () => {
+    const graph = buildCapabilityGraph({
+      catalog: capabilityGraphCatalogFixture,
+      registry: gatewayRegistryFixture,
+      nativeManifest: nativeCapabilityManifestFixture,
+      transportKind: 'tauri-local'
+    })
+
+    expect(nativeCapabilityManifestFixture.mobileIntegrations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: 'ios',
+          id: 'appIntents',
+          label: 'Siri/Shortcuts/App Intents integration',
+          support: 'planned'
+        }),
+        expect.objectContaining({
+          platform: 'ios',
+          id: 'shortcuts',
+          support: 'supported-path'
+        }),
+        expect.objectContaining({
+          platform: 'ios',
+          id: 'siriReplacement',
+          support: 'unsupported',
+          userCopy: expect.stringContaining('does not allow Aurora to replace Siri')
+        })
+      ])
+    )
+    expect(nativeCapabilityManifestFixture.platformLimitations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'noSiriReplacement',
+          userCopy: 'Use Siri/Shortcuts/App Intents integration; do not claim Aurora replaces Siri.'
+        })
+      ])
+    )
+
+    expect(graph.explain('native:ios:appIntents')).toEqual(
+      expect.objectContaining({
+        state: 'pending',
+        routeable: false,
+        nextRepairAction: 'implement scoped iOS plugin, App Intent, or extension task'
+      })
+    )
+    expect(graph.explain('native:ios:shortcuts')).toEqual(
+      expect.objectContaining({
+        state: 'degraded',
+        routeable: false,
+        nextRepairAction: 'verify platform path in macOS/Xcode simulator or device'
+      })
+    )
+    expect(graph.explain('native:ios:siriReplacement')).toEqual(
+      expect.objectContaining({
+        state: 'unsupported',
+        routeable: false,
+        nextRepairAction: 'do not claim this platform capability'
+      })
+    )
+  })
+
   it('explains policy, selector, stale, and unsupported capability states', () => {
     const graph = buildCapabilityGraph({
       catalog: capabilityGraphCatalogFixture,


### PR DESCRIPTION
## Summary

- Add optional native manifest metadata for mobile integrations and platform limitations.
- Surface iOS App Intents, Shortcuts, share/widget/deep-link, and unsupported Siri replacement states through the SDK/Tauri native manifest.
- Add Tauri native-boundary copy that says Siri/Shortcuts/App Intents integration and does not claim Siri replacement.
- Document the IOS-001 macOS/Xcode Tauri iOS build baseline and security boundary.

## Validation

- pnpm --filter @aurora/client test
- pnpm --filter @aurora/client typecheck
- pnpm --filter @aurora/client build
- pnpm --filter @aurora/tauri-ui test
- pnpm --filter @aurora/tauri-ui typecheck
- pnpm --filter @aurora/tauri-ui build
- cargo fmt --manifest-path apps/aurora-tauri/src-tauri/Cargo.toml

## Environment-limited checks

- cargo check/test are blocked on this Linux host by missing glib-2.0 pkg-config files required by glib-sys/Tauri WebKit dependencies.
- tauri ios build and Xcode simulator/device verification require macOS + Xcode and are documented in apps/aurora-tauri/README.md for the required IOS-001 platform gate.
