### PR TITLE
PER-208 Implement iOS App Intents invocation metadata

### DIFF
--- a/.github/scripts/ios_app_intent_smoke.swift
+++ b/.github/scripts/ios_app_intent_smoke.swift
@@ -1,0 +1,29 @@
+import AppIntents
+import Foundation
+
+@available(iOS 16.0, macOS 13.0, *)
+@main
+struct AuroraAppIntentSmoke {
+  static func main() async throws {
+    var intent = AskAuroraIntent()
+    intent.prompt = "CI App Intent smoke"
+    let handoff = intent.makeHandoff()
+    _ = try await intent.perform()
+
+    precondition(handoff.action == "askAuroraAppIntent")
+    precondition(handoff.backendMethod == "Orchestrator.ExternalUserInput")
+    precondition(handoff.invocation == "app-intent")
+    precondition(handoff.privacyClass == "personal")
+    precondition(handoff.requiresConfirmation == false)
+    precondition(handoff.siriReplacement == false)
+    precondition(handoff.correlationId.isEmpty == false)
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(handoff)
+    guard let json = String(data: data, encoding: .utf8) else {
+      throw CocoaError(.fileWriteInapplicableStringEncoding)
+    }
+    print(json)
+  }
+}

--- a/.github/workflows/tauri-ios.yml
+++ b/.github/workflows/tauri-ios.yml
@@ -68,3 +68,23 @@ jobs:
           CODE_SIGNING_ALLOWED: "NO"
           CODE_SIGNING_REQUIRED: "NO"
         run: pnpm --filter @aurora/tauri-ui tauri ios build --target aarch64-sim --config src-tauri/tauri.ios.conf.json
+
+      - name: Smoke invoke Aurora App Intent handoff
+        run: |
+          xcrun swiftc \
+            -parse-as-library \
+            apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/Sources/AuroraNativePlugin/AuroraAppIntents.swift \
+            .github/scripts/ios_app_intent_smoke.swift \
+            -o /tmp/aurora-ios-app-intent-smoke
+          /tmp/aurora-ios-app-intent-smoke | tee /tmp/aurora-ios-app-intent-smoke.json
+          grep '"action":"askAuroraAppIntent"' /tmp/aurora-ios-app-intent-smoke.json
+          grep '"backendMethod":"Orchestrator.ExternalUserInput"' /tmp/aurora-ios-app-intent-smoke.json
+          grep '"invocation":"app-intent"' /tmp/aurora-ios-app-intent-smoke.json
+          grep '"privacyClass":"personal"' /tmp/aurora-ios-app-intent-smoke.json
+          grep '"siriReplacement":false' /tmp/aurora-ios-app-intent-smoke.json
+
+      - name: Upload Aurora App Intent smoke artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aurora-ios-app-intent-smoke
+          path: /tmp/aurora-ios-app-intent-smoke.json

--- a/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/README.md
+++ b/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/README.md
@@ -9,3 +9,15 @@ Current commands:
 - `nativeCapabilityManifest` returns the iOS native capability/permission manifest.
 - `invocationStatus` reports the allowed invocation surface and explicitly sets `siriReplacement` to `false`.
 - `invokeAuroraAction` accepts concrete Aurora action IDs and hands off to the SDK/backend boundary instead of duplicating orchestrator logic in Swift.
+
+Current App Intents/Shortcuts surfaces:
+
+- `AuroraAppIntents.swift` declares `AskAuroraIntent`, `AskAuroraShortcutIntent`, `SummarizeSharedContentIntent`, and `StopAuroraSpeechIntent`.
+- `AuroraAppShortcuts` registers app-owned shortcut phrases for those intents.
+- Intent results return `AuroraIntentHandoff` entities containing the Aurora action ID, backend method, invocation surface, privacy class, confirmation requirement, generated correlation ID, and `siriReplacement: false`.
+
+Required native verification remains macOS/Xcode-only:
+
+- `tauri ios build` or Xcode build of the generated iOS project with this package linked.
+- Simulator or device invocation of at least one App Intent or Shortcut.
+- Evidence that the handoff reaches the AuroraClient/backend boundary with correlation/provenance preserved.

--- a/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/Sources/AuroraNativePlugin/AuroraAppIntents.swift
+++ b/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/Sources/AuroraNativePlugin/AuroraAppIntents.swift
@@ -1,0 +1,220 @@
+import AppIntents
+import Foundation
+
+@available(iOS 16.0, *)
+public struct AuroraIntentHandoff: AppEntity {
+  public static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Aurora handoff")
+  public static var defaultQuery = AuroraIntentHandoffQuery()
+
+  public let id: String
+  public let action: String
+  public let backendMethod: String
+  public let invocation: String
+  public let privacyClass: String
+  public let requiresConfirmation: Bool
+  public let siriReplacement: Bool
+  public let correlationId: String
+
+  public var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(
+      title: "\(action)",
+      subtitle: "\(backendMethod) / \(correlationId)"
+    )
+  }
+}
+
+@available(iOS 16.0, *)
+public struct AuroraIntentHandoffQuery: EntityQuery {
+  public init() {}
+
+  public func entities(for identifiers: [AuroraIntentHandoff.ID]) async throws -> [AuroraIntentHandoff] {
+    identifiers.map { identifier in
+      AuroraIntentHandoff(
+        id: identifier,
+        action: "unknown",
+        backendMethod: "AuroraClient",
+        invocation: "app-intent",
+        privacyClass: "personal",
+        requiresConfirmation: false,
+        siriReplacement: false,
+        correlationId: identifier
+      )
+    }
+  }
+
+  public func suggestedEntities() async throws -> [AuroraIntentHandoff] {
+    []
+  }
+}
+
+@available(iOS 16.0, *)
+public enum AuroraIntentHandoffFactory {
+  public static func make(
+    action: String,
+    backendMethod: String,
+    invocation: String,
+    privacyClass: String,
+    requiresConfirmation: Bool,
+    prompt: String? = nil
+  ) -> AuroraIntentHandoff {
+    let correlationId = UUID().uuidString
+    let normalizedPrompt = prompt?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let handoffId = [action, correlationId].joined(separator: ":")
+    return AuroraIntentHandoff(
+      id: handoffId,
+      action: action,
+      backendMethod: backendMethod,
+      invocation: invocation,
+      privacyClass: privacyClass,
+      requiresConfirmation: requiresConfirmation,
+      siriReplacement: false,
+      correlationId: normalizedPrompt?.isEmpty == false ? "\(correlationId):prompt" : correlationId
+    )
+  }
+}
+
+@available(iOS 16.0, *)
+public struct AskAuroraIntent: AppIntent {
+  public static var title: LocalizedStringResource = "Ask Aurora"
+  public static var description = IntentDescription("Send an app-owned prompt handoff to Aurora.")
+  public static var openAppWhenRun = true
+
+  @Parameter(title: "Prompt", description: "Prompt to hand off to Aurora.")
+  public var prompt: String?
+
+  public init() {}
+
+  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
+    let handoff = AuroraIntentHandoffFactory.make(
+      action: "askAuroraAppIntent",
+      backendMethod: "Orchestrator.ExternalUserInput",
+      invocation: "app-intent",
+      privacyClass: "personal",
+      requiresConfirmation: false,
+      prompt: prompt
+    )
+    return .result(
+      value: handoff,
+      dialog: IntentDialog("Aurora handoff prepared for Orchestrator.")
+    )
+  }
+}
+
+@available(iOS 16.0, *)
+public struct AskAuroraShortcutIntent: AppIntent {
+  public static var title: LocalizedStringResource = "Ask Aurora Shortcut"
+  public static var description = IntentDescription("Open Aurora from a Shortcut and preserve backend handoff metadata.")
+  public static var openAppWhenRun = true
+
+  @Parameter(title: "Prompt", description: "Prompt to hand off to Aurora.")
+  public var prompt: String?
+
+  public init() {}
+
+  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
+    let handoff = AuroraIntentHandoffFactory.make(
+      action: "askAuroraShortcut",
+      backendMethod: "Orchestrator.ExternalUserInput",
+      invocation: "shortcut",
+      privacyClass: "personal",
+      requiresConfirmation: false,
+      prompt: prompt
+    )
+    return .result(
+      value: handoff,
+      dialog: IntentDialog("Aurora shortcut handoff prepared.")
+    )
+  }
+}
+
+@available(iOS 16.0, *)
+public struct SummarizeSharedContentIntent: AppIntent {
+  public static var title: LocalizedStringResource = "Summarize shared content"
+  public static var description = IntentDescription("Hand shared text to Aurora with sensitive-data confirmation.")
+  public static var openAppWhenRun = true
+
+  @Parameter(title: "Shared text", description: "Text selected by the user for Aurora to summarize.")
+  public var sharedText: String?
+
+  public init() {}
+
+  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
+    let handoff = AuroraIntentHandoffFactory.make(
+      action: "summarizeSharedContentShortcut",
+      backendMethod: "Orchestrator.IngestContext",
+      invocation: "shortcut",
+      privacyClass: "sensitive",
+      requiresConfirmation: true,
+      prompt: sharedText
+    )
+    return .result(
+      value: handoff,
+      dialog: IntentDialog("Aurora shared-content handoff prepared.")
+    )
+  }
+}
+
+@available(iOS 16.0, *)
+public struct StopAuroraSpeechIntent: AppIntent {
+  public static var title: LocalizedStringResource = "Stop Aurora speech"
+  public static var description = IntentDescription("Stop Aurora-owned playback without controlling Siri or system assistant audio.")
+  public static var openAppWhenRun = true
+
+  public init() {}
+
+  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
+    let handoff = AuroraIntentHandoffFactory.make(
+      action: "stopAuroraSpeechAppIntent",
+      backendMethod: "TTS.Stop",
+      invocation: "app-intent",
+      privacyClass: "personal",
+      requiresConfirmation: false
+    )
+    return .result(
+      value: handoff,
+      dialog: IntentDialog("Aurora speech stop handoff prepared.")
+    )
+  }
+}
+
+@available(iOS 16.0, *)
+public struct AuroraAppShortcuts: AppShortcutsProvider {
+  public static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: AskAuroraIntent(),
+      phrases: [
+        "Ask \(.applicationName)",
+        "Ask \(.applicationName) with \(\.$prompt)"
+      ],
+      shortTitle: "Ask Aurora",
+      systemImageName: "sparkles"
+    )
+    AppShortcut(
+      intent: AskAuroraShortcutIntent(),
+      phrases: [
+        "Open \(.applicationName)",
+        "Ask \(.applicationName) shortcut"
+      ],
+      shortTitle: "Ask Aurora Shortcut",
+      systemImageName: "bubble.left.and.text.bubble.right"
+    )
+    AppShortcut(
+      intent: SummarizeSharedContentIntent(),
+      phrases: [
+        "Summarize with \(.applicationName)",
+        "Summarize \(\.$sharedText) with \(.applicationName)"
+      ],
+      shortTitle: "Summarize",
+      systemImageName: "doc.text.magnifyingglass"
+    )
+    AppShortcut(
+      intent: StopAuroraSpeechIntent(),
+      phrases: [
+        "Stop \(.applicationName) speech",
+        "Stop \(.applicationName)"
+      ],
+      shortTitle: "Stop speech",
+      systemImageName: "speaker.slash"
+    )
+  }
+}

--- a/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/Sources/AuroraNativePlugin/AuroraAppIntents.swift
+++ b/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/Sources/AuroraNativePlugin/AuroraAppIntents.swift
@@ -1,8 +1,8 @@
 import AppIntents
 import Foundation
 
-@available(iOS 16.0, *)
-public struct AuroraIntentHandoff: AppEntity {
+@available(iOS 16.0, macOS 13.0, *)
+public struct AuroraIntentHandoff: AppEntity, Encodable {
   public static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Aurora handoff")
   public static var defaultQuery = AuroraIntentHandoffQuery()
 
@@ -23,7 +23,7 @@ public struct AuroraIntentHandoff: AppEntity {
   }
 }
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 public struct AuroraIntentHandoffQuery: EntityQuery {
   public init() {}
 
@@ -47,7 +47,7 @@ public struct AuroraIntentHandoffQuery: EntityQuery {
   }
 }
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 public enum AuroraIntentHandoffFactory {
   public static func make(
     action: String,
@@ -73,7 +73,7 @@ public enum AuroraIntentHandoffFactory {
   }
 }
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 public struct AskAuroraIntent: AppIntent {
   public static var title: LocalizedStringResource = "Ask Aurora"
   public static var description = IntentDescription("Send an app-owned prompt handoff to Aurora.")
@@ -84,8 +84,8 @@ public struct AskAuroraIntent: AppIntent {
 
   public init() {}
 
-  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
-    let handoff = AuroraIntentHandoffFactory.make(
+  public func makeHandoff() -> AuroraIntentHandoff {
+    AuroraIntentHandoffFactory.make(
       action: "askAuroraAppIntent",
       backendMethod: "Orchestrator.ExternalUserInput",
       invocation: "app-intent",
@@ -93,6 +93,10 @@ public struct AskAuroraIntent: AppIntent {
       requiresConfirmation: false,
       prompt: prompt
     )
+  }
+
+  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
+    let handoff = makeHandoff()
     return .result(
       value: handoff,
       dialog: IntentDialog("Aurora handoff prepared for Orchestrator.")
@@ -100,7 +104,7 @@ public struct AskAuroraIntent: AppIntent {
   }
 }
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 public struct AskAuroraShortcutIntent: AppIntent {
   public static var title: LocalizedStringResource = "Ask Aurora Shortcut"
   public static var description = IntentDescription("Open Aurora from a Shortcut and preserve backend handoff metadata.")
@@ -111,8 +115,8 @@ public struct AskAuroraShortcutIntent: AppIntent {
 
   public init() {}
 
-  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
-    let handoff = AuroraIntentHandoffFactory.make(
+  public func makeHandoff() -> AuroraIntentHandoff {
+    AuroraIntentHandoffFactory.make(
       action: "askAuroraShortcut",
       backendMethod: "Orchestrator.ExternalUserInput",
       invocation: "shortcut",
@@ -120,6 +124,10 @@ public struct AskAuroraShortcutIntent: AppIntent {
       requiresConfirmation: false,
       prompt: prompt
     )
+  }
+
+  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
+    let handoff = makeHandoff()
     return .result(
       value: handoff,
       dialog: IntentDialog("Aurora shortcut handoff prepared.")
@@ -127,7 +135,7 @@ public struct AskAuroraShortcutIntent: AppIntent {
   }
 }
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 public struct SummarizeSharedContentIntent: AppIntent {
   public static var title: LocalizedStringResource = "Summarize shared content"
   public static var description = IntentDescription("Hand shared text to Aurora with sensitive-data confirmation.")
@@ -138,8 +146,8 @@ public struct SummarizeSharedContentIntent: AppIntent {
 
   public init() {}
 
-  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
-    let handoff = AuroraIntentHandoffFactory.make(
+  public func makeHandoff() -> AuroraIntentHandoff {
+    AuroraIntentHandoffFactory.make(
       action: "summarizeSharedContentShortcut",
       backendMethod: "Orchestrator.IngestContext",
       invocation: "shortcut",
@@ -147,6 +155,10 @@ public struct SummarizeSharedContentIntent: AppIntent {
       requiresConfirmation: true,
       prompt: sharedText
     )
+  }
+
+  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
+    let handoff = makeHandoff()
     return .result(
       value: handoff,
       dialog: IntentDialog("Aurora shared-content handoff prepared.")
@@ -154,7 +166,7 @@ public struct SummarizeSharedContentIntent: AppIntent {
   }
 }
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 public struct StopAuroraSpeechIntent: AppIntent {
   public static var title: LocalizedStringResource = "Stop Aurora speech"
   public static var description = IntentDescription("Stop Aurora-owned playback without controlling Siri or system assistant audio.")
@@ -162,14 +174,18 @@ public struct StopAuroraSpeechIntent: AppIntent {
 
   public init() {}
 
-  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
-    let handoff = AuroraIntentHandoffFactory.make(
+  public func makeHandoff() -> AuroraIntentHandoff {
+    AuroraIntentHandoffFactory.make(
       action: "stopAuroraSpeechAppIntent",
       backendMethod: "TTS.Stop",
       invocation: "app-intent",
       privacyClass: "personal",
       requiresConfirmation: false
     )
+  }
+
+  public func perform() async throws -> some IntentResult & ReturnsValue<AuroraIntentHandoff> {
+    let handoff = makeHandoff()
     return .result(
       value: handoff,
       dialog: IntentDialog("Aurora speech stop handoff prepared.")
@@ -177,7 +193,7 @@ public struct StopAuroraSpeechIntent: AppIntent {
   }
 }
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 public struct AuroraAppShortcuts: AppShortcutsProvider {
   public static var appShortcuts: [AppShortcut] {
     AppShortcut(

--- a/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/Sources/AuroraNativePlugin/AuroraNativePlugin.swift
+++ b/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/Sources/AuroraNativePlugin/AuroraNativePlugin.swift
@@ -14,11 +14,85 @@ struct AuroraInvocationRequest: Decodable {
 
 @objc(AuroraNativePlugin)
 public final class AuroraNativePlugin: Plugin {
-  private let supportedActions = [
-    "app-intent.open-assistant",
-    "shortcut.open-assistant",
-    "share.import-context",
-    "deeplink.open"
+  private let mobileIntegrations: [[String: Any]] = [
+    [
+      "platform": "ios",
+      "id": "askAuroraAppIntent",
+      "label": "Ask Aurora",
+      "support": "supported-path",
+      "capability": "ios.appIntents",
+      "permission": "aurora.iosAppIntents",
+      "invocation": "app-intent",
+      "backendMethod": "Orchestrator.ExternalUserInput",
+      "privacyClass": "personal",
+      "requiresConfirmation": false,
+      "siriReplacement": false,
+      "evidenceSource": "IOS-003 native plugin manifest",
+      "userCopy": "Runs as an app-owned Siri/Shortcuts/App Intents integration and does not replace Siri.",
+      "verifier": "tauri ios build plus simulator/device App Intent invocation on macOS/Xcode"
+    ],
+    [
+      "platform": "ios",
+      "id": "askAuroraShortcut",
+      "label": "Ask Aurora Shortcut",
+      "support": "supported-path",
+      "capability": "ios.shortcuts",
+      "permission": "aurora.iosShortcuts",
+      "invocation": "shortcut",
+      "backendMethod": "Orchestrator.ExternalUserInput",
+      "privacyClass": "personal",
+      "requiresConfirmation": false,
+      "siriReplacement": false,
+      "evidenceSource": "IOS-003 native plugin manifest",
+      "userCopy": "Shortcut invocation hands off to AuroraClient/backend evidence before executing assistant work.",
+      "verifier": "simulator/device Shortcut invocation through the Xcode-managed iOS target"
+    ],
+    [
+      "platform": "ios",
+      "id": "summarizeSharedContentShortcut",
+      "label": "Summarize shared content",
+      "support": "supported-path",
+      "capability": "ios.shortcuts",
+      "permission": "aurora.iosShortcuts",
+      "invocation": "shortcut",
+      "backendMethod": "Orchestrator.IngestContext",
+      "privacyClass": "sensitive",
+      "requiresConfirmation": true,
+      "siriReplacement": false,
+      "evidenceSource": "IOS-003 native plugin manifest",
+      "userCopy": "Requires explicit user invocation and backend route/privacy evidence before sending shared content.",
+      "verifier": "simulator/device Shortcut or share handoff smoke with backend correlation evidence"
+    ],
+    [
+      "platform": "ios",
+      "id": "stopAuroraSpeechAppIntent",
+      "label": "Stop Aurora speech",
+      "support": "supported-path",
+      "capability": "ios.appIntents",
+      "permission": "aurora.iosAppIntents",
+      "invocation": "app-intent",
+      "backendMethod": "TTS.Stop",
+      "privacyClass": "personal",
+      "requiresConfirmation": false,
+      "siriReplacement": false,
+      "evidenceSource": "IOS-003 native plugin manifest",
+      "userCopy": "Controls Aurora-owned playback only; it cannot control Siri or system assistant audio.",
+      "verifier": "simulator/device App Intent invocation with TTS stop route evidence"
+    ],
+    [
+      "platform": "ios",
+      "id": "siriReplacement",
+      "label": "Siri replacement",
+      "support": "unsupported",
+      "capability": "ios.siriReplacement",
+      "permission": NSNull(),
+      "privacyClass": "public",
+      "requiresConfirmation": false,
+      "siriReplacement": false,
+      "evidenceSource": "Apple-platform-policy",
+      "userCopy": "iOS does not allow Aurora to replace Siri as the default assistant.",
+      "verifier": "copy and capability review; no executable route should be exposed"
+    ]
   ]
 
   @objc public func nativeCapabilityManifest(_ invoke: Invoke) throws {
@@ -43,15 +117,41 @@ public final class AuroraNativePlugin: Plugin {
         "ios.siriReplacement": false,
         "native.audioCapture": false,
         "native.audioPlayback": false
-      ]
+      ],
+      "mobileIntegrations": mobileIntegrations,
+      "platformLimitations": [
+        [
+          "platform": "ios",
+          "id": "noSiriReplacement",
+          "label": "No Siri replacement",
+          "reason": "Apple permits app-owned App Intents, Shortcuts, widgets, share extensions, and deep links, not replacing Siri as the system assistant.",
+          "userCopy": "Use Siri/Shortcuts/App Intents integration; do not claim Aurora replaces Siri.",
+          "evidenceSource": "Apple App Intents and SiriKit extension documentation"
+        ],
+        [
+          "platform": "ios",
+          "id": "foregroundConsentRequired",
+          "label": "Foreground consent required",
+          "reason": "Always-on background assistant capture is unavailable on iOS without explicit app-owned foreground consent.",
+          "userCopy": "Audio and shared-content actions require app-owned user invocation and backend privacy evidence.",
+          "evidenceSource": "Apple App Intents, extensions, and privacy review requirements"
+        ]
+      ],
+      "evidenceSource": "IOS-003 native plugin manifest",
+      "secretsRedacted": true
     ])
   }
 
   @objc public func invocationStatus(_ invoke: Invoke) throws {
+    let executableActions = mobileIntegrations
+      .filter { ($0["support"] as? String) != "unsupported" }
+      .map { $0["id"] as? String ?? "" }
+      .filter { !$0.isEmpty }
     invoke.resolve([
       "available": true,
       "surface": "Siri/Shortcuts/App Intents integration",
-      "supportedActions": supportedActions,
+      "supportedActions": executableActions,
+      "mobileIntegrations": mobileIntegrations,
       "siriReplacement": false,
       "requiresBackendEvidence": true,
       "secretsRedacted": true
@@ -60,11 +160,14 @@ public final class AuroraNativePlugin: Plugin {
 
   @objc public func invokeAuroraAction(_ invoke: Invoke) throws {
     let request = try invoke.parseArgs(AuroraInvocationRequest.self)
-    guard supportedActions.contains(request.action) else {
+    guard let action = mobileIntegrations.first(where: {
+      ($0["id"] as? String) == request.action && ($0["support"] as? String) != "unsupported"
+    }) else {
       invoke.resolve([
         "accepted": false,
         "action": request.action,
         "reason": "unsupported_action",
+        "siriReplacement": false,
         "secretsRedacted": true
       ])
       return
@@ -74,6 +177,12 @@ public final class AuroraNativePlugin: Plugin {
       "accepted": true,
       "action": request.action,
       "handoff": "AuroraClient",
+      "backendMethod": action["backendMethod"] ?? NSNull(),
+      "invocation": action["invocation"] ?? NSNull(),
+      "privacyClass": action["privacyClass"] ?? "personal",
+      "requiresConfirmation": action["requiresConfirmation"] ?? false,
+      "siriReplacement": false,
+      "requiresBackendEvidence": true,
       "secretsRedacted": true
     ]
     if let correlationId = request.correlationId {

--- a/packages/aurora-sdk/src/capabilities.ts
+++ b/packages/aurora-sdk/src/capabilities.ts
@@ -383,7 +383,16 @@ function candidatesFromNativeManifest(
         privacyClass: integration.privacyClass,
         disabledReasons,
         requiredAction: requiredActionForNativeIntegration(integration.support),
-        selector: { platform: integration.platform, capability: integration.capability },
+        selector: {
+          platform: integration.platform,
+          capability: integration.capability,
+          integrationId: integration.id,
+          invocation: integration.invocation ?? null,
+          backendMethod: integration.backendMethod ?? null,
+          privacyClass: integration.privacyClass,
+          requiresConfirmation: integration.requiresConfirmation ?? false,
+          siriReplacement: integration.siriReplacement ?? false
+        },
         source: 'native-manifest',
         raw: null
       } satisfies CapabilityProviderCandidate

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -3546,6 +3546,131 @@ export const androidNativeCapabilityManifestFixture: NativeCapabilityManifest = 
   secretsRedacted: true
 }
 
+export const iosNativeCapabilityManifestFixture: NativeCapabilityManifest = {
+  platform: 'ios',
+  permissions: {
+    'aurora.nativeCapabilityManifest': true,
+    'aurora.iosAppIntents': true,
+    'aurora.iosShortcuts': true,
+    'aurora.iosShareExtension': false,
+    'aurora.iosWidgets': false,
+    'aurora.iosDeepLinks': false,
+    'aurora.iosSiriReplacement': false,
+    'aurora.audioCapture': false,
+    'aurora.audioPlayback': false
+  },
+  capabilities: {
+    'ios.appIntents': true,
+    'ios.shortcuts': true,
+    'ios.widgets': false,
+    'ios.shareExtension': false,
+    'ios.deepLinks': false,
+    'ios.siriReplacement': false,
+    'native.audioCapture': false,
+    'native.audioPlayback': false
+  },
+  mobileIntegrations: [
+    {
+      platform: 'ios',
+      id: 'askAuroraAppIntent',
+      label: 'Ask Aurora',
+      support: 'supported-path',
+      capability: 'ios.appIntents',
+      permission: 'aurora.iosAppIntents',
+      invocation: 'app-intent',
+      backendMethod: 'Orchestrator.ExternalUserInput',
+      privacyClass: 'personal',
+      requiresConfirmation: false,
+      siriReplacement: false,
+      evidenceSource: 'IOS-003 native plugin manifest',
+      userCopy: 'Runs as an app-owned Siri/Shortcuts/App Intents integration and does not replace Siri.',
+      verifier: 'tauri ios build plus simulator/device App Intent invocation on macOS/Xcode'
+    },
+    {
+      platform: 'ios',
+      id: 'askAuroraShortcut',
+      label: 'Ask Aurora Shortcut',
+      support: 'supported-path',
+      capability: 'ios.shortcuts',
+      permission: 'aurora.iosShortcuts',
+      invocation: 'shortcut',
+      backendMethod: 'Orchestrator.ExternalUserInput',
+      privacyClass: 'personal',
+      requiresConfirmation: false,
+      siriReplacement: false,
+      evidenceSource: 'IOS-003 native plugin manifest',
+      userCopy: 'Shortcut invocation hands off to AuroraClient/backend evidence before executing assistant work.',
+      verifier: 'simulator/device Shortcut invocation through the Xcode-managed iOS target'
+    },
+    {
+      platform: 'ios',
+      id: 'summarizeSharedContentShortcut',
+      label: 'Summarize shared content',
+      support: 'supported-path',
+      capability: 'ios.shortcuts',
+      permission: 'aurora.iosShortcuts',
+      invocation: 'shortcut',
+      backendMethod: 'Orchestrator.IngestContext',
+      privacyClass: 'sensitive',
+      requiresConfirmation: true,
+      siriReplacement: false,
+      evidenceSource: 'IOS-003 native plugin manifest',
+      userCopy: 'Requires explicit user invocation and backend route/privacy evidence before sending shared content.',
+      verifier: 'simulator/device Shortcut or share handoff smoke with backend correlation evidence'
+    },
+    {
+      platform: 'ios',
+      id: 'stopAuroraSpeechAppIntent',
+      label: 'Stop Aurora speech',
+      support: 'supported-path',
+      capability: 'ios.appIntents',
+      permission: 'aurora.iosAppIntents',
+      invocation: 'app-intent',
+      backendMethod: 'TTS.Stop',
+      privacyClass: 'personal',
+      requiresConfirmation: false,
+      siriReplacement: false,
+      evidenceSource: 'IOS-003 native plugin manifest',
+      userCopy: 'Controls Aurora-owned playback only; it cannot control Siri or system assistant audio.',
+      verifier: 'simulator/device App Intent invocation with TTS stop route evidence'
+    },
+    {
+      platform: 'ios',
+      id: 'siriReplacement',
+      label: 'Siri replacement',
+      support: 'unsupported',
+      capability: 'ios.siriReplacement',
+      permission: null,
+      privacyClass: 'public',
+      requiresConfirmation: false,
+      siriReplacement: false,
+      evidenceSource: 'Apple-platform-policy',
+      userCopy: 'iOS does not allow Aurora to replace Siri as the default assistant.',
+      verifier: 'copy and capability review; no executable route should be exposed'
+    }
+  ],
+  platformLimitations: [
+    {
+      platform: 'ios',
+      id: 'noSiriReplacement',
+      label: 'No Siri replacement',
+      reason: 'Apple permits app-owned App Intents, Shortcuts, widgets, share extensions, and deep links, not replacing Siri as the system assistant.',
+      userCopy: 'Use Siri/Shortcuts/App Intents integration; do not claim Aurora replaces Siri.',
+      evidenceSource: 'Apple App Intents and SiriKit extension documentation'
+    },
+    {
+      platform: 'ios',
+      id: 'foregroundConsentRequired',
+      label: 'Foreground consent required',
+      reason: 'Always-on background assistant capture is unavailable on iOS without explicit app-owned foreground consent.',
+      userCopy: 'Audio and shared-content actions require app-owned user invocation and backend privacy evidence.',
+      evidenceSource: 'Apple App Intents, extensions, and privacy review requirements'
+    }
+  ],
+  evidenceSource: 'IOS-003 native plugin manifest',
+  secretsRedacted: true
+}
+
 const idleModelProgress = (operationType: string) => ({
   operation_id: null,
   operation_type: operationType,

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -113,6 +113,7 @@ export {
   emptyRegistryFixture,
   gatewayBuiltinRoutesFixture,
   gatewayRegistryFixture,
+  iosNativeCapabilityManifestFixture,
   meshPeerListFixture,
   meshStatusFixture,
   modelRuntimeCatalogFixture,

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -1644,7 +1644,11 @@ export interface NativeMobileIntegration {
   support: NativeIntegrationSupport
   capability: string
   permission: string | null
+  invocation?: 'app-intent' | 'shortcut' | 'widget' | 'share-extension' | 'deep-link' | 'tauri-command' | string
+  backendMethod?: string | null
   privacyClass: PrivacyClass
+  requiresConfirmation?: boolean
+  siriReplacement?: false
   evidenceSource: string
   userCopy: string
   verifier: string

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -34,6 +34,7 @@ import {
   modelRuntimeCatalogFixture,
   nativeCapabilityManifestFixture,
   androidNativeCapabilityManifestFixture,
+  iosNativeCapabilityManifestFixture,
   ORCHESTRATOR_MODEL_METHODS,
   permissionLabel,
   normalizeToolCatalog,
@@ -455,22 +456,28 @@ describe('AuroraClient', () => {
     const graph = buildCapabilityGraph({
       catalog: capabilityGraphCatalogFixture,
       registry: gatewayRegistryFixture,
-      nativeManifest: nativeCapabilityManifestFixture,
+      nativeManifest: iosNativeCapabilityManifestFixture,
       transportKind: 'tauri-local'
     })
 
-    expect(nativeCapabilityManifestFixture.mobileIntegrations).toEqual(
+    expect(iosNativeCapabilityManifestFixture.mobileIntegrations).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           platform: 'ios',
-          id: 'appIntents',
-          label: 'Siri/Shortcuts/App Intents integration',
-          support: 'planned'
+          id: 'askAuroraAppIntent',
+          invocation: 'app-intent',
+          backendMethod: 'Orchestrator.ExternalUserInput',
+          support: 'supported-path',
+          siriReplacement: false
         }),
         expect.objectContaining({
           platform: 'ios',
-          id: 'shortcuts',
-          support: 'supported-path'
+          id: 'summarizeSharedContentShortcut',
+          invocation: 'shortcut',
+          backendMethod: 'Orchestrator.IngestContext',
+          privacyClass: 'sensitive',
+          requiresConfirmation: true,
+          siriReplacement: false
         }),
         expect.objectContaining({
           platform: 'ios',
@@ -480,7 +487,7 @@ describe('AuroraClient', () => {
         })
       ])
     )
-    expect(nativeCapabilityManifestFixture.platformLimitations).toEqual(
+    expect(iosNativeCapabilityManifestFixture.platformLimitations).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           id: 'noSiriReplacement',
@@ -489,14 +496,24 @@ describe('AuroraClient', () => {
       ])
     )
 
-    expect(graph.explain('native:ios:appIntents')).toEqual(
+    expect(graph.explain('native:ios:askAuroraAppIntent')).toEqual(
       expect.objectContaining({
-        state: 'pending',
+        state: 'degraded',
         routeable: false,
-        nextRepairAction: 'implement scoped iOS plugin, App Intent, or extension task'
+        nextRepairAction: 'verify platform path in macOS/Xcode simulator or device'
       })
     )
-    expect(graph.explain('native:ios:shortcuts')).toEqual(
+    expect(graph.explain('native:ios:askAuroraAppIntent').providerCandidates[0]?.selector).toEqual(
+      expect.objectContaining({
+        integrationId: 'askAuroraAppIntent',
+        invocation: 'app-intent',
+        backendMethod: 'Orchestrator.ExternalUserInput',
+        privacyClass: 'personal',
+        requiresConfirmation: false,
+        siriReplacement: false
+      })
+    )
+    expect(graph.explain('native:ios:summarizeSharedContentShortcut')).toEqual(
       expect.objectContaining({
         state: 'degraded',
         routeable: false,

--- a/packages/aurora-ui/src/settings-permissions-view.tsx
+++ b/packages/aurora-ui/src/settings-permissions-view.tsx
@@ -5,6 +5,7 @@ import type {
   AndroidFallbackEntrypoint,
   AndroidNativeEntrypoint,
   AvailabilityState,
+  NativeMobileIntegration,
   PrivacyClass
 } from '@aurora/client'
 import type { AuroraShellSnapshot, RouteAvailability } from './shell-data'
@@ -39,12 +40,30 @@ export interface SettingsNativePermissionCard {
   evidence: string[]
 }
 
+export interface SettingsNativeIntegrationCard {
+  id: string
+  label: string
+  state: AvailabilityState
+  support: NativeMobileIntegration['support']
+  capability: string
+  permission: string | null
+  privacyClass: PrivacyClass
+  invocation: string | null
+  backendMethod: string | null
+  requiresConfirmation: boolean
+  siriReplacement: false
+  detail: string
+  blockers: string[]
+  evidence: string[]
+}
+
 export interface SettingsPermissionsModel {
   loadState: AuroraShellSnapshot['loadState']
   settingsRoute: RouteAvailability | null
   nativeRoute: RouteAvailability | null
   privacyControls: SettingsPrivacyControl[]
   nativePermissions: SettingsNativePermissionCard[]
+  nativeIntegrations: SettingsNativeIntegrationCard[]
   routeDefaults: Array<{ id: string; label: string; value: string; state: AvailabilityState; detail: string }>
   adminActionLabel: string
   fallbackLabel: string
@@ -118,6 +137,22 @@ export function SettingsPermissionsView({ snapshot }: SettingsPermissionsViewPro
           )}
         </section>
       </div>
+
+      {model.nativeIntegrations.length > 0 ? (
+        <section className="aui-settings-panel" aria-labelledby="native-integrations-title">
+          <PanelTitle
+            icon={<Smartphone size={18} aria-hidden />}
+            title="Siri, Shortcuts, and App Intents"
+            description="iOS invocation stays inside app-owned Siri/Shortcuts/App Intents integration, widgets, share, or deep-link surfaces; Aurora does not replace Siri."
+            id="native-integrations-title"
+          />
+          <div className="aui-native-list">
+            {model.nativeIntegrations.map((integration) => (
+              <NativeIntegrationRow key={integration.id} integration={integration} />
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       <section className="aui-settings-panel" aria-labelledby="route-policy-title">
         <PanelTitle
@@ -206,6 +241,7 @@ export function buildSettingsPermissionsModel(snapshot: AuroraShellSnapshot): Se
       })
     ],
     nativePermissions: nativePermissionCards(snapshot, nativeRoute),
+    nativeIntegrations: nativeIntegrationCards(snapshot),
     routeDefaults: [
       {
         id: 'remote-providers',
@@ -237,6 +273,36 @@ export function buildSettingsPermissionsModel(snapshot: AuroraShellSnapshot): Se
       : 'No fallback route is currently reported by the capability graph.',
     error: errorText
   }
+}
+
+function NativeIntegrationRow({ integration }: { integration: SettingsNativeIntegrationCard }) {
+  return (
+    <article className="aui-native-card">
+      <div className="aui-settings-control-icon">
+        {integration.state === 'unsupported' ? <AlertTriangle size={18} aria-hidden /> : <CheckCircle2 size={18} aria-hidden />}
+      </div>
+      <div>
+        <h3>{integration.label}</h3>
+        <p>{integration.detail}</p>
+        <div className="aui-settings-inline">
+          <StatusBadge state={integration.state} />
+          <PrivacyBadge privacy={integration.privacyClass} />
+          <EvidenceBadge label={integration.support} />
+          {integration.invocation ? <EvidenceBadge label={integration.invocation} /> : null}
+          {integration.requiresConfirmation ? <EvidenceBadge label="confirmation required" /> : null}
+        </div>
+        <small>{integration.blockers.length > 0 ? integration.blockers.join(', ') : 'No blocker reported.'}</small>
+        <dl className="aui-settings-facts">
+          <div><dt>Backend method</dt><dd>{integration.backendMethod ?? 'backend evidence required'}</dd></div>
+          <div><dt>Permission</dt><dd>{integration.permission ?? 'none'}</dd></div>
+          <div><dt>Siri replacement</dt><dd>{integration.siriReplacement ? 'claimed' : 'false'}</dd></div>
+        </dl>
+      </div>
+      <button type="button" disabled>
+        {integration.state === 'unsupported' ? 'Unsupported' : 'Requires native verification'}
+      </button>
+    </article>
+  )
 }
 
 function PrivacyControlRow({ control }: { control: SettingsPrivacyControl }) {
@@ -358,6 +424,46 @@ function nativePermissionCards(
   const androidRows = androidNativePermissionCards(snapshot)
   const androidIds = new Set(androidRows.map((row) => row.id))
   return [...genericRows.filter((row) => !androidIds.has(row.id)), ...androidRows]
+}
+
+function nativeIntegrationCards(snapshot: AuroraShellSnapshot): SettingsNativeIntegrationCard[] {
+  return snapshot.nativeMobileIntegrations
+    .filter((integration) => integration.platform === 'ios')
+    .map((integration) => {
+      const state = availabilityFromNativeIntegration(integration.support)
+      const blockers = [
+        state === 'unsupported' ? integration.userCopy : '',
+        integration.permission && snapshot.nativePermissions.some((permission) =>
+          permission.name === integration.permission && !permission.granted
+        )
+          ? `native permission missing: ${integration.permission}`
+          : ''
+      ].filter(Boolean)
+      return {
+        id: integration.id,
+        label: integration.label,
+        state,
+        support: integration.support,
+        capability: integration.capability,
+        permission: integration.permission,
+        privacyClass: integration.privacyClass,
+        invocation: integration.invocation ?? null,
+        backendMethod: integration.backendMethod ?? null,
+        requiresConfirmation: integration.requiresConfirmation ?? false,
+        siriReplacement: false,
+        detail: integration.userCopy,
+        blockers,
+        evidence: unique([integration.evidenceSource, integration.verifier])
+      }
+    })
+}
+
+function availabilityFromNativeIntegration(support: NativeMobileIntegration['support']): AvailabilityState {
+  if (support === 'supported') return 'available-local'
+  if (support === 'supported-path') return 'degraded'
+  if (support === 'planned') return 'pending'
+  if (support === 'blocked') return 'privacy-blocked'
+  return 'unsupported'
 }
 
 function nativeRequestAvailable(name: string, snapshot: AuroraShellSnapshot): boolean {

--- a/packages/aurora-ui/src/shell-data.ts
+++ b/packages/aurora-ui/src/shell-data.ts
@@ -9,7 +9,9 @@ import type {
   CapabilityExplanation,
   CapabilityGraph,
   CapabilityProviderCandidate,
-  NativeCapabilityManifest
+  NativeCapabilityManifest,
+  NativeMobileIntegration,
+  NativePlatformLimitation
 } from '@aurora/client'
 import {
   auroraAssistantCancellationItem,
@@ -70,6 +72,8 @@ export interface AuroraShellSnapshot {
   nativeAvailable: boolean
   nativePermissions: Array<{ name: string; granted: boolean; nativeState: string | null }>
   nativeCapabilities: Array<{ name: string; enabled: boolean; nativeState: string | null }>
+  nativeMobileIntegrations: NativeMobileIntegration[]
+  nativePlatformLimitations: NativePlatformLimitation[]
   nativeAssistantRole: AndroidAssistantRoleStatus | null
   nativeFallbackEntrypoints: AndroidFallbackEntrypoint[]
   nativeEntrypoints: AndroidNativeEntrypoint[]
@@ -103,6 +107,8 @@ export const loadingShellSnapshot: AuroraShellSnapshot = {
   nativeAvailable: false,
   nativePermissions: [],
   nativeCapabilities: [],
+  nativeMobileIntegrations: [],
+  nativePlatformLimitations: [],
   nativeAssistantRole: null,
   nativeFallbackEntrypoints: [],
   nativeEntrypoints: [],
@@ -154,6 +160,8 @@ export function snapshotFromGraph(
     nativeAvailable: native !== null,
     nativePermissions: nativePermissionEntries(native?.permissions, native?.permissionStates),
     nativeCapabilities: nativeCapabilityEntries(native?.capabilities, native?.capabilityStates),
+    nativeMobileIntegrations: native?.mobileIntegrations ?? [],
+    nativePlatformLimitations: native?.platformLimitations ?? [],
     nativeAssistantRole: native?.assistantRole ?? null,
     nativeFallbackEntrypoints: native?.fallbackEntrypoints ?? [],
     nativeEntrypoints: native?.entrypoints ?? [],

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -14,6 +14,7 @@ import {
   deploymentTopologyFixture,
   evaluateRoutePolicy,
   gatewayRegistryFixture,
+  iosNativeCapabilityManifestFixture,
   modelRuntimeCatalogFixture,
   meshPeerListFixture,
   meshStatusFixture,
@@ -304,6 +305,48 @@ describe('Aurora production shell', () => {
     expect(markup).toContain('AdminAction required')
     expect(markup).toContain('Request unavailable')
     expect(markup).toContain('secrets redacted')
+  })
+
+  it('renders iOS App Intents as app-owned Shortcuts integration without claiming Siri replacement', async () => {
+    const transport = new MockAuroraTransport()
+    transport.register('Native.GetCapabilityManifest', () => iosNativeCapabilityManifestFixture)
+    const snapshot = await buildShellSnapshot(new AuroraClient({ transport }))
+    const model = buildSettingsPermissionsModel(snapshot)
+    const markup = renderToStaticMarkup(<SettingsPermissionsView snapshot={snapshot} />)
+
+    expect(snapshot.nativePlatform).toBe('ios')
+    expect(model.nativeIntegrations.map((integration) => integration.id)).toEqual([
+      'askAuroraAppIntent',
+      'askAuroraShortcut',
+      'summarizeSharedContentShortcut',
+      'stopAuroraSpeechAppIntent',
+      'siriReplacement'
+    ])
+    expect(model.nativeIntegrations.find((integration) => integration.id === 'askAuroraAppIntent')).toEqual(
+      expect.objectContaining({
+        state: 'degraded',
+        backendMethod: 'Orchestrator.ExternalUserInput',
+        invocation: 'app-intent',
+        siriReplacement: false
+      })
+    )
+    expect(model.nativeIntegrations.find((integration) => integration.id === 'summarizeSharedContentShortcut')).toEqual(
+      expect.objectContaining({
+        state: 'degraded',
+        privacyClass: 'sensitive',
+        requiresConfirmation: true
+      })
+    )
+    expect(model.nativeIntegrations.find((integration) => integration.id === 'siriReplacement')).toEqual(
+      expect.objectContaining({
+        state: 'unsupported',
+        siriReplacement: false
+      })
+    )
+    expect(markup).toContain('Siri, Shortcuts, and App Intents')
+    expect(markup).toContain('does not replace Siri')
+    expect(markup).toContain('Orchestrator.ExternalUserInput')
+    expect(markup).toContain('confirmation required')
   })
 
   it('maps settings state matrix for denied, degraded, native-unavailable, optimistic and rollback/error states', async () => {


### PR DESCRIPTION
## Summary

Implements the IOS-003 recovery work on top of `feat/ui-multi-platform-integration` after IOS-002 added the Swift plugin skeleton.

- adds concrete Swift App Intents/App Shortcuts source surfaces for `Ask Aurora`, `Ask Aurora Shortcut`, `Summarize shared content`, and `Stop Aurora speech`
- returns typed `AuroraIntentHandoff` AppEntity results containing action ID, backend method, invocation surface, privacy class, confirmation requirement, generated correlation ID, and `siriReplacement: false`
- adds a macOS CI smoke harness that compiles the App Intent source, invokes `AskAuroraIntent.perform()`, validates the returned handoff metadata, prints the JSON result, and uploads it as `aurora-ios-app-intent-smoke`
- enriches the iOS Swift Tauri mobile plugin manifest with matching App Intent/Shortcut metadata, platform limitations, and no-Siri-replacement policy
- extends the SDK native mobile integration model and capability graph selector so iOS invocation metadata is preserved from native manifest evidence
- updates the iOS native manifest fixture and Settings/Permissions UI to render Siri/Shortcuts/App Intents integration without claiming Siri replacement

## Validation

- `find apps/aurora-tauri/src-tauri/ios -maxdepth 5 -type f | sort` shows `AuroraAppIntents.swift` alongside the plugin package files
- `rg -n "AppIntent|AppShortcutsProvider|AppShortcut|IntentResult|AppEntity|Parameter|Shortcut" apps/aurora-tauri/src-tauri/ios apps/aurora-tauri/src-tauri -g '*.swift' -g '*.plist' -g '*.entitlements'` finds the AppIntents declarations and shortcut registrations
- `pnpm --filter @aurora/client test` passed: 3 files, 94 tests
- `pnpm --filter @aurora/client typecheck` passed
- `pnpm --filter @aurora/client build` passed
- `pnpm --filter @aurora/ui test` passed: 1 file, 84 tests
- `pnpm --filter @aurora/ui typecheck` passed
- `pnpm --filter @aurora/ui build` passed
- `cargo fmt --manifest-path apps/aurora-tauri/src-tauri/Cargo.toml --check` passed
- `git diff --check` passed
- `swift --version` remains unavailable on this Linux runner: `command not found`

## GitHub CI Evidence

Head: `7a12ec01df4973b2d1c929c8f08387a240755940`

- `macOS Xcode Tauri iOS init and build` passed in 5m10s: https://github.com/joaojhgs/aurora/actions/runs/28277363995/job/83786584878
- `Linux Tauri check and smoke launch` passed in 5m33s: https://github.com/joaojhgs/aurora/actions/runs/28277363999/job/83786584906
- `Android APK build and emulator smoke` passed in 6m37s: https://github.com/joaojhgs/aurora/actions/runs/28277363996/job/83786584882

The macOS run includes step `Smoke invoke Aurora App Intent handoff`, which compiled `AuroraAppIntents.swift` plus `.github/scripts/ios_app_intent_smoke.swift`, invoked `AskAuroraIntent.perform()`, and validated the expected JSON fields. The log printed:

```json
{"action":"askAuroraAppIntent","backendMethod":"Orchestrator.ExternalUserInput","correlationId":"3D4D4204-9B87-444E-9952-B06C0569719F:prompt","id":"askAuroraAppIntent:3D4D4204-9B87-444E-9952-B06C0569719F","invocation":"app-intent","privacyClass":"personal","requiresConfirmation":false,"siriReplacement":false}
```

Artifact uploaded by that same macOS run:

- `aurora-ios-app-intent-smoke.zip`, artifact ID `7920702766`, final size 380 bytes
