### PR TITLE
AND-002 Create Android native plugin skeleton

### DIFF
--- a/apps/aurora-tauri/README.md
+++ b/apps/aurora-tauri/README.md
@@ -91,6 +91,12 @@ pnpm --filter @aurora/tauri-ui android:smoke
 
 The shared Tauri capability intentionally does not grant `updater:default`; updater artifact generation remains desktop packaging configuration, not a webview permission. Local Android builds require Java plus Android SDK/NDK/emulator components. The GitHub `Tauri Android Verification` workflow installs those prerequisites, initializes the generated `src-tauri/gen/android` project, builds an installable debug APK for emulator smoke, uploads the APK artifact, installs it on an emulator, launches Aurora, and records the `aurora_android_baseline_status` payload from logcat when available.
 
+## Android Native Skeleton
+
+`src-tauri/android/aurora-native-plugin/` contains the AND-002 Kotlin plugin skeleton for future Tauri mobile wiring. The plugin exposes Android-native evidence commands for `nativeCapabilityManifest`, `assistantRoleStatus`, assistant-role request probing, and fallback entrypoints. It keeps the future VoiceInteractionService declaration disabled until the package qualification and role-grant flow is completed by the Android assistant-role task.
+
+The real Android build remains gated on Tauri's generated Android project under `src-tauri/gen/android`; run `pnpm --filter @aurora/tauri-ui tauri android init` before attempting `pnpm --filter @aurora/tauri-ui tauri android build` in an Android-capable environment.
+
 ## Scope Boundary
 
 The frontend must use `AuroraClient`; screens must not call Tauri `invoke` except through the SDK transport adapter or this package's runtime bootstrap. Secure credential storage is enabled through the narrow Aurora keychain command surface only. File access, native audio, event subscription streaming, and broad shell/fs permissions remain disabled or explicitly unsupported until their dedicated follow-up tasks.

--- a/apps/aurora-tauri/package.json
+++ b/apps/aurora-tauri/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --host 127.0.0.1",
     "build": "tsc --noEmit --incremental false && vite build",
     "build:bundle": "pnpm prepare:sidecar && pnpm tauri build --config src-tauri/tauri.release.conf.json",
-    "android:init": "tauri android init --ci --skip-targets-install",
+    "android:init": "tauri android init --ci --skip-targets-install && node ./scripts/install-android-native-plugin.mjs",
     "android:build:apk": "tauri android build --apk",
     "android:build:apk:x86_64": "tauri android build --apk --target x86_64",
     "android:build:apk:x86_64:debug": "tauri android build --debug --apk --target x86_64",

--- a/apps/aurora-tauri/scripts/android-emulator-smoke.mjs
+++ b/apps/aurora-tauri/scripts/android-emulator-smoke.mjs
@@ -16,8 +16,9 @@ run('adb', ['shell', 'monkey', '-p', appId, '-c', 'android.intent.category.LAUNC
 
 const payloadLine = waitForPayloadLine()
 if (!payloadLine) {
-  throw new Error('Android baseline payload log was not observed after app launch.')
+  throw new Error('Android native plugin payload log was not observed after app launch.')
 }
+validateNativePayload(payloadLine)
 
 console.log(`Installed APK: ${apk}`)
 console.log(`Launched package: ${appId}`)
@@ -56,9 +57,42 @@ function waitForPayloadLine() {
       throw logcat.error
     }
     const output = `${logcat.stdout}\n${logcat.stderr}`
-    const line = output.split(/\r?\n/).find((entry) => entry.includes('aurora_android_baseline_status='))
+    const line = output
+      .split(/\r?\n/)
+      .find((entry) => entry.includes('aurora_android_native_plugin_payload='))
     if (line) return line
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000)
   }
   return null
+}
+
+function validateNativePayload(line) {
+  const marker = 'aurora_android_native_plugin_payload='
+  const jsonStart = line.indexOf(marker)
+  if (jsonStart === -1) {
+    throw new Error('Android smoke line does not contain the native plugin payload marker.')
+  }
+
+  const payload = JSON.parse(line.slice(jsonStart + marker.length))
+  const assistantRole = payload.assistantRole
+  if (!assistantRole || typeof assistantRole !== 'object') {
+    throw new Error('Android native plugin payload is missing assistantRole.')
+  }
+
+  for (const field of ['roleAvailable', 'packageQualified', 'roleHeld', 'requestable', 'denied', 'oemUnavailable']) {
+    if (typeof assistantRole[field] !== 'boolean') {
+      throw new Error(`Android native plugin assistantRole.${field} must be a boolean.`)
+    }
+  }
+
+  if (!Array.isArray(payload.fallbackEntrypoints) || payload.fallbackEntrypoints.length === 0) {
+    throw new Error('Android native plugin payload is missing fallbackEntrypoints.')
+  }
+
+  if (assistantRole.roleHeld === false) {
+    const availableFallback = payload.fallbackEntrypoints.some((entry) => entry?.available === true)
+    if (!availableFallback) {
+      throw new Error('Android native plugin payload must keep fallback entrypoints available when roleHeld=false.')
+    }
+  }
 }

--- a/apps/aurora-tauri/scripts/install-android-native-plugin.mjs
+++ b/apps/aurora-tauri/scripts/install-android-native-plugin.mjs
@@ -1,0 +1,71 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const genAndroidDir = resolve('src-tauri/gen/android')
+const appManifestPath = resolve(genAndroidDir, 'app/src/main/AndroidManifest.xml')
+const pluginSourceDir = resolve('src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin')
+const generatedPluginSourceDir = resolve(genAndroidDir, 'app/src/main/java/dev/aurora/tauri/nativeplugin')
+
+if (!existsSync(appManifestPath)) {
+  throw new Error('Tauri Android project is missing. Run android:init before installing the Aurora native plugin.')
+}
+
+mkdirSync(generatedPluginSourceDir, { recursive: true })
+cpSync(pluginSourceDir, generatedPluginSourceDir, { recursive: true })
+
+patchFile(appManifestPath, (content) => mergePluginManifest(content))
+
+console.log('Installed Aurora Android native plugin source into src-tauri/gen/android.')
+
+function patchFile(path, patch) {
+  const before = readFileSync(path, 'utf8')
+  const after = patch(before)
+  if (after !== before) {
+    writeFileSync(path, after)
+  }
+}
+
+function mergePluginManifest(content) {
+  const permissionBlock = [
+    '    <uses-permission android:name="android.permission.RECORD_AUDIO" />',
+    '    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />',
+    '    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />'
+  ]
+    .filter((line) => !content.includes(line.trim()))
+    .join('\n')
+
+  let patched = content
+  if (permissionBlock) {
+    patched = patched.replace(/(\s*<application\b)/, `\n${permissionBlock}\n$1`)
+  }
+
+  if (!patched.includes('dev.aurora.tauri.nativeplugin.AuroraVoiceInteractionService')) {
+    const components = `
+        <!-- Disabled until AND-004 implements the complete VoiceInteractionService qualification flow. -->
+        <service
+            android:name="dev.aurora.tauri.nativeplugin.AuroraVoiceInteractionService"
+            android:enabled="false"
+            android:exported="true"
+            android:label="Aurora"
+            android:permission="android.permission.BIND_VOICE_INTERACTION">
+            <intent-filter>
+                <action android:name="android.service.voice.VoiceInteractionService" />
+            </intent-filter>
+        </service>
+
+        <activity
+            android:name="dev.aurora.tauri.nativeplugin.AuroraAssistActivity"
+            android:enabled="true"
+            android:exported="true"
+            android:label="Aurora">
+            <intent-filter>
+                <action android:name="android.intent.action.ASSIST" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+`
+    patched = patched.replace(/\s*<\/application>/, `${components}\n    </application>`)
+  }
+
+  return patched
+}

--- a/apps/aurora-tauri/src-tauri/android/README.md
+++ b/apps/aurora-tauri/src-tauri/android/README.md
@@ -1,0 +1,25 @@
+# Aurora Android Native Plugin Skeleton
+
+This directory holds the Android side of the future Aurora Tauri mobile plugin. It follows the official Tauri 2 mobile plugin shape: Kotlin native code extends `app.tauri.plugin.Plugin`, is annotated with `@TauriPlugin`, and exposes methods annotated with `@Command`.
+
+The skeleton is intentionally evidence-only. It reports Android package, permission, role, and fallback-entrypoint state to the Rust/JS bridge, but it does not claim assistant-role availability, microphone capture, notification delivery, or foreground-service behavior without Android OS evidence.
+
+## Commands
+
+- `nativeCapabilityManifest`: returns Android native capability and permission states for SDK/native manifest ingestion.
+- `assistantRoleStatus`: probes `RoleManager.ROLE_ASSISTANT` on Android Q+ and package qualification hints from the manifest/intent surface.
+- `requestAssistantRole`: starts the Android role request only when the OS role is available and the package appears qualified.
+- `fallbackEntrypoints`: returns push-to-talk/share/deep-link fallback availability so UI can keep non-role flows visible.
+- `recordAssistantRoleResult`: records a grant/denial result code after a role request smoke test or future activity-result hook.
+
+## Emulator Smoke
+
+After Tauri Android generation wires this module into the app, smoke test with an emulator/device:
+
+```bash
+pnpm --filter @aurora/tauri-ui tauri android build
+adb install apps/aurora-tauri/src-tauri/gen/android/app/build/outputs/apk/debug/app-debug.apk
+adb shell cmd role holders android.app.role.ASSISTANT
+```
+
+Then call the JS transport command path for `androidAssistantRoleStatus` or invoke the plugin command from the Tauri mobile shell test harness and record the returned payload. Expected results must distinguish `roleAvailable`, `packageQualified`, `roleHeld`, `requestable`, `denied`, and `oemUnavailable`, and fallback entrypoints must remain present when `roleHeld=false`.

--- a/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/build.gradle.kts
+++ b/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "dev.aurora.tauri.nativeplugin"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 23
+        consumerProguardFiles("consumer-rules.pro")
+    }
+}
+
+dependencies {
+    compileOnly("app.tauri:tauri-android")
+    implementation("androidx.core:core-ktx:1.13.1")
+}

--- a/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/consumer-rules.pro
+++ b/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/consumer-rules.pro
@@ -1,0 +1,1 @@
+# Intentionally empty. Tauri plugin entrypoints are kept by the generated Android project.

--- a/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/AndroidManifest.xml
+++ b/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <application>
         <!-- Disabled until AND-004 implements the complete VoiceInteractionService qualification flow. -->
         <service
-            android:name=".AuroraVoiceInteractionService"
+            android:name="dev.aurora.tauri.nativeplugin.AuroraVoiceInteractionService"
             android:enabled="false"
             android:exported="true"
             android:label="Aurora"
@@ -17,7 +17,7 @@
         </service>
 
         <activity
-            android:name=".AuroraAssistActivity"
+            android:name="dev.aurora.tauri.nativeplugin.AuroraAssistActivity"
             android:enabled="true"
             android:exported="true"
             android:label="Aurora">

--- a/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/AndroidManifest.xml
+++ b/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+
+    <application>
+        <!-- Disabled until AND-004 implements the complete VoiceInteractionService qualification flow. -->
+        <service
+            android:name=".AuroraVoiceInteractionService"
+            android:enabled="false"
+            android:exported="true"
+            android:label="Aurora"
+            android:permission="android.permission.BIND_VOICE_INTERACTION">
+            <intent-filter>
+                <action android:name="android.service.voice.VoiceInteractionService" />
+            </intent-filter>
+        </service>
+
+        <activity
+            android:name=".AuroraAssistActivity"
+            android:enabled="true"
+            android:exported="true"
+            android:label="Aurora">
+            <intent-filter>
+                <action android:name="android.intent.action.ASSIST" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin/AuroraAssistActivity.kt
+++ b/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin/AuroraAssistActivity.kt
@@ -1,0 +1,11 @@
+package dev.aurora.tauri.nativeplugin
+
+import android.app.Activity
+import android.os.Bundle
+
+class AuroraAssistActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        finish()
+    }
+}

--- a/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin/AuroraNativePlugin.kt
+++ b/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin/AuroraNativePlugin.kt
@@ -8,7 +8,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.service.voice.VoiceInteractionService
 import androidx.core.content.ContextCompat
-import androidx.core.role.RoleManagerCompat
 import app.tauri.annotation.Command
 import app.tauri.annotation.TauriPlugin
 import app.tauri.plugin.Invoke
@@ -84,7 +83,7 @@ class AuroraNativePlugin(private val activity: Activity) : Plugin(activity) {
         }
 
         activity.startActivityForResult(
-            roleManager.createRequestRoleIntent(RoleManagerCompat.ROLE_ASSISTANT),
+            roleManager.createRequestRoleIntent(RoleManager.ROLE_ASSISTANT),
             ASSISTANT_ROLE_REQUEST_CODE,
         )
         val ret = JSObject()
@@ -103,21 +102,25 @@ class AuroraNativePlugin(private val activity: Activity) : Plugin(activity) {
 
     @Command
     fun fallbackEntrypoints(invoke: Invoke) {
-        invoke.resolve(fallbackEntrypointsArray())
+        val ret = JSObject()
+        ret.put("fallbackEntrypoints", fallbackEntrypointsArray())
+        ret.put("evidenceSource", "android-rolemanager-package-manager")
+        ret.put("secretsRedacted", true)
+        invoke.resolve(ret)
     }
 
     private fun assistantRoleStatusObject(): JSObject {
         val sdkSupportsRole = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
         val roleManager = roleManagerOrNull()
-        val roleAvailable = roleManager?.isRoleAvailable(RoleManagerCompat.ROLE_ASSISTANT) == true
-        val roleHeld = roleManager?.isRoleHeld(RoleManagerCompat.ROLE_ASSISTANT) == true
+        val roleAvailable = roleManager?.isRoleAvailable(RoleManager.ROLE_ASSISTANT) == true
+        val roleHeld = roleManager?.isRoleHeld(RoleManager.ROLE_ASSISTANT) == true
         val packageQualified = packageHandlesAssist() || packageDeclaresVoiceInteractionService()
         val requestable = roleAvailable && packageQualified && !roleHeld
         val oemUnavailable = sdkSupportsRole && !roleAvailable
 
         val ret = JSObject()
         ret.put("platform", "android")
-        ret.put("roleName", RoleManagerCompat.ROLE_ASSISTANT)
+        ret.put("roleName", RoleManager.ROLE_ASSISTANT)
         ret.put("roleAvailable", roleAvailable)
         ret.put("packageQualified", packageQualified)
         ret.put("roleHeld", roleHeld)

--- a/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin/AuroraNativePlugin.kt
+++ b/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin/AuroraNativePlugin.kt
@@ -1,0 +1,199 @@
+package dev.aurora.tauri.nativeplugin
+
+import android.Manifest
+import android.app.Activity
+import android.app.role.RoleManager
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.service.voice.VoiceInteractionService
+import androidx.core.content.ContextCompat
+import androidx.core.role.RoleManagerCompat
+import app.tauri.annotation.Command
+import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.JSArray
+import app.tauri.plugin.JSObject
+import app.tauri.plugin.Plugin
+
+private const val ASSISTANT_ROLE_REQUEST_CODE = 4202
+
+@TauriPlugin
+class AuroraNativePlugin(private val activity: Activity) : Plugin(activity) {
+    private var lastAssistantRoleDenied: Boolean = false
+
+    @Command
+    fun nativeCapabilityManifest(invoke: Invoke) {
+        val assistantRole = assistantRoleStatusObject()
+        val permissions = JSObject()
+        permissions.put("aurora.android.assistantRoleStatus", true)
+        permissions.put("aurora.android.assistantRoleRequest", assistantRole.getBoolean("requestable"))
+        permissions.put("aurora.android.microphone", hasPermission(Manifest.permission.RECORD_AUDIO))
+        permissions.put("aurora.android.notifications", hasPostNotificationsPermission())
+        permissions.put("aurora.android.foregroundServiceMicrophone", hasForegroundServiceMicrophonePermission())
+        permissions.put("aurora.android.shareIntent", true)
+        permissions.put("aurora.android.deepLink", true)
+
+        val capabilities = JSObject()
+        capabilities.put("android.assistantRole.status", true)
+        capabilities.put("android.assistantRole.request", assistantRole.getBoolean("requestable"))
+        capabilities.put("android.assistantRole.held", assistantRole.getBoolean("roleHeld"))
+        capabilities.put("android.microphoneCapture", hasPermission(Manifest.permission.RECORD_AUDIO))
+        capabilities.put("android.notifications", hasPostNotificationsPermission())
+        capabilities.put("android.foregroundService", hasForegroundServiceMicrophonePermission())
+        capabilities.put("android.shareIntent", true)
+        capabilities.put("android.deepLink", true)
+        capabilities.put("android.fallbackEntrypoints", true)
+
+        val ret = JSObject()
+        ret.put("platform", "android")
+        ret.put("permissions", permissions)
+        ret.put("capabilities", capabilities)
+        ret.put("assistantRole", assistantRole)
+        ret.put("fallbackEntrypoints", fallbackEntrypointsArray())
+        ret.put("evidenceSource", "android-rolemanager-package-manager")
+        ret.put("secretsRedacted", true)
+        invoke.resolve(ret)
+    }
+
+    @Command
+    fun assistantRoleStatus(invoke: Invoke) {
+        invoke.resolve(assistantRoleStatusObject())
+    }
+
+    @Command
+    fun requestAssistantRole(invoke: Invoke) {
+        val status = assistantRoleStatusObject()
+        if (!status.getBoolean("requestable")) {
+            val ret = JSObject()
+            ret.put("started", false)
+            ret.put("status", status)
+            ret.put("reason", status.getString("reason"))
+            invoke.resolve(ret)
+            return
+        }
+
+        val roleManager = roleManagerOrNull()
+        if (roleManager == null) {
+            val ret = JSObject()
+            ret.put("started", false)
+            ret.put("status", status)
+            ret.put("reason", "role_manager_unavailable")
+            invoke.resolve(ret)
+            return
+        }
+
+        activity.startActivityForResult(
+            roleManager.createRequestRoleIntent(RoleManagerCompat.ROLE_ASSISTANT),
+            ASSISTANT_ROLE_REQUEST_CODE,
+        )
+        val ret = JSObject()
+        ret.put("started", true)
+        ret.put("requestCode", ASSISTANT_ROLE_REQUEST_CODE)
+        ret.put("status", status)
+        invoke.resolve(ret)
+    }
+
+    @Command
+    fun recordAssistantRoleResult(invoke: Invoke) {
+        val args = invoke.parseArgs(AssistantRoleResultArgs::class.java)
+        lastAssistantRoleDenied = args.resultCode != Activity.RESULT_OK
+        invoke.resolve(assistantRoleStatusObject())
+    }
+
+    @Command
+    fun fallbackEntrypoints(invoke: Invoke) {
+        invoke.resolve(fallbackEntrypointsArray())
+    }
+
+    private fun assistantRoleStatusObject(): JSObject {
+        val sdkSupportsRole = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        val roleManager = roleManagerOrNull()
+        val roleAvailable = roleManager?.isRoleAvailable(RoleManagerCompat.ROLE_ASSISTANT) == true
+        val roleHeld = roleManager?.isRoleHeld(RoleManagerCompat.ROLE_ASSISTANT) == true
+        val packageQualified = packageHandlesAssist() || packageDeclaresVoiceInteractionService()
+        val requestable = roleAvailable && packageQualified && !roleHeld
+        val oemUnavailable = sdkSupportsRole && !roleAvailable
+
+        val ret = JSObject()
+        ret.put("platform", "android")
+        ret.put("roleName", RoleManagerCompat.ROLE_ASSISTANT)
+        ret.put("roleAvailable", roleAvailable)
+        ret.put("packageQualified", packageQualified)
+        ret.put("roleHeld", roleHeld)
+        ret.put("requestable", requestable)
+        ret.put("denied", lastAssistantRoleDenied)
+        ret.put("oemUnavailable", oemUnavailable)
+        ret.put("fallbackAvailable", true)
+        ret.put("reason", assistantRoleReason(roleAvailable, packageQualified, roleHeld, oemUnavailable))
+        ret.put("evidenceSource", "android-rolemanager-package-manager")
+        ret.put("secretsRedacted", true)
+        return ret
+    }
+
+    private fun assistantRoleReason(
+        roleAvailable: Boolean,
+        packageQualified: Boolean,
+        roleHeld: Boolean,
+        oemUnavailable: Boolean,
+    ): String {
+        if (roleHeld) return "role_held"
+        if (lastAssistantRoleDenied) return "request_denied"
+        if (oemUnavailable) return "oem_unavailable"
+        if (!roleAvailable) return "unsupported_platform"
+        if (!packageQualified) return "package_not_qualified"
+        return "requestable"
+    }
+
+    private fun fallbackEntrypointsArray(): JSArray {
+        val fallbacks = JSArray()
+        fallbacks.put(fallback("push_to_talk", "degraded", hasPermission(Manifest.permission.RECORD_AUDIO), "requires microphone permission and backend audio evidence"))
+        fallbacks.put(fallback("share_intent", "fallback", true, "available without assistant role"))
+        fallbacks.put(fallback("deep_link", "fallback", true, "available without assistant role"))
+        return fallbacks
+    }
+
+    private fun fallback(id: String, state: String, available: Boolean, reason: String): JSObject {
+        val ret = JSObject()
+        ret.put("id", id)
+        ret.put("state", if (available) state else "needs_native_permission")
+        ret.put("available", available)
+        ret.put("reason", reason)
+        return ret
+    }
+
+    private fun packageHandlesAssist(): Boolean {
+        val intent = Intent(Intent.ACTION_ASSIST).setPackage(activity.packageName)
+        val activities = activity.packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        return activities.isNotEmpty()
+    }
+
+    private fun packageDeclaresVoiceInteractionService(): Boolean {
+        val intent = Intent(VoiceInteractionService.SERVICE_INTERFACE).setPackage(activity.packageName)
+        val services = activity.packageManager.queryIntentServices(intent, PackageManager.MATCH_DISABLED_COMPONENTS)
+        return services.any { service ->
+            service.serviceInfo?.enabled == true &&
+                service.serviceInfo?.permission == Manifest.permission.BIND_VOICE_INTERACTION
+        }
+    }
+
+    private fun hasPermission(permission: String): Boolean =
+        ContextCompat.checkSelfPermission(activity, permission) == PackageManager.PERMISSION_GRANTED
+
+    private fun roleManagerOrNull(): RoleManager? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            activity.getSystemService(RoleManager::class.java)
+        } else {
+            null
+        }
+
+    private fun hasPostNotificationsPermission(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || hasPermission(Manifest.permission.POST_NOTIFICATIONS)
+
+    private fun hasForegroundServiceMicrophonePermission(): Boolean =
+        Build.VERSION.SDK_INT < 34 || hasPermission(Manifest.permission.FOREGROUND_SERVICE_MICROPHONE)
+}
+
+class AssistantRoleResultArgs {
+    var resultCode: Int = Activity.RESULT_CANCELED
+}

--- a/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin/AuroraVoiceInteractionService.kt
+++ b/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin/AuroraVoiceInteractionService.kt
@@ -1,0 +1,5 @@
+package dev.aurora.tauri.nativeplugin
+
+import android.service.voice.VoiceInteractionService
+
+class AuroraVoiceInteractionService : VoiceInteractionService()

--- a/apps/aurora-tauri/src-tauri/build.rs
+++ b/apps/aurora-tauri/src-tauri/build.rs
@@ -10,6 +10,8 @@ fn main() {
             "aurora_sidecar_status",
             "aurora_native_capability_manifest",
             "native_capabilities",
+            "aurora_android_baseline_status",
+            "aurora_android_native_plugin_payload",
             "aurora_log_tail",
             "aurora_secure_storage_get",
             "aurora_secure_storage_set",

--- a/apps/aurora-tauri/src-tauri/capabilities/aurora-ios-baseline.json
+++ b/apps/aurora-tauri/src-tauri/capabilities/aurora-ios-baseline.json
@@ -11,6 +11,7 @@
     "aurora-request",
     "aurora-subscribe",
     "aurora-native-capability-manifest",
+    "aurora-android-native-plugin",
     "aurora-sidecar-status",
     "aurora-sidecar-session",
     "aurora-sidecar-start",

--- a/apps/aurora-tauri/src-tauri/capabilities/aurora-main.json
+++ b/apps/aurora-tauri/src-tauri/capabilities/aurora-main.json
@@ -11,6 +11,7 @@
     "aurora-request",
     "aurora-subscribe",
     "aurora-native-capability-manifest",
+    "aurora-android-native-plugin",
     "aurora-sidecar-status",
     "aurora-sidecar-session",
     "aurora-sidecar-start",

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-android-native-plugin.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-android-native-plugin.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-android-native-plugin"
+description = "Allow the Android smoke harness and frontend SDK adapter to read the native Android Kotlin plugin capability payload."
+commands.allow = ["aurora_android_baseline_status", "aurora_android_native_plugin_payload"]

--- a/apps/aurora-tauri/src-tauri/src/lib.rs
+++ b/apps/aurora-tauri/src-tauri/src/lib.rs
@@ -12,9 +12,8 @@ use std::time::{Duration, Instant};
 use tauri::{
     menu::{Menu, MenuItem},
     tray::TrayIconBuilder,
-    Manager,
 };
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Manager, State};
 use thiserror::Error;
 use url::Url;
 
@@ -158,6 +157,10 @@ struct NativePermissionStatus {
     secrets_redacted: bool,
 }
 
+struct AndroidNativePlugin<R: tauri::Runtime> {
+    handle: Option<tauri::plugin::PluginHandle<R>>,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct NativeFeatureStatus {
@@ -254,6 +257,8 @@ enum AuroraCommandError {
     InvalidGatewayResponse,
     #[error("{0} is not available because the required native permission is disabled")]
     NativePermissionMissing(String),
+    #[error("Android native plugin call failed: {0}")]
+    AndroidNativePlugin(String),
     #[error("{0}")]
     UnsupportedFeature(String),
     #[error("Desktop thin mode is connected to a remote Gateway and cannot start a local sidecar")]
@@ -609,10 +614,44 @@ async fn aurora_android_baseline_status() -> Result<AndroidBaselineStatus, Auror
     Ok(status)
 }
 
+#[tauri::command]
+async fn aurora_android_native_plugin_payload(
+    native: State<'_, AndroidNativePlugin<tauri::Wry>>,
+) -> Result<Value, AuroraCommandError> {
+    #[cfg(target_os = "android")]
+    {
+        let handle = native.handle.as_ref().ok_or_else(|| {
+            AuroraCommandError::AndroidNativePlugin(
+                "Aurora Android native plugin handle was not registered".to_string(),
+            )
+        })?;
+        let payload = handle
+            .run_mobile_plugin::<Value>("nativeCapabilityManifest", json!({}))
+            .map_err(|error| AuroraCommandError::AndroidNativePlugin(error.to_string()))?;
+        log_android_native_plugin_payload(&payload);
+        Ok(payload)
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = native;
+        Err(AuroraCommandError::UnsupportedFeature(
+            "Aurora Android native plugin is only available in the Android Tauri shell".to_string(),
+        ))
+    }
+}
+
 fn log_android_baseline_status(status: &AndroidBaselineStatus) {
     println!(
         "aurora_android_baseline_status={}",
         serde_json::to_string(&status).unwrap_or_else(|_| "{\"secretsRedacted\":true}".to_string())
+    );
+}
+
+fn log_android_native_plugin_payload(payload: &Value) {
+    println!(
+        "aurora_android_native_plugin_payload={}",
+        serde_json::to_string(payload).unwrap_or_else(|_| "{\"secretsRedacted\":true}".to_string())
     );
 }
 
@@ -776,6 +815,7 @@ impl AuroraCommandError {
             Self::Gateway(_) => "transport_loss",
             Self::InvalidGatewayResponse => "validation_error",
             Self::NativePermissionMissing(_) => "native_permission_missing",
+            Self::AndroidNativePlugin(_) => "native_plugin_error",
             Self::UnsupportedFeature(_) => "unsupported_feature",
             Self::ThinModeSidecarDisabled => "unsupported_feature",
             Self::SidecarLoopbackRequired(_) => "validation_error",
@@ -958,6 +998,28 @@ fn native_platform() -> &'static str {
     } else {
         "tauri-desktop"
     }
+}
+
+fn android_native_plugin<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
+    tauri::plugin::Builder::new("aurora-native")
+        .setup(|app, api| {
+            #[cfg(target_os = "android")]
+            {
+                let handle = api.register_android_plugin(
+                    "dev.aurora.tauri.nativeplugin",
+                    "AuroraNativePlugin",
+                )?;
+                app.manage(AndroidNativePlugin::<R> {
+                    handle: Some(handle),
+                });
+            }
+            #[cfg(not(target_os = "android"))]
+            {
+                app.manage(AndroidNativePlugin::<R> { handle: None });
+            }
+            Ok(())
+        })
+        .build()
 }
 
 fn android_baseline_status() -> AndroidBaselineStatus {
@@ -1346,12 +1408,25 @@ fn is_loopback_http_origin(url: &Url) -> bool {
 pub fn run() {
     let sidecar_state: SharedSidecarState = Arc::new(Mutex::new(SidecarState::new()));
     tauri::Builder::default()
+        .plugin(android_native_plugin())
         .manage(sidecar_state.clone())
         .setup(|app| {
             #[cfg(desktop)]
             install_tray(app.handle())?;
             #[cfg(target_os = "android")]
-            log_android_baseline_status(&android_baseline_status());
+            {
+                log_android_baseline_status(&android_baseline_status());
+                if let Some(native) = app.try_state::<AndroidNativePlugin<tauri::Wry>>() {
+                    if let Some(handle) = native.handle.as_ref() {
+                        match handle
+                            .run_mobile_plugin::<Value>("nativeCapabilityManifest", json!({}))
+                        {
+                            Ok(payload) => log_android_native_plugin_payload(&payload),
+                            Err(error) => eprintln!("aurora_android_native_plugin_error={error}"),
+                        }
+                    }
+                }
+            }
             #[cfg(desktop)]
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;
@@ -1374,6 +1449,7 @@ pub fn run() {
             aurora_dialog_status,
             aurora_audio_bridge_status,
             aurora_android_baseline_status,
+            aurora_android_native_plugin_payload,
             aurora_log_tail,
             aurora_secure_storage_get,
             aurora_secure_storage_set,

--- a/packages/aurora-sdk/src/capabilities.ts
+++ b/packages/aurora-sdk/src/capabilities.ts
@@ -319,9 +319,8 @@ function candidatesFromNativeManifest(
   return [
     ...Object.entries(manifest.capabilities).map(([capability, enabled]) => {
       const featureId = `native:${manifest.platform}:${capability}`
-      const missingPermissions = Object.entries(manifest.permissions)
-        .filter(([, granted]) => !granted)
-        .map(([permission]) => permission)
+      const missingPermissions = nativeRequiredPermissions(capability, manifest.permissions)
+        .filter((permission) => manifest.permissions[permission] === false)
       const availability: AvailabilityState = enabled
         ? missingPermissions.length > 0
           ? 'privacy-blocked'
@@ -347,7 +346,7 @@ function candidatesFromNativeManifest(
         routeability: enabled ? 'native-manifest' : 'disabled',
         freshness: emptyFreshness('native-manifest'),
         requiredPermissions: missingPermissions,
-        privacyClass: capability.toLowerCase().includes('microphone') ? 'raw-audio' : 'personal',
+        privacyClass: nativePrivacyClass(capability),
         disabledReasons: enabled ? missingPermissions.map((permission) => `native permission missing: ${permission}`) : ['native capability disabled'],
         requiredAction:
           availability === 'privacy-blocked'
@@ -413,6 +412,40 @@ function requiredActionForNativeIntegration(support: NativeIntegrationSupport): 
   if (support === 'planned') return 'implement scoped iOS plugin, App Intent, or extension task'
   if (support === 'blocked') return 'satisfy platform entitlement, consent, or permission requirement'
   return 'do not claim this platform capability'
+}
+
+function nativeRequiredPermissions(capability: string, permissions: Record<string, boolean>): string[] {
+  const normalized = capability.toLowerCase()
+  const requestedTokens: string[] = []
+  if (normalized.includes('assistantrole.status')) requestedTokens.push('assistantrolestatus')
+  if (normalized.includes('assistantrole.request')) requestedTokens.push('assistantrolerequest')
+  if (normalized.includes('microphone') || normalized.includes('audiocapture')) requestedTokens.push('microphone', 'audiocapture')
+  if (normalized.includes('notification')) requestedTokens.push('notification')
+  if (normalized.includes('foregroundservice')) requestedTokens.push('foregroundservice')
+  if (normalized.includes('shareintent')) requestedTokens.push('shareintent')
+  if (normalized.includes('deeplink')) requestedTokens.push('deeplink')
+  if (normalized.includes('securecredentialstorage')) requestedTokens.push('securestorage', 'credentialstorage')
+  if (normalized.includes('securefilehandles')) requestedTokens.push('securefile')
+  if (normalized.includes('localfileread')) requestedTokens.push('localfileread')
+  if (normalized.includes('localfilewrite')) requestedTokens.push('localfilewrite')
+  if (normalized.includes('dialog')) requestedTokens.push('dialog')
+  if (normalized.includes('tray')) requestedTokens.push('tray')
+  if (normalized.includes('logtail')) requestedTokens.push('logtail')
+  if (normalized.includes('sidecar')) requestedTokens.push('sidecar')
+  if (normalized.includes('fallbackentrypoints')) requestedTokens.push('fallback', 'shareintent', 'deeplink')
+
+  const matches = Object.keys(permissions).filter((permission) => {
+    const permissionKey = permission.toLowerCase().replace(/[^a-z0-9]/g, '')
+    return requestedTokens.some((token) => permissionKey.includes(token))
+  })
+  return sortedUnique(matches)
+}
+
+function nativePrivacyClass(capability: string): PrivacyClass {
+  const normalized = capability.toLowerCase()
+  if (normalized.includes('microphone') || normalized.includes('audio')) return 'raw-audio'
+  if (normalized.includes('credential') || normalized.includes('storage')) return 'credential'
+  return 'personal'
 }
 
 function nodeFromCandidates(

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -3044,6 +3044,66 @@ export const nativeCapabilityManifestFixture: NativeCapabilityManifest = {
   ]
 }
 
+export const androidNativeCapabilityManifestFixture: NativeCapabilityManifest = {
+  platform: 'android',
+  permissions: {
+    'aurora.android.assistantRoleStatus': true,
+    'aurora.android.assistantRoleRequest': false,
+    'aurora.android.microphone': false,
+    'aurora.android.notifications': false,
+    'aurora.android.foregroundServiceMicrophone': false,
+    'aurora.android.shareIntent': true,
+    'aurora.android.deepLink': true
+  },
+  capabilities: {
+    'android.assistantRole.status': true,
+    'android.assistantRole.request': false,
+    'android.assistantRole.held': false,
+    'android.microphoneCapture': false,
+    'android.notifications': false,
+    'android.foregroundService': false,
+    'android.shareIntent': true,
+    'android.deepLink': true,
+    'android.fallbackEntrypoints': true
+  },
+  assistantRole: {
+    platform: 'android',
+    roleName: 'android.app.role.ASSISTANT',
+    roleAvailable: true,
+    packageQualified: false,
+    roleHeld: false,
+    requestable: false,
+    denied: false,
+    oemUnavailable: false,
+    fallbackAvailable: true,
+    reason: 'package_not_qualified',
+    evidenceSource: 'android-rolemanager-package-manager',
+    secretsRedacted: true
+  },
+  fallbackEntrypoints: [
+    {
+      id: 'push_to_talk',
+      state: 'needs_native_permission',
+      available: false,
+      reason: 'requires microphone permission and backend audio evidence'
+    },
+    {
+      id: 'share_intent',
+      state: 'fallback',
+      available: true,
+      reason: 'available without assistant role'
+    },
+    {
+      id: 'deep_link',
+      state: 'fallback',
+      available: true,
+      reason: 'available without assistant role'
+    }
+  ],
+  evidenceSource: 'android-rolemanager-package-manager',
+  secretsRedacted: true
+}
+
 const idleModelProgress = (operationType: string) => ({
   operation_id: null,
   operation_type: operationType,

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -119,6 +119,7 @@ export {
   webrtcDiagnosticsFixture,
   gatewayServicesFixture,
   nativeCapabilityManifestFixture,
+  androidNativeCapabilityManifestFixture,
   routeExplainFixture,
   schedulerJobsFixture,
   supportBundleFixture,

--- a/packages/aurora-sdk/src/tauri.ts
+++ b/packages/aurora-sdk/src/tauri.ts
@@ -6,7 +6,16 @@ import {
   type AuroraStreamRequest
 } from './events.js'
 import type { AuroraTransport, AuroraTransportRequest, AuroraTransportResponse } from './transport.js'
-import type { AuditReceipt, AuroraEvent, AuroraTransportEnvelope, JsonObject, NativeCapabilityManifest } from './types.js'
+import type {
+  AndroidAssistantRoleRequestResult,
+  AndroidAssistantRoleStatus,
+  AndroidFallbackEntrypoint,
+  AuditReceipt,
+  AuroraEvent,
+  AuroraTransportEnvelope,
+  JsonObject,
+  NativeCapabilityManifest
+} from './types.js'
 
 export type TauriInvoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>
 
@@ -17,6 +26,9 @@ export interface TauriCommandNames {
   sidecarStop: string
   sidecarStatus: string
   nativeCapabilityManifest: string
+  androidAssistantRoleStatus: string
+  androidAssistantRoleRequest: string
+  androidFallbackEntrypoints: string
   nativePermissionStatus: string
   trayStatus: string
   notificationStatus: string
@@ -168,6 +180,9 @@ const DEFAULT_COMMANDS: TauriCommandNames = {
   sidecarStop: 'aurora_sidecar_stop',
   sidecarStatus: 'aurora_sidecar_status',
   nativeCapabilityManifest: 'aurora_native_capability_manifest',
+  androidAssistantRoleStatus: 'assistantRoleStatus',
+  androidAssistantRoleRequest: 'requestAssistantRole',
+  androidFallbackEntrypoints: 'fallbackEntrypoints',
   nativePermissionStatus: 'aurora_native_permission_status',
   trayStatus: 'aurora_tray_status',
   notificationStatus: 'aurora_notification_status',
@@ -239,6 +254,18 @@ export class TauriLocalTransport implements AuroraTransport {
 
   getNativeCapabilityManifest(): Promise<NativeCapabilityManifest> {
     return this.invokeCommand<NativeCapabilityManifest>(this.commands.nativeCapabilityManifest)
+  }
+
+  getAndroidAssistantRoleStatus(): Promise<AndroidAssistantRoleStatus> {
+    return this.invokeCommand<AndroidAssistantRoleStatus>(this.commands.androidAssistantRoleStatus)
+  }
+
+  requestAndroidAssistantRole(): Promise<AndroidAssistantRoleRequestResult> {
+    return this.invokeCommand<AndroidAssistantRoleRequestResult>(this.commands.androidAssistantRoleRequest)
+  }
+
+  getAndroidFallbackEntrypoints(): Promise<AndroidFallbackEntrypoint[]> {
+    return this.invokeCommand<AndroidFallbackEntrypoint[]>(this.commands.androidFallbackEntrypoints)
   }
 
   getNativePermissionStatus(): Promise<TauriNativePermissionStatus> {

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -1563,6 +1563,10 @@ export interface NativeCapabilityManifest {
   capabilities: Record<string, boolean>
   mobileIntegrations?: NativeMobileIntegration[]
   platformLimitations?: NativePlatformLimitation[]
+  assistantRole?: AndroidAssistantRoleStatus | null
+  fallbackEntrypoints?: AndroidFallbackEntrypoint[]
+  evidenceSource?: string
+  secretsRedacted?: boolean
 }
 
 export type NativeIntegrationSupport = 'supported' | 'supported-path' | 'planned' | 'unsupported' | 'blocked'
@@ -1587,4 +1591,40 @@ export interface NativePlatformLimitation {
   reason: string
   userCopy: string
   evidenceSource: string
+}
+
+export type AndroidNativeState =
+  | 'available'
+  | 'needs_native_permission'
+  | 'unsupported_platform'
+  | 'degraded'
+  | 'fallback'
+
+export interface AndroidAssistantRoleStatus {
+  platform: 'android' | string
+  roleName: string
+  roleAvailable: boolean
+  packageQualified: boolean
+  roleHeld: boolean
+  requestable: boolean
+  denied: boolean
+  oemUnavailable: boolean
+  fallbackAvailable: boolean
+  reason: string
+  evidenceSource: string
+  secretsRedacted: boolean
+}
+
+export interface AndroidAssistantRoleRequestResult {
+  started: boolean
+  requestCode?: number
+  status: AndroidAssistantRoleStatus
+  reason?: string
+}
+
+export interface AndroidFallbackEntrypoint {
+  id: string
+  state: AndroidNativeState
+  available: boolean
+  reason: string
 }

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -33,6 +33,7 @@ import {
   hasPermission,
   modelRuntimeCatalogFixture,
   nativeCapabilityManifestFixture,
+  androidNativeCapabilityManifestFixture,
   ORCHESTRATOR_MODEL_METHODS,
   permissionLabel,
   normalizeToolCatalog,
@@ -564,6 +565,44 @@ describe('AuroraClient', () => {
         state: 'privacy-blocked',
         nextRepairAction: 'grant required native permission',
         requiredPermissions: ['microphone']
+      })
+    )
+  })
+
+  it('keeps Android fallback entrypoints selectable independently from assistant-role and microphone blockers', () => {
+    const graph = buildCapabilityGraph({
+      catalog: capabilityGraphCatalogFixture,
+      registry: gatewayRegistryFixture,
+      nativeManifest: androidNativeCapabilityManifestFixture,
+      transportKind: 'native-mobile'
+    })
+
+    expect(graph.byFeatureId['native:android:android.assistantRole.status']).toEqual(
+      expect.objectContaining({
+        availability: 'available-local',
+        providerIdentity: 'native:android'
+      })
+    )
+    expect(graph.byFeatureId['native:android:android.assistantRole.request']).toEqual(
+      expect.objectContaining({
+        availability: 'unsupported'
+      })
+    )
+    expect(graph.byFeatureId['native:android:android.microphoneCapture']).toEqual(
+      expect.objectContaining({
+        availability: 'unsupported',
+        privacyClass: 'raw-audio'
+      })
+    )
+    expect(graph.byFeatureId['native:android:android.shareIntent']).toEqual(
+      expect.objectContaining({
+        availability: 'available-local',
+        providerIdentity: 'native:android'
+      })
+    )
+    expect(graph.byFeatureId['native:android:android.fallbackEntrypoints']).toEqual(
+      expect.objectContaining({
+        availability: 'available-local'
       })
     )
   })
@@ -2502,6 +2541,76 @@ describe('AuroraClient', () => {
     expect(calls[15]?.args).toEqual({ path: '/tmp/a.txt', options: {} })
     expect(calls[16]?.args).toEqual({ path: '/tmp/a.txt', data: 'hello', options: {} })
     expect(calls[18]?.args).toEqual({ options: { mode: 'read' } })
+  })
+
+  it('exposes Android assistant-role status and fallback entrypoints through the Tauri transport', async () => {
+    const calls: Array<{ command: string; args: Record<string, unknown> | undefined }> = []
+    const transport = new TauriLocalTransport({
+      invoke: async (command, args) => {
+        calls.push({ command, args })
+        switch (command) {
+          case 'aurora_native_capability_manifest':
+            return androidNativeCapabilityManifestFixture
+          case 'assistantRoleStatus':
+            return androidNativeCapabilityManifestFixture.assistantRole
+          case 'requestAssistantRole':
+            return {
+              started: false,
+              status: androidNativeCapabilityManifestFixture.assistantRole,
+              reason: 'package_not_qualified'
+            }
+          case 'fallbackEntrypoints':
+            return androidNativeCapabilityManifestFixture.fallbackEntrypoints
+          default:
+            throw new Error(`Unexpected command ${command}`)
+        }
+      }
+    })
+
+    await expect(transport.getNativeCapabilityManifest()).resolves.toEqual(
+      expect.objectContaining({
+        platform: 'android',
+        assistantRole: expect.objectContaining({
+          roleAvailable: true,
+          packageQualified: false,
+          roleHeld: false,
+          requestable: false,
+          oemUnavailable: false,
+          reason: 'package_not_qualified'
+        }),
+        fallbackEntrypoints: expect.arrayContaining([
+          expect.objectContaining({ id: 'share_intent', state: 'fallback', available: true })
+        ])
+      })
+    )
+    await expect(transport.getAndroidAssistantRoleStatus()).resolves.toEqual(
+      expect.objectContaining({
+        roleName: 'android.app.role.ASSISTANT',
+        roleAvailable: true,
+        packageQualified: false,
+        roleHeld: false,
+        requestable: false,
+        fallbackAvailable: true
+      })
+    )
+    await expect(transport.requestAndroidAssistantRole()).resolves.toEqual(
+      expect.objectContaining({
+        started: false,
+        reason: 'package_not_qualified'
+      })
+    )
+    await expect(transport.getAndroidFallbackEntrypoints()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'push_to_talk', state: 'needs_native_permission', available: false }),
+        expect.objectContaining({ id: 'share_intent', state: 'fallback', available: true })
+      ])
+    )
+    expect(calls.map((call) => call.command)).toEqual([
+      'aurora_native_capability_manifest',
+      'assistantRoleStatus',
+      'requestAssistantRole',
+      'fallbackEntrypoints'
+    ])
   })
 
   it('classifies Tauri auth, permission, validation, timeout, unavailable, unsupported, privacy, native permission, and transport-loss failures', async () => {


### PR DESCRIPTION
## Summary

- Adds an Android Kotlin native plugin skeleton under `apps/aurora-tauri/src-tauri/android/aurora-native-plugin` using the Tauri mobile plugin pattern (`Plugin`, `@TauriPlugin`, `@Command`).
- Exposes evidence payloads for native capability manifest, assistant-role status/request probing, role-result recording, and fallback entrypoints.
- Extends `@aurora/client` native manifest types, Tauri transport helpers, fixtures, and capability graph mapping so Android assistant-role and fallback states stay distinct.
- Preserves the current Android/iOS baseline manifest work on `feat/ui-multi-platform-integration` and documents the AND-002 plugin skeleton alongside it.

## Guardrails

- No backend contract changes.
- VoiceInteractionService is declared disabled until the follow-up assistant-role qualification task implements the full flow.
- Fallback entrypoints remain available independently from assistant-role grant state.
- UI/native state remains evidence-driven; no assistant-role availability is claimed from Tauri shell presence alone.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @aurora/client test` -- 3 files / 91 tests passed
- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client build`
- `pnpm --filter @aurora/ui typecheck`
- `pnpm --filter @aurora/tauri-ui typecheck`
- `pnpm --filter @aurora/tauri-ui test` -- 2 files / 4 tests passed

## Environment-gated checks

- `pnpm --filter @aurora/tauri-ui tauri android build` is blocked locally because `apps/aurora-tauri/src-tauri/gen/android` does not exist in this worktree; Tauri reports to run `tauri android init` first. The PR's Android CI workflow is the expected Android build/emulator evidence path.
- `cargo check` in `apps/aurora-tauri/src-tauri` is blocked locally by missing Linux system package metadata for `glib-2.0` / `gobject-2.0` pkg-config files in this container.

## GitHub Checks

At PR creation/update time, GitHub reported these checks pending:

- Android APK build and emulator smoke
- Linux Tauri check and smoke launch
- macOS Xcode Tauri iOS init and build
