### PR TITLE
PER-181: Implement Android native capability manifest provider

### DIFF
--- a/apps/aurora-tauri/README.md
+++ b/apps/aurora-tauri/README.md
@@ -93,7 +93,7 @@ The shared Tauri capability intentionally does not grant `updater:default`; upda
 
 ## Android Native Skeleton
 
-`src-tauri/android/aurora-native-plugin/` contains the AND-002 Kotlin plugin skeleton for future Tauri mobile wiring. The plugin exposes Android-native evidence commands for `nativeCapabilityManifest`, `assistantRoleStatus`, assistant-role request probing, and fallback entrypoints. It keeps the future VoiceInteractionService declaration disabled until the package qualification and role-grant flow is completed by the Android assistant-role task.
+`src-tauri/android/aurora-native-plugin/` contains the Android Kotlin plugin used by the native capability manifest. The plugin exposes Android-native evidence commands for `nativeCapabilityManifest`, `assistantRoleStatus`, assistant-role request probing, and fallback entrypoints. `Native.GetCapabilityManifest` routes through this plugin on Android, so the SDK receives explicit Android states for assistant role, mic, notifications, biometric, local network, foreground service, file, share/deep-link, and fallback entrypoints. It keeps the future VoiceInteractionService declaration disabled until the package qualification and role-grant flow is completed by the Android assistant-role task.
 
 The real Android build remains gated on Tauri's generated Android project under `src-tauri/gen/android`; run `pnpm --filter @aurora/tauri-ui tauri android init` before attempting `pnpm --filter @aurora/tauri-ui tauri android build` in an Android-capable environment.
 

--- a/apps/aurora-tauri/scripts/android-emulator-smoke.mjs
+++ b/apps/aurora-tauri/scripts/android-emulator-smoke.mjs
@@ -14,15 +14,16 @@ run('adb', ['install', '-r', apk])
 run('adb', ['logcat', '-c'])
 run('adb', ['shell', 'monkey', '-p', appId, '-c', 'android.intent.category.LAUNCHER', '1'])
 
-const payloadLine = waitForPayloadLine()
-if (!payloadLine) {
+const payloadJson = waitForPayloadJson()
+if (!payloadJson) {
   throw new Error('Android native plugin payload log was not observed after app launch.')
 }
-validateNativePayload(payloadLine)
+const payload = validateNativePayload(payloadJson)
 
 console.log(`Installed APK: ${apk}`)
 console.log(`Launched package: ${appId}`)
-console.log(payloadLine)
+console.log(`Android native plugin payload bytes: ${Buffer.byteLength(payloadJson, 'utf8')}`)
+console.log(`Android native plugin payload platform: ${payload.platform}`)
 
 function findApk() {
   const roots = [
@@ -49,34 +50,89 @@ function run(command, args) {
   execFileSync(command, args, { stdio: 'inherit' })
 }
 
-function waitForPayloadLine() {
+function waitForPayloadJson() {
   const deadline = Date.now() + Number(process.env.AURORA_ANDROID_SMOKE_TIMEOUT_MS ?? 60_000)
   while (Date.now() < deadline) {
-    const logcat = spawnSync('adb', ['logcat', '-d', '-t', '800'], { encoding: 'utf8' })
+    const logcat = spawnSync('adb', ['logcat', '-d', '-t', '2000'], { encoding: 'utf8' })
     if (logcat.error) {
       throw logcat.error
     }
     const output = `${logcat.stdout}\n${logcat.stderr}`
-    const line = output
-      .split(/\r?\n/)
-      .find((entry) => entry.includes('aurora_android_native_plugin_payload='))
-    if (line) return line
+    const payload = extractChunkedPayload(output) ?? extractLegacyPayload(output)
+    if (payload) return payload
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000)
   }
   return null
 }
 
-function validateNativePayload(line) {
-  const marker = 'aurora_android_native_plugin_payload='
-  const jsonStart = line.indexOf(marker)
-  if (jsonStart === -1) {
-    throw new Error('Android smoke line does not contain the native plugin payload marker.')
+function extractChunkedPayload(output) {
+  const lines = output.split(/\r?\n/)
+  const beginPattern = /aurora_android_native_plugin_payload_begin chunks=(\d+) bytes=(\d+)/
+  const chunkPattern = /aurora_android_native_plugin_payload_chunk index=(\d+) total=(\d+) data=(.*)$/
+  const endPattern = /aurora_android_native_plugin_payload_end chunks=(\d+)/
+
+  let expectedChunks = null
+  let expectedBytes = null
+  let endObserved = false
+  const chunks = new Map()
+
+  for (const line of lines) {
+    const begin = line.match(beginPattern)
+    if (begin) {
+      expectedChunks = Number(begin[1])
+      expectedBytes = Number(begin[2])
+      endObserved = false
+      chunks.clear()
+      continue
+    }
+
+    const chunk = line.match(chunkPattern)
+    if (chunk && expectedChunks !== null) {
+      const index = Number(chunk[1])
+      const total = Number(chunk[2])
+      if (total === expectedChunks && index >= 0 && index < expectedChunks) {
+        chunks.set(index, chunk[3])
+      }
+      continue
+    }
+
+    const end = line.match(endPattern)
+    if (end && expectedChunks !== null && Number(end[1]) === expectedChunks) {
+      endObserved = true
+    }
   }
 
-  const payload = JSON.parse(line.slice(jsonStart + marker.length))
+  if (expectedChunks === null || !endObserved || chunks.size !== expectedChunks) {
+    return null
+  }
+
+  const payload = Array.from({ length: expectedChunks }, (_, index) => chunks.get(index) ?? '').join('')
+  if (expectedBytes !== null && Buffer.byteLength(payload, 'utf8') !== expectedBytes) {
+    throw new Error(
+      `Android native plugin payload byte count mismatch: expected ${expectedBytes}, got ${Buffer.byteLength(payload, 'utf8')}.`
+    )
+  }
+  return payload
+}
+
+function extractLegacyPayload(output) {
+  const marker = 'aurora_android_native_plugin_payload='
+  const line = output
+    .split(/\r?\n/)
+    .find((entry) => entry.includes(marker))
+  if (!line) return null
+  return line.slice(line.indexOf(marker) + marker.length)
+}
+
+function validateNativePayload(payloadJson) {
+  const payload = JSON.parse(payloadJson)
   const assistantRole = payload.assistantRole
   if (!assistantRole || typeof assistantRole !== 'object') {
     throw new Error('Android native plugin payload is missing assistantRole.')
+  }
+
+  if (payload.platform !== 'android') {
+    throw new Error(`Android native plugin payload platform must be android, got ${String(payload.platform)}.`)
   }
 
   for (const field of ['roleAvailable', 'packageQualified', 'roleHeld', 'requestable', 'denied', 'oemUnavailable']) {
@@ -85,8 +141,47 @@ function validateNativePayload(line) {
     }
   }
 
+  assertStateMap('permissionStates', payload.permissionStates, [
+    'aurora.android.assistantRoleRequest',
+    'aurora.android.assistantRoleStatus',
+    'aurora.android.microphone',
+    'aurora.android.notifications',
+    'aurora.android.biometric',
+    'aurora.android.localNetwork',
+    'aurora.android.foregroundServiceMicrophone',
+    'aurora.android.filePick',
+    'aurora.android.shareIntent',
+    'aurora.android.deepLink'
+  ])
+  assertStateMap('capabilityStates', payload.capabilityStates, [
+    'android.assistantRole.available',
+    'android.assistantRole.packageQualified',
+    'android.assistantRole.held',
+    'android.assistantRole.request',
+    'android.assistantRole.denied',
+    'android.assistantRole.oemUnavailable',
+    'android.microphoneCapture',
+    'android.notifications',
+    'android.biometric',
+    'android.localNetwork',
+    'android.foregroundService',
+    'android.filePick',
+    'android.shareIntent',
+    'android.deepLink',
+    'android.fallbackEntrypoints'
+  ])
+
   if (!Array.isArray(payload.fallbackEntrypoints) || payload.fallbackEntrypoints.length === 0) {
     throw new Error('Android native plugin payload is missing fallbackEntrypoints.')
+  }
+  for (const entry of payload.fallbackEntrypoints) {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error('Android native plugin fallbackEntrypoints entries must be objects.')
+    }
+    if (typeof entry.id !== 'string' || typeof entry.available !== 'boolean' || typeof entry.capability !== 'string') {
+      throw new Error('Android native plugin fallbackEntrypoints entries must include id, available, and capability.')
+    }
+    assertNativeState(`fallbackEntrypoints.${entry.id}.state`, entry.state)
   }
 
   if (assistantRole.roleHeld === false) {
@@ -94,5 +189,23 @@ function validateNativePayload(line) {
     if (!availableFallback) {
       throw new Error('Android native plugin payload must keep fallback entrypoints available when roleHeld=false.')
     }
+  }
+
+  return payload
+}
+
+function assertStateMap(label, value, requiredKeys) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Android native plugin payload is missing ${label}.`)
+  }
+  for (const key of requiredKeys) {
+    assertNativeState(`${label}.${key}`, value[key])
+  }
+}
+
+function assertNativeState(label, value) {
+  const allowed = ['available', 'needs_native_permission', 'unsupported_platform', 'degraded', 'fallback']
+  if (!allowed.includes(value)) {
+    throw new Error(`Android native plugin ${label} must be one of ${allowed.join(', ')}.`)
   }
 }

--- a/apps/aurora-tauri/src-tauri/android/README.md
+++ b/apps/aurora-tauri/src-tauri/android/README.md
@@ -6,11 +6,21 @@ The skeleton is intentionally evidence-only. It reports Android package, permiss
 
 ## Commands
 
-- `nativeCapabilityManifest`: returns Android native capability and permission states for SDK/native manifest ingestion.
+- `nativeCapabilityManifest`: returns Android native capability and permission states for SDK/native manifest ingestion. The payload keeps backward-compatible boolean `permissions`/`capabilities` maps and also includes `permissionStates`/`capabilityStates` so UI can distinguish `available`, `needs_native_permission`, `unsupported_platform`, `degraded`, and `fallback`.
 - `assistantRoleStatus`: probes `RoleManager.ROLE_ASSISTANT` on Android Q+ and package qualification hints from the manifest/intent surface.
 - `requestAssistantRole`: starts the Android role request only when the OS role is available and the package appears qualified.
 - `fallbackEntrypoints`: returns push-to-talk/share/deep-link fallback availability so UI can keep non-role flows visible.
 - `recordAssistantRoleResult`: records a grant/denial result code after a role request smoke test or future activity-result hook.
+
+## Native Manifest Fields
+
+The Android provider reports status for:
+
+- assistant-role availability, package qualification, held state, requestability, denial, OEM/platform unavailability, and fallback availability;
+- microphone, notifications, biometric, local-network, foreground-service microphone, local file read/write/pick, share intent, deep link, and fallback entrypoints;
+- redacted evidence source `android-rolemanager-package-manager`.
+
+File read/write/pick are reported as `degraded` until a scoped Android file/share intake task wires a native picker contract. Foreground service microphone remains `needs_native_permission` until both microphone and foreground-service microphone permission evidence is present. Fallback entrypoints remain present when the assistant role is not held.
 
 ## Emulator Smoke
 
@@ -22,4 +32,4 @@ adb install apps/aurora-tauri/src-tauri/gen/android/app/build/outputs/apk/debug/
 adb shell cmd role holders android.app.role.ASSISTANT
 ```
 
-Then call the JS transport command path for `androidAssistantRoleStatus` or invoke the plugin command from the Tauri mobile shell test harness and record the returned payload. Expected results must distinguish `roleAvailable`, `packageQualified`, `roleHeld`, `requestable`, `denied`, and `oemUnavailable`, and fallback entrypoints must remain present when `roleHeld=false`.
+Then call the JS transport command path for `getNativeCapabilityManifest()` / `androidAssistantRoleStatus` or invoke the plugin command from the Tauri mobile shell test harness and record the returned payload. Expected results must distinguish `roleAvailable`, `packageQualified`, `roleHeld`, `requestable`, `denied`, and `oemUnavailable`; include mic/notification/biometric/local-network/foreground-service/file/share states; and keep fallback entrypoints present when `roleHeld=false`.

--- a/apps/aurora-tauri/src-tauri/android/README.md
+++ b/apps/aurora-tauri/src-tauri/android/README.md
@@ -33,3 +33,5 @@ adb shell cmd role holders android.app.role.ASSISTANT
 ```
 
 Then call the JS transport command path for `getNativeCapabilityManifest()` / `androidAssistantRoleStatus` or invoke the plugin command from the Tauri mobile shell test harness and record the returned payload. Expected results must distinguish `roleAvailable`, `packageQualified`, `roleHeld`, `requestable`, `denied`, and `oemUnavailable`; include mic/notification/biometric/local-network/foreground-service/file/share states; and keep fallback entrypoints present when `roleHeld=false`.
+
+The CI smoke harness reads chunked `aurora_android_native_plugin_payload_*` log markers and reassembles them before JSON validation. Do not rely on a single full-payload logcat line; Android log output can truncate long JSON lines before the parser sees them.

--- a/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/AndroidManifest.xml
+++ b/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
     <application>
         <!-- Disabled until AND-004 implements the complete VoiceInteractionService qualification flow. -->

--- a/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin/AuroraNativePlugin.kt
+++ b/apps/aurora-tauri/src-tauri/android/aurora-native-plugin/src/main/java/dev/aurora/tauri/nativeplugin/AuroraNativePlugin.kt
@@ -2,6 +2,7 @@ package dev.aurora.tauri.nativeplugin
 
 import android.Manifest
 import android.app.Activity
+import android.app.KeyguardManager
 import android.app.role.RoleManager
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -24,30 +25,93 @@ class AuroraNativePlugin(private val activity: Activity) : Plugin(activity) {
     @Command
     fun nativeCapabilityManifest(invoke: Invoke) {
         val assistantRole = assistantRoleStatusObject()
+        val microphoneGranted = hasRuntimePermission(Manifest.permission.RECORD_AUDIO)
+        val notificationsGranted = hasPostNotificationsPermission()
+        val foregroundServiceReady = hasForegroundServiceMicrophonePermission() && microphoneGranted
+        val biometricReady = hasBiometricCapability()
+        val localNetworkReady = hasPackagePermission(Manifest.permission.INTERNET) &&
+            hasPackagePermission(Manifest.permission.ACCESS_NETWORK_STATE)
+        val assistantRoleRequestable = assistantRole.getBoolean("requestable")
+        val assistantRoleHeld = assistantRole.getBoolean("roleHeld")
+        val assistantRoleAvailable = assistantRole.getBoolean("roleAvailable")
+        val assistantRolePackageQualified = assistantRole.getBoolean("packageQualified")
+        val assistantRoleDenied = assistantRole.getBoolean("denied")
+        val assistantRoleOemUnavailable = assistantRole.getBoolean("oemUnavailable")
+
         val permissions = JSObject()
         permissions.put("aurora.android.assistantRoleStatus", true)
-        permissions.put("aurora.android.assistantRoleRequest", assistantRole.getBoolean("requestable"))
-        permissions.put("aurora.android.microphone", hasPermission(Manifest.permission.RECORD_AUDIO))
-        permissions.put("aurora.android.notifications", hasPostNotificationsPermission())
-        permissions.put("aurora.android.foregroundServiceMicrophone", hasForegroundServiceMicrophonePermission())
+        permissions.put("aurora.android.assistantRoleRequest", assistantRoleRequestable)
+        permissions.put("aurora.android.microphone", microphoneGranted)
+        permissions.put("aurora.android.notifications", notificationsGranted)
+        permissions.put("aurora.android.biometric", biometricReady)
+        permissions.put("aurora.android.localNetwork", localNetworkReady)
+        permissions.put("aurora.android.foregroundServiceMicrophone", foregroundServiceReady)
+        permissions.put("aurora.android.localFileRead", false)
+        permissions.put("aurora.android.localFileWrite", false)
+        permissions.put("aurora.android.filePick", false)
         permissions.put("aurora.android.shareIntent", true)
         permissions.put("aurora.android.deepLink", true)
 
         val capabilities = JSObject()
         capabilities.put("android.assistantRole.status", true)
-        capabilities.put("android.assistantRole.request", assistantRole.getBoolean("requestable"))
-        capabilities.put("android.assistantRole.held", assistantRole.getBoolean("roleHeld"))
-        capabilities.put("android.microphoneCapture", hasPermission(Manifest.permission.RECORD_AUDIO))
-        capabilities.put("android.notifications", hasPostNotificationsPermission())
-        capabilities.put("android.foregroundService", hasForegroundServiceMicrophonePermission())
+        capabilities.put("android.assistantRole.available", assistantRoleAvailable)
+        capabilities.put("android.assistantRole.packageQualified", assistantRolePackageQualified)
+        capabilities.put("android.assistantRole.request", assistantRoleRequestable)
+        capabilities.put("android.assistantRole.held", assistantRoleHeld)
+        capabilities.put("android.assistantRole.denied", assistantRoleDenied)
+        capabilities.put("android.assistantRole.oemUnavailable", assistantRoleOemUnavailable)
+        capabilities.put("android.microphoneCapture", microphoneGranted)
+        capabilities.put("android.notifications", notificationsGranted)
+        capabilities.put("android.biometric", biometricReady)
+        capabilities.put("android.localNetwork", localNetworkReady)
+        capabilities.put("android.foregroundService", foregroundServiceReady)
+        capabilities.put("android.localFileRead", false)
+        capabilities.put("android.localFileWrite", false)
+        capabilities.put("android.filePick", false)
         capabilities.put("android.shareIntent", true)
         capabilities.put("android.deepLink", true)
         capabilities.put("android.fallbackEntrypoints", true)
+
+        val permissionStates = JSObject()
+        permissionStates.put("aurora.android.assistantRoleStatus", "available")
+        permissionStates.put("aurora.android.assistantRoleRequest", assistantRoleState(assistantRole))
+        permissionStates.put("aurora.android.microphone", permissionState(microphoneGranted))
+        permissionStates.put("aurora.android.notifications", permissionState(notificationsGranted))
+        permissionStates.put("aurora.android.biometric", if (biometricReady) "available" else "unsupported_platform")
+        permissionStates.put("aurora.android.localNetwork", if (localNetworkReady) "available" else "degraded")
+        permissionStates.put("aurora.android.foregroundServiceMicrophone", permissionState(foregroundServiceReady))
+        permissionStates.put("aurora.android.localFileRead", "degraded")
+        permissionStates.put("aurora.android.localFileWrite", "degraded")
+        permissionStates.put("aurora.android.filePick", "degraded")
+        permissionStates.put("aurora.android.shareIntent", "available")
+        permissionStates.put("aurora.android.deepLink", "available")
+
+        val capabilityStates = JSObject()
+        capabilityStates.put("android.assistantRole.status", "available")
+        capabilityStates.put("android.assistantRole.available", if (assistantRoleAvailable) "available" else "unsupported_platform")
+        capabilityStates.put("android.assistantRole.packageQualified", if (assistantRolePackageQualified) "available" else "degraded")
+        capabilityStates.put("android.assistantRole.request", assistantRoleState(assistantRole))
+        capabilityStates.put("android.assistantRole.held", if (assistantRoleHeld) "available" else "needs_native_permission")
+        capabilityStates.put("android.assistantRole.denied", if (assistantRoleDenied) "needs_native_permission" else "degraded")
+        capabilityStates.put("android.assistantRole.oemUnavailable", if (assistantRoleOemUnavailable) "unsupported_platform" else "degraded")
+        capabilityStates.put("android.microphoneCapture", permissionState(microphoneGranted))
+        capabilityStates.put("android.notifications", permissionState(notificationsGranted))
+        capabilityStates.put("android.biometric", if (biometricReady) "available" else "unsupported_platform")
+        capabilityStates.put("android.localNetwork", if (localNetworkReady) "available" else "degraded")
+        capabilityStates.put("android.foregroundService", permissionState(foregroundServiceReady))
+        capabilityStates.put("android.localFileRead", "degraded")
+        capabilityStates.put("android.localFileWrite", "degraded")
+        capabilityStates.put("android.filePick", "degraded")
+        capabilityStates.put("android.shareIntent", "available")
+        capabilityStates.put("android.deepLink", "available")
+        capabilityStates.put("android.fallbackEntrypoints", "fallback")
 
         val ret = JSObject()
         ret.put("platform", "android")
         ret.put("permissions", permissions)
         ret.put("capabilities", capabilities)
+        ret.put("permissionStates", permissionStates)
+        ret.put("capabilityStates", capabilityStates)
         ret.put("assistantRole", assistantRole)
         ret.put("fallbackEntrypoints", fallbackEntrypointsArray())
         ret.put("evidenceSource", "android-rolemanager-package-manager")
@@ -150,17 +214,29 @@ class AuroraNativePlugin(private val activity: Activity) : Plugin(activity) {
 
     private fun fallbackEntrypointsArray(): JSArray {
         val fallbacks = JSArray()
-        fallbacks.put(fallback("push_to_talk", "degraded", hasPermission(Manifest.permission.RECORD_AUDIO), "requires microphone permission and backend audio evidence"))
-        fallbacks.put(fallback("share_intent", "fallback", true, "available without assistant role"))
-        fallbacks.put(fallback("deep_link", "fallback", true, "available without assistant role"))
+        fallbacks.put(fallback("app_open", "fallback", true, "android.deepLink", null, "available without assistant role"))
+        fallbacks.put(fallback("push_to_talk", "degraded", hasRuntimePermission(Manifest.permission.RECORD_AUDIO), "android.microphoneCapture", "aurora.android.microphone", "requires microphone permission and backend audio evidence"))
+        fallbacks.put(fallback("notification", "fallback", hasPostNotificationsPermission(), "android.notifications", "aurora.android.notifications", "requires notification permission on Android 13+"))
+        fallbacks.put(fallback("quick_tile", "degraded", true, "android.fallbackEntrypoints", null, "planned Android quick tile entrypoint; not assistant-role dependent"))
+        fallbacks.put(fallback("share_intent", "fallback", true, "android.shareIntent", "aurora.android.shareIntent", "available without assistant role"))
+        fallbacks.put(fallback("deep_link", "fallback", true, "android.deepLink", "aurora.android.deepLink", "available without assistant role"))
         return fallbacks
     }
 
-    private fun fallback(id: String, state: String, available: Boolean, reason: String): JSObject {
+    private fun fallback(
+        id: String,
+        state: String,
+        available: Boolean,
+        capability: String,
+        permission: String?,
+        reason: String,
+    ): JSObject {
         val ret = JSObject()
         ret.put("id", id)
         ret.put("state", if (available) state else "needs_native_permission")
         ret.put("available", available)
+        ret.put("capability", capability)
+        ret.put("permission", permission)
         ret.put("reason", reason)
         return ret
     }
@@ -180,8 +256,11 @@ class AuroraNativePlugin(private val activity: Activity) : Plugin(activity) {
         }
     }
 
-    private fun hasPermission(permission: String): Boolean =
+    private fun hasRuntimePermission(permission: String): Boolean =
         ContextCompat.checkSelfPermission(activity, permission) == PackageManager.PERMISSION_GRANTED
+
+    private fun hasPackagePermission(permission: String): Boolean =
+        activity.packageManager.checkPermission(permission, activity.packageName) == PackageManager.PERMISSION_GRANTED
 
     private fun roleManagerOrNull(): RoleManager? =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -191,10 +270,29 @@ class AuroraNativePlugin(private val activity: Activity) : Plugin(activity) {
         }
 
     private fun hasPostNotificationsPermission(): Boolean =
-        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || hasPermission(Manifest.permission.POST_NOTIFICATIONS)
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || hasRuntimePermission(Manifest.permission.POST_NOTIFICATIONS)
 
     private fun hasForegroundServiceMicrophonePermission(): Boolean =
-        Build.VERSION.SDK_INT < 34 || hasPermission(Manifest.permission.FOREGROUND_SERVICE_MICROPHONE)
+        Build.VERSION.SDK_INT < 34 || hasRuntimePermission(Manifest.permission.FOREGROUND_SERVICE_MICROPHONE)
+
+    private fun hasBiometricCapability(): Boolean {
+        val keyguard = activity.getSystemService(KeyguardManager::class.java)
+        if (keyguard?.isDeviceSecure == true) return true
+        return activity.packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT) ||
+            activity.packageManager.hasSystemFeature(PackageManager.FEATURE_FACE) ||
+            activity.packageManager.hasSystemFeature(PackageManager.FEATURE_IRIS)
+    }
+
+    private fun permissionState(granted: Boolean): String =
+        if (granted) "available" else "needs_native_permission"
+
+    private fun assistantRoleState(status: JSObject): String {
+        if (status.getBoolean("roleHeld")) return "available"
+        if (status.getBoolean("requestable")) return "needs_native_permission"
+        if (status.getBoolean("oemUnavailable")) return "unsupported_platform"
+        if (status.getBoolean("denied")) return "needs_native_permission"
+        return "degraded"
+    }
 }
 
 class AssistantRoleResultArgs {

--- a/apps/aurora-tauri/src-tauri/src/lib.rs
+++ b/apps/aurora-tauri/src-tauri/src/lib.rs
@@ -507,14 +507,17 @@ async fn aurora_sidecar_status(
 }
 
 #[tauri::command]
-async fn aurora_native_capability_manifest() -> Result<NativeCapabilityManifest, AuroraCommandError>
-{
-    Ok(native_capability_manifest())
+async fn aurora_native_capability_manifest(
+    native: State<'_, AndroidNativePlugin<tauri::Wry>>,
+) -> Result<Value, AuroraCommandError> {
+    native_capability_manifest_value(native).await
 }
 
 #[tauri::command]
-async fn native_capabilities() -> Result<NativeCapabilityManifest, AuroraCommandError> {
-    Ok(native_capability_manifest())
+async fn native_capabilities(
+    native: State<'_, AndroidNativePlugin<tauri::Wry>>,
+) -> Result<Value, AuroraCommandError> {
+    native_capability_manifest_value(native).await
 }
 
 #[tauri::command]
@@ -638,6 +641,31 @@ async fn aurora_android_native_plugin_payload(
         Err(AuroraCommandError::UnsupportedFeature(
             "Aurora Android native plugin is only available in the Android Tauri shell".to_string(),
         ))
+    }
+}
+
+async fn native_capability_manifest_value(
+    native: State<'_, AndroidNativePlugin<tauri::Wry>>,
+) -> Result<Value, AuroraCommandError> {
+    #[cfg(target_os = "android")]
+    {
+        let handle = native.handle.as_ref().ok_or_else(|| {
+            AuroraCommandError::AndroidNativePlugin(
+                "Aurora Android native plugin handle was not registered".to_string(),
+            )
+        })?;
+        let payload = handle
+            .run_mobile_plugin::<Value>("nativeCapabilityManifest", json!({}))
+            .map_err(|error| AuroraCommandError::AndroidNativePlugin(error.to_string()))?;
+        log_android_native_plugin_payload(&payload);
+        Ok(payload)
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = native;
+        serde_json::to_value(native_capability_manifest())
+            .map_err(|_| AuroraCommandError::InvalidGatewayResponse)
     }
 }
 

--- a/apps/aurora-tauri/src-tauri/src/lib.rs
+++ b/apps/aurora-tauri/src-tauri/src/lib.rs
@@ -677,10 +677,46 @@ fn log_android_baseline_status(status: &AndroidBaselineStatus) {
 }
 
 fn log_android_native_plugin_payload(payload: &Value) {
+    const CHUNK_BYTES: usize = 900;
+
+    let serialized =
+        serde_json::to_string(payload).unwrap_or_else(|_| "{\"secretsRedacted\":true}".to_string());
+    let chunks = chunk_string_for_logcat(&serialized, CHUNK_BYTES);
     println!(
-        "aurora_android_native_plugin_payload={}",
-        serde_json::to_string(payload).unwrap_or_else(|_| "{\"secretsRedacted\":true}".to_string())
+        "aurora_android_native_plugin_payload_begin chunks={} bytes={}",
+        chunks.len(),
+        serialized.len()
     );
+    for (index, chunk) in chunks.iter().enumerate() {
+        println!(
+            "aurora_android_native_plugin_payload_chunk index={} total={} data={}",
+            index,
+            chunks.len(),
+            chunk
+        );
+    }
+    println!(
+        "aurora_android_native_plugin_payload_end chunks={}",
+        chunks.len()
+    );
+}
+
+fn chunk_string_for_logcat(value: &str, max_bytes: usize) -> Vec<&str> {
+    if value.is_empty() {
+        return vec![""];
+    }
+
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < value.len() {
+        let mut end = usize::min(start + max_bytes, value.len());
+        while !value.is_char_boundary(end) {
+            end -= 1;
+        }
+        chunks.push(&value[start..end]);
+        start = end;
+    }
+    chunks
 }
 
 #[tauri::command]

--- a/packages/aurora-sdk/src/capabilities.ts
+++ b/packages/aurora-sdk/src/capabilities.ts
@@ -1,5 +1,6 @@
 import { describeRegistry } from './descriptors.js'
 import type {
+  AndroidNativeState,
   AdminOverviewManifest,
   AdminOverviewManifestInput,
   AdminOverviewServiceSummary,
@@ -217,7 +218,7 @@ function nativeCapabilityState(manifest: NativeCapabilityManifest | null | undef
     availability: 'available-local',
     permissions: { ...manifest.permissions },
     capabilityKeys: Object.keys(manifest.capabilities).sort(),
-    evidenceSource: 'native-manifest'
+    evidenceSource: manifest.evidenceSource ?? 'native-manifest'
   }
 }
 
@@ -319,13 +320,11 @@ function candidatesFromNativeManifest(
   return [
     ...Object.entries(manifest.capabilities).map(([capability, enabled]) => {
       const featureId = `native:${manifest.platform}:${capability}`
+      const nativeState = manifest.capabilityStates?.[capability]
       const missingPermissions = nativeRequiredPermissions(capability, manifest.permissions)
         .filter((permission) => manifest.permissions[permission] === false)
-      const availability: AvailabilityState = enabled
-        ? missingPermissions.length > 0
-          ? 'privacy-blocked'
-          : 'available-local'
-        : 'unsupported'
+      const availability = availabilityForNativeState(nativeState, enabled, missingPermissions)
+      const disabledReasons = disabledReasonsForNativeState(nativeState, enabled, missingPermissions)
       return {
         id: `${featureId}@native:${manifest.platform}`,
         featureId,
@@ -343,17 +342,12 @@ function candidatesFromNativeManifest(
         selectable: availability === 'available-local',
         selected: false,
         trustTier: 'device',
-        routeability: enabled ? 'native-manifest' : 'disabled',
-        freshness: emptyFreshness('native-manifest'),
+        routeability: nativeState ?? (enabled ? 'native-manifest' : 'disabled'),
+        freshness: emptyFreshness(manifest.evidenceSource ?? 'native-manifest'),
         requiredPermissions: missingPermissions,
         privacyClass: nativePrivacyClass(capability),
-        disabledReasons: enabled ? missingPermissions.map((permission) => `native permission missing: ${permission}`) : ['native capability disabled'],
-        requiredAction:
-          availability === 'privacy-blocked'
-            ? 'grant required native permission'
-            : availability === 'unsupported'
-              ? 'enable native capability in manifest'
-              : null,
+        disabledReasons,
+        requiredAction: requiredActionForNativeState(nativeState, availability),
         selector: { platform: manifest.platform, capability },
         source: 'native-manifest',
         raw: null
@@ -398,6 +392,55 @@ function candidatesFromNativeManifest(
     .sort((a, b) => a.featureId.localeCompare(b.featureId))
 }
 
+function availabilityForNativeState(
+  state: AndroidNativeState | undefined,
+  enabled: boolean,
+  missingPermissions: string[]
+): AvailabilityState {
+  if (state === 'available') return missingPermissions.length > 0 ? 'privacy-blocked' : 'available-local'
+  if (state === 'needs_native_permission') return 'privacy-blocked'
+  if (state === 'degraded' || state === 'fallback') return 'degraded'
+  if (state === 'unsupported_platform') return 'unsupported'
+  return enabled
+    ? missingPermissions.length > 0
+      ? 'privacy-blocked'
+      : 'available-local'
+    : 'unsupported'
+}
+
+function disabledReasonsForNativeState(
+  state: AndroidNativeState | undefined,
+  enabled: boolean,
+  missingPermissions: string[]
+): string[] {
+  if (state === 'needs_native_permission') {
+    return missingPermissions.length > 0
+      ? missingPermissions.map((permission) => `native permission missing: ${permission}`)
+      : ['native permission missing']
+  }
+  if (state === 'degraded') return ['native capability degraded']
+  if (state === 'fallback') return ['native fallback path only']
+  if (state === 'unsupported_platform') return ['native platform unsupported']
+  return enabled
+    ? missingPermissions.map((permission) => `native permission missing: ${permission}`)
+    : ['native capability disabled']
+}
+
+function requiredActionForNativeState(
+  state: AndroidNativeState | undefined,
+  availability: AvailabilityState
+): string | null {
+  if (state === 'needs_native_permission' || availability === 'privacy-blocked') {
+    return 'grant required native permission'
+  }
+  if (state === 'degraded') return 'use the supported subset or complete native integration'
+  if (state === 'fallback') return 'use fallback entrypoint until primary native role is available'
+  if (state === 'unsupported_platform' || availability === 'unsupported') {
+    return 'do not claim this platform capability'
+  }
+  return null
+}
+
 function availabilityForNativeIntegration(support: NativeIntegrationSupport): AvailabilityState {
   if (support === 'supported') return 'available-local'
   if (support === 'supported-path') return 'degraded'
@@ -424,8 +467,11 @@ function nativeRequiredPermissions(capability: string, permissions: Record<strin
   if (normalized.includes('foregroundservice')) requestedTokens.push('foregroundservice')
   if (normalized.includes('shareintent')) requestedTokens.push('shareintent')
   if (normalized.includes('deeplink')) requestedTokens.push('deeplink')
+  if (normalized.includes('biometric')) requestedTokens.push('biometric')
+  if (normalized.includes('localnetwork')) requestedTokens.push('localnetwork')
   if (normalized.includes('securecredentialstorage')) requestedTokens.push('securestorage', 'credentialstorage')
   if (normalized.includes('securefilehandles')) requestedTokens.push('securefile')
+  if (normalized.includes('filepick')) requestedTokens.push('filepick', 'securefile')
   if (normalized.includes('localfileread')) requestedTokens.push('localfileread')
   if (normalized.includes('localfilewrite')) requestedTokens.push('localfilewrite')
   if (normalized.includes('dialog')) requestedTokens.push('dialog')

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -3051,20 +3051,68 @@ export const androidNativeCapabilityManifestFixture: NativeCapabilityManifest = 
     'aurora.android.assistantRoleRequest': false,
     'aurora.android.microphone': false,
     'aurora.android.notifications': false,
+    'aurora.android.biometric': false,
+    'aurora.android.localNetwork': true,
     'aurora.android.foregroundServiceMicrophone': false,
+    'aurora.android.localFileRead': false,
+    'aurora.android.localFileWrite': false,
+    'aurora.android.filePick': false,
     'aurora.android.shareIntent': true,
     'aurora.android.deepLink': true
   },
   capabilities: {
     'android.assistantRole.status': true,
+    'android.assistantRole.available': true,
+    'android.assistantRole.packageQualified': false,
     'android.assistantRole.request': false,
     'android.assistantRole.held': false,
+    'android.assistantRole.denied': false,
+    'android.assistantRole.oemUnavailable': false,
     'android.microphoneCapture': false,
     'android.notifications': false,
+    'android.biometric': false,
+    'android.localNetwork': true,
     'android.foregroundService': false,
+    'android.localFileRead': false,
+    'android.localFileWrite': false,
+    'android.filePick': false,
     'android.shareIntent': true,
     'android.deepLink': true,
     'android.fallbackEntrypoints': true
+  },
+  permissionStates: {
+    'aurora.android.assistantRoleStatus': 'available',
+    'aurora.android.assistantRoleRequest': 'degraded',
+    'aurora.android.microphone': 'needs_native_permission',
+    'aurora.android.notifications': 'needs_native_permission',
+    'aurora.android.biometric': 'unsupported_platform',
+    'aurora.android.localNetwork': 'available',
+    'aurora.android.foregroundServiceMicrophone': 'needs_native_permission',
+    'aurora.android.localFileRead': 'degraded',
+    'aurora.android.localFileWrite': 'degraded',
+    'aurora.android.filePick': 'degraded',
+    'aurora.android.shareIntent': 'available',
+    'aurora.android.deepLink': 'available'
+  },
+  capabilityStates: {
+    'android.assistantRole.status': 'available',
+    'android.assistantRole.available': 'available',
+    'android.assistantRole.packageQualified': 'degraded',
+    'android.assistantRole.request': 'degraded',
+    'android.assistantRole.held': 'needs_native_permission',
+    'android.assistantRole.denied': 'available',
+    'android.assistantRole.oemUnavailable': 'available',
+    'android.microphoneCapture': 'needs_native_permission',
+    'android.notifications': 'needs_native_permission',
+    'android.biometric': 'unsupported_platform',
+    'android.localNetwork': 'available',
+    'android.foregroundService': 'needs_native_permission',
+    'android.localFileRead': 'degraded',
+    'android.localFileWrite': 'degraded',
+    'android.filePick': 'degraded',
+    'android.shareIntent': 'available',
+    'android.deepLink': 'available',
+    'android.fallbackEntrypoints': 'fallback'
   },
   assistantRole: {
     platform: 'android',
@@ -3082,21 +3130,51 @@ export const androidNativeCapabilityManifestFixture: NativeCapabilityManifest = 
   },
   fallbackEntrypoints: [
     {
+      id: 'app_open',
+      state: 'fallback',
+      available: true,
+      capability: 'android.deepLink',
+      permission: null,
+      reason: 'available without assistant role'
+    },
+    {
       id: 'push_to_talk',
       state: 'needs_native_permission',
       available: false,
+      capability: 'android.microphoneCapture',
+      permission: 'aurora.android.microphone',
       reason: 'requires microphone permission and backend audio evidence'
+    },
+    {
+      id: 'notification',
+      state: 'needs_native_permission',
+      available: false,
+      capability: 'android.notifications',
+      permission: 'aurora.android.notifications',
+      reason: 'requires notification permission on Android 13+'
+    },
+    {
+      id: 'quick_tile',
+      state: 'degraded',
+      available: true,
+      capability: 'android.fallbackEntrypoints',
+      permission: null,
+      reason: 'planned Android quick tile entrypoint; not assistant-role dependent'
     },
     {
       id: 'share_intent',
       state: 'fallback',
       available: true,
+      capability: 'android.shareIntent',
+      permission: 'aurora.android.shareIntent',
       reason: 'available without assistant role'
     },
     {
       id: 'deep_link',
       state: 'fallback',
       available: true,
+      capability: 'android.deepLink',
+      permission: 'aurora.android.deepLink',
       reason: 'available without assistant role'
     }
   ],

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -1561,6 +1561,8 @@ export interface NativeCapabilityManifest {
   platform: 'tauri-desktop' | 'android' | 'ios' | string
   permissions: Record<string, boolean>
   capabilities: Record<string, boolean>
+  permissionStates?: Record<string, AndroidNativeState>
+  capabilityStates?: Record<string, AndroidNativeState>
   mobileIntegrations?: NativeMobileIntegration[]
   platformLimitations?: NativePlatformLimitation[]
   assistantRole?: AndroidAssistantRoleStatus | null
@@ -1627,4 +1629,6 @@ export interface AndroidFallbackEntrypoint {
   state: AndroidNativeState
   available: boolean
   reason: string
+  capability?: string
+  permission?: string | null
 }

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -585,13 +585,34 @@ describe('AuroraClient', () => {
     )
     expect(graph.byFeatureId['native:android:android.assistantRole.request']).toEqual(
       expect.objectContaining({
-        availability: 'unsupported'
+        availability: 'degraded',
+        providers: expect.arrayContaining([expect.objectContaining({ routeability: 'degraded' })])
       })
     )
     expect(graph.byFeatureId['native:android:android.microphoneCapture']).toEqual(
       expect.objectContaining({
+        availability: 'privacy-blocked',
+        privacyClass: 'raw-audio',
+        requiredPermissions: expect.arrayContaining(['aurora.android.microphone']),
+        providers: expect.arrayContaining([expect.objectContaining({ routeability: 'needs_native_permission' })])
+      })
+    )
+    expect(graph.byFeatureId['native:android:android.notifications']).toEqual(
+      expect.objectContaining({
+        availability: 'privacy-blocked',
+        providers: expect.arrayContaining([expect.objectContaining({ routeability: 'needs_native_permission' })])
+      })
+    )
+    expect(graph.byFeatureId['native:android:android.biometric']).toEqual(
+      expect.objectContaining({
         availability: 'unsupported',
-        privacyClass: 'raw-audio'
+        providers: expect.arrayContaining([expect.objectContaining({ routeability: 'unsupported_platform' })])
+      })
+    )
+    expect(graph.byFeatureId['native:android:android.localFileRead']).toEqual(
+      expect.objectContaining({
+        availability: 'degraded',
+        providers: expect.arrayContaining([expect.objectContaining({ routeability: 'degraded' })])
       })
     )
     expect(graph.byFeatureId['native:android:android.shareIntent']).toEqual(
@@ -602,7 +623,8 @@ describe('AuroraClient', () => {
     )
     expect(graph.byFeatureId['native:android:android.fallbackEntrypoints']).toEqual(
       expect.objectContaining({
-        availability: 'available-local'
+        availability: 'degraded',
+        providers: expect.arrayContaining([expect.objectContaining({ routeability: 'fallback' })])
       })
     )
   })
@@ -2578,7 +2600,25 @@ describe('AuroraClient', () => {
           oemUnavailable: false,
           reason: 'package_not_qualified'
         }),
+        permissionStates: expect.objectContaining({
+          'aurora.android.microphone': 'needs_native_permission',
+          'aurora.android.notifications': 'needs_native_permission',
+          'aurora.android.biometric': 'unsupported_platform',
+          'aurora.android.localNetwork': 'available',
+          'aurora.android.filePick': 'degraded',
+          'aurora.android.shareIntent': 'available'
+        }),
+        capabilityStates: expect.objectContaining({
+          'android.assistantRole.packageQualified': 'degraded',
+          'android.assistantRole.held': 'needs_native_permission',
+          'android.foregroundService': 'needs_native_permission',
+          'android.localFileRead': 'degraded',
+          'android.fallbackEntrypoints': 'fallback'
+        }),
         fallbackEntrypoints: expect.arrayContaining([
+          expect.objectContaining({ id: 'app_open', state: 'fallback', available: true }),
+          expect.objectContaining({ id: 'notification', state: 'needs_native_permission', available: false }),
+          expect.objectContaining({ id: 'quick_tile', state: 'degraded', available: true }),
           expect.objectContaining({ id: 'share_intent', state: 'fallback', available: true })
         ])
       })
@@ -2602,6 +2642,7 @@ describe('AuroraClient', () => {
     await expect(transport.getAndroidFallbackEntrypoints()).resolves.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'push_to_talk', state: 'needs_native_permission', available: false }),
+        expect.objectContaining({ id: 'notification', state: 'needs_native_permission', available: false }),
         expect.objectContaining({ id: 'share_intent', state: 'fallback', available: true })
       ])
     )

--- a/packages/aurora-ui/src/settings-permissions-view.tsx
+++ b/packages/aurora-ui/src/settings-permissions-view.tsx
@@ -325,11 +325,8 @@ function nativePermissionCards(
     const capability = snapshot.nativeCapabilities.find((candidate) => candidate.name === name)
     const granted = permission?.granted ?? false
     const capabilityEnabled = capability?.enabled ?? granted
-    const state: AvailabilityState = granted && capabilityEnabled
-      ? 'available-local'
-      : snapshot.nativeAvailable
-        ? 'privacy-blocked'
-        : 'unsupported'
+    const nativeState = capability?.nativeState ?? permission?.nativeState ?? null
+    const state = availabilityFromNativeState(nativeState, granted, capabilityEnabled, snapshot.nativeAvailable)
     return {
       id: name,
       label: nativePermissionLabel(name),
@@ -339,11 +336,28 @@ function nativePermissionCards(
       requestEnabled: false,
       detail: granted
         ? 'Native manifest reports this permission as granted.'
-        : 'Permission request is disabled until a native request command is advertised by the SDK/native manifest.',
-      blockers: granted ? [] : [`native permission missing: ${name}`],
+        : nativeState === 'degraded'
+          ? 'Native manifest reports a degraded or partial platform path for this feature.'
+          : nativeState === 'fallback'
+            ? 'Native manifest reports this as a fallback entrypoint instead of primary capability.'
+            : 'Permission request is disabled until a native request command is advertised by the SDK/native manifest.',
+      blockers: granted || nativeState === 'fallback' ? [] : [`native permission missing: ${name}`],
       evidence: nativeRoute?.evidenceSources ?? (snapshot.nativeAvailable ? ['native-manifest'] : [])
     }
   })
+}
+
+function availabilityFromNativeState(
+  nativeState: string | null,
+  granted: boolean,
+  capabilityEnabled: boolean,
+  nativeAvailable: boolean
+): AvailabilityState {
+  if (!nativeAvailable || nativeState === 'unsupported_platform') return 'unsupported'
+  if (nativeState === 'available') return granted && capabilityEnabled ? 'available-local' : 'privacy-blocked'
+  if (nativeState === 'needs_native_permission') return 'privacy-blocked'
+  if (nativeState === 'degraded' || nativeState === 'fallback') return 'degraded'
+  return granted && capabilityEnabled ? 'available-local' : 'privacy-blocked'
 }
 
 function routeById(snapshot: AuroraShellSnapshot, id: string): RouteAvailability | null {

--- a/packages/aurora-ui/src/shell-data.ts
+++ b/packages/aurora-ui/src/shell-data.ts
@@ -64,8 +64,8 @@ export interface AuroraShellSnapshot {
   blockedCount: number
   nativePlatform: string
   nativeAvailable: boolean
-  nativePermissions: Array<{ name: string; granted: boolean }>
-  nativeCapabilities: Array<{ name: string; enabled: boolean }>
+  nativePermissions: Array<{ name: string; granted: boolean; nativeState: string | null }>
+  nativeCapabilities: Array<{ name: string; enabled: boolean; nativeState: string | null }>
   routes: RouteAvailability[]
   assistantCancellationRoute: RouteAvailability | null
   assistantVoiceRoutes: AssistantVoiceRoutes
@@ -140,8 +140,8 @@ export function snapshotFromGraph(
     blockedCount: routes.filter((route) => route.disabled).length,
     nativePlatform: native?.platform ?? 'not available',
     nativeAvailable: native !== null,
-    nativePermissions: nativePermissionEntries(native?.permissions),
-    nativeCapabilities: nativeCapabilityEntries(native?.capabilities),
+    nativePermissions: nativePermissionEntries(native?.permissions, native?.permissionStates),
+    nativeCapabilities: nativeCapabilityEntries(native?.capabilities, native?.capabilityStates),
     routes,
     assistantCancellationRoute,
     assistantVoiceRoutes,
@@ -462,16 +462,22 @@ function sortedUnique(values: Array<string | null | undefined>): string[] {
   return [...new Set(values.filter((value): value is string => Boolean(value)))].sort()
 }
 
-function nativePermissionEntries(values: Record<string, boolean> | undefined): Array<{ name: string; granted: boolean }> {
+function nativePermissionEntries(
+  values: Record<string, boolean> | undefined,
+  states: Record<string, string> | undefined
+): Array<{ name: string; granted: boolean; nativeState: string | null }> {
   return Object.entries(values ?? {})
     .sort(([left], [right]) => left.localeCompare(right))
-    .map(([name, granted]) => ({ name, granted }))
+    .map(([name, granted]) => ({ name, granted, nativeState: states?.[name] ?? null }))
 }
 
-function nativeCapabilityEntries(values: Record<string, boolean> | undefined): Array<{ name: string; enabled: boolean }> {
+function nativeCapabilityEntries(
+  values: Record<string, boolean> | undefined,
+  states: Record<string, string> | undefined
+): Array<{ name: string; enabled: boolean; nativeState: string | null }> {
   return Object.entries(values ?? {})
     .sort(([left], [right]) => left.localeCompare(right))
-    .map(([name, enabled]) => ({ name, enabled }))
+    .map(([name, enabled]) => ({ name, enabled, nativeState: states?.[name] ?? null }))
 }
 
 function nullToPending(value: string | null): string {


### PR DESCRIPTION
## Summary
- expands the Android native plugin manifest to report assistant-role, mic, notifications, biometric, local-network, foreground-service, file, share, deep-link, and fallback states
- routes Android Native.GetCapabilityManifest through the Kotlin Tauri plugin on Android instead of the Rust desktop baseline
- teaches the SDK capability graph and settings permissions UI to consume explicit Android native states

## Validation
- pnpm --filter @aurora/client test
- pnpm --filter @aurora/client typecheck
- pnpm --filter @aurora/ui test
- pnpm --filter @aurora/ui typecheck
- pnpm --filter @aurora/tauri-ui typecheck
- cargo fmt --check (apps/aurora-tauri/src-tauri)
- git diff --check

## Android follow-up
- cargo check is blocked in this environment by missing glib-2.0/gobject-2.0 pkg-config system dependencies.
- Android build/emulator smoke is blocked because the generated Tauri Android project is not initialized and JAVA_HOME/java are unavailable.