### PR TITLE
IOS-006 — Implement iOS voice capability states

### DIFF
--- a/apps/aurora-tauri/src-tauri/capabilities/aurora-ios-baseline.json
+++ b/apps/aurora-tauri/src-tauri/capabilities/aurora-ios-baseline.json
@@ -21,6 +21,7 @@
     "aurora-native-permissions",
     "aurora-tray",
     "aurora-notifications",
+    "aurora-ios-voice",
     "aurora-dialogs",
     "aurora-local-file",
     "aurora-secure-file-handle",

--- a/apps/aurora-tauri/src-tauri/capabilities/aurora-main.json
+++ b/apps/aurora-tauri/src-tauri/capabilities/aurora-main.json
@@ -21,6 +21,7 @@
     "aurora-native-permissions",
     "aurora-tray",
     "aurora-notifications",
+    "aurora-ios-voice",
     "aurora-dialogs",
     "aurora-local-file",
     "aurora-secure-file-handle",

--- a/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/README.md
+++ b/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/README.md
@@ -8,6 +8,9 @@ Current commands:
 
 - `nativeCapabilityManifest` returns the iOS native capability/permission manifest.
 - `invocationStatus` reports the allowed invocation surface and explicitly sets `siriReplacement` to `false`.
+- `voiceStatus` reports foreground-only microphone capture state from `AVAudioSession` and keeps raw-audio consent/backend evidence required.
+- `notificationStatus` reports `UNUserNotificationCenter` authorization without claiming background assistant wake.
+- `backgroundStatus` reports always-on background voice and Siri replacement as unsupported, with app-owned fallback surfaces listed.
 - `iosEntrypointPayload` returns redacted IOS-004 entrypoint descriptors and the last payload envelope shape.
 - `invokeAuroraAction` accepts concrete Aurora action IDs and hands off to the SDK/backend boundary instead of duplicating orchestrator logic in Swift.
 
@@ -28,4 +31,5 @@ Required native verification remains macOS/Xcode-only:
 - `tauri ios build` or Xcode build of the generated iOS project with this package linked.
 - Simulator or device invocation of at least one App Intent or Shortcut.
 - Simulator or device invocation of at least one share extension, deep-link, widget, or file-open entrypoint.
+- Simulator or device verification of microphone permission, notification authorization, and background-limit status.
 - Evidence that each handoff reaches the AuroraClient/backend boundary with correlation/provenance preserved.

--- a/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/Sources/AuroraNativePlugin/AuroraNativePlugin.swift
+++ b/apps/aurora-tauri/src-tauri/ios/AuroraNativePlugin/Sources/AuroraNativePlugin/AuroraNativePlugin.swift
@@ -1,7 +1,9 @@
+import AVFAudio
 import Foundation
 import LocalAuthentication
 import Security
 import Tauri
+import UserNotifications
 import WebKit
 
 @_cdecl("init_plugin_aurora_native")
@@ -181,6 +183,10 @@ public final class AuroraNativePlugin: Plugin {
         "aurora.ios.entrypointPayload": true,
         "aurora.iosKeychain": true,
         "aurora.iosBiometricUnlock": true,
+        "aurora.iosVoiceStatus": true,
+        "aurora.iosBackgroundStatus": true,
+        "aurora.iosMicrophoneCapture": false,
+        "aurora.iosBackgroundAudio": false,
         "aurora.iosSiriReplacement": false,
         "aurora.audioCapture": false,
         "aurora.audioPlayback": false
@@ -195,6 +201,10 @@ public final class AuroraNativePlugin: Plugin {
         "ios.entrypointPayload": true,
         "ios.keychain.secureCredentialStorage": true,
         "ios.biometric.adminUnlock": true,
+        "ios.voiceForegroundCapture": false,
+        "ios.notifications": false,
+        "ios.backgroundVoice": false,
+        "ios.appOwnedInvocation": true,
         "ios.siriReplacement": false,
         "native.audioCapture": false,
         "native.audioPlayback": false
@@ -209,6 +219,8 @@ public final class AuroraNativePlugin: Plugin {
         "aurora.ios.entrypointPayload": "available",
         "aurora.iosKeychain": "available",
         "aurora.iosBiometricUnlock": "available",
+        "aurora.iosMicrophoneCapture": "needs_native_permission",
+        "aurora.iosBackgroundAudio": "unsupported_platform",
         "aurora.iosSiriReplacement": "unsupported_platform"
       ],
       "capabilityStates": [
@@ -221,6 +233,10 @@ public final class AuroraNativePlugin: Plugin {
         "ios.entrypointPayload": "available",
         "ios.keychain.secureCredentialStorage": "available",
         "ios.biometric.adminUnlock": "available",
+        "ios.voiceForegroundCapture": "needs_native_permission",
+        "ios.notifications": "needs_native_permission",
+        "ios.backgroundVoice": "unsupported_platform",
+        "ios.appOwnedInvocation": "available",
         "ios.siriReplacement": "unsupported_platform"
       ],
       "mobileIntegrations": mobileIntegrations,
@@ -279,6 +295,79 @@ public final class AuroraNativePlugin: Plugin {
       "requiresBackendEvidence": true,
       "entrypoints": AuroraNativePlugin.entrypoints(),
       "secretsRedacted": true
+    ])
+  }
+
+  @objc public func voiceStatus(_ invoke: Invoke) throws {
+    let permission = AVAudioSession.sharedInstance().recordPermission
+    let reason: Any = permission == .granted
+      ? NSNull()
+      : "iOS microphone capture requires foreground AVAudioSession record permission, raw-audio consent, backend audio evidence, and a visible stop/revoke path."
+    invoke.resolve([
+      "available": permission == .granted,
+      "permission": "aurora.iosMicrophoneCapture",
+      "capability": "ios.voiceForegroundCapture",
+      "source": "tauri-ios-native-plugin",
+      "reason": reason,
+      "details": [
+        "platform": "ios",
+        "recordPermission": AuroraNativePlugin.recordPermissionLabel(permission),
+        "privacyClass": "raw-audio",
+        "foregroundOnly": true,
+        "supportsBackgroundListening": false,
+        "supportsSiriReplacement": false,
+        "consentRequired": true,
+        "stopRevokeRequired": true,
+        "secretsRedacted": true
+      ]
+    ])
+  }
+
+  @objc public func notificationStatus(_ invoke: Invoke) throws {
+    UNUserNotificationCenter.current().getNotificationSettings { settings in
+      let available = settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional
+      let reason: Any = available
+        ? NSNull()
+        : "iOS notifications require explicit user authorization and cannot provide always-on assistant wake."
+      invoke.resolve([
+        "available": available,
+        "permission": "aurora.notificationsSend",
+        "capability": "ios.notifications",
+        "source": "tauri-ios-native-plugin",
+        "reason": reason,
+        "details": [
+          "platform": "ios",
+          "authorizationStatus": AuroraNativePlugin.notificationAuthorizationLabel(settings.authorizationStatus),
+          "supportsSiriReplacement": false,
+          "backgroundAssistantWake": false,
+          "secretsRedacted": true
+        ]
+      ])
+    }
+  }
+
+  @objc public func backgroundStatus(_ invoke: Invoke) throws {
+    invoke.resolve([
+      "available": false,
+      "permission": "aurora.iosBackgroundAudio",
+      "capability": "ios.backgroundVoice",
+      "source": "tauri-ios-native-plugin",
+      "reason": "iOS does not allow Aurora to run always-on background assistant listening or replace Siri; use app-owned foreground, notification, Shortcut, App Intent, widget, share, or deep-link entrypoints.",
+      "details": [
+        "platform": "ios",
+        "alwaysOnWake": false,
+        "supportsSiriReplacement": false,
+        "allowedFallbackSurfaces": [
+          "foreground microphone permission",
+          "user notifications",
+          "App Intents",
+          "Shortcuts",
+          "widgets",
+          "share sheet",
+          "deep links"
+        ],
+        "secretsRedacted": true
+      ]
     ])
   }
 
@@ -463,5 +552,35 @@ public final class AuroraNativePlugin: Plugin {
       return NSNull()
     }
     return value
+  }
+
+  private static func recordPermissionLabel(_ permission: AVAudioSession.RecordPermission) -> String {
+    switch permission {
+    case .granted:
+      return "granted"
+    case .denied:
+      return "denied"
+    case .undetermined:
+      return "undetermined"
+    @unknown default:
+      return "unknown"
+    }
+  }
+
+  private static func notificationAuthorizationLabel(_ status: UNAuthorizationStatus) -> String {
+    switch status {
+    case .authorized:
+      return "authorized"
+    case .denied:
+      return "denied"
+    case .notDetermined:
+      return "notDetermined"
+    case .provisional:
+      return "provisional"
+    case .ephemeral:
+      return "ephemeral"
+    @unknown default:
+      return "unknown"
+    }
   }
 }

--- a/apps/aurora-tauri/src-tauri/permissions/aurora-ios-voice.toml
+++ b/apps/aurora-tauri/src-tauri/permissions/aurora-ios-voice.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "aurora-ios-voice"
+description = "Allow iOS voice, invocation, and background-limit status checks without granting microphone capture, background listening, or Siri replacement."
+commands.allow = ["aurora_ios_voice_status", "aurora_ios_background_status"]

--- a/apps/aurora-tauri/src-tauri/src/lib.rs
+++ b/apps/aurora-tauri/src-tauri/src/lib.rs
@@ -705,6 +705,100 @@ async fn aurora_audio_bridge_status() -> Result<NativeFeatureStatus, AuroraComma
 }
 
 #[tauri::command]
+async fn aurora_ios_voice_status(
+    native: State<'_, AuroraMobileNativePlugin<tauri::Wry>>,
+) -> Result<Value, AuroraCommandError> {
+    #[cfg(target_os = "ios")]
+    {
+        let payload = run_ios_plugin_command(native, "voiceStatus", json!({}))?;
+        log_ios_native_plugin_payload("voiceStatus", &payload);
+        Ok(payload)
+    }
+
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = native;
+        serde_json::to_value(ios_voice_status()?)
+            .map_err(|_| AuroraCommandError::InvalidGatewayResponse)
+    }
+}
+
+fn ios_voice_status() -> Result<NativeFeatureStatus, AuroraCommandError> {
+    let mut status = denied_native_feature_status(
+        "aurora.iosMicrophoneCapture",
+        "ios.voiceForegroundCapture",
+        "iOS microphone capture requires foreground AVAudioSession record permission, raw-audio consent, backend audio evidence, and a visible stop/revoke path.",
+    )?;
+    status.details.insert("platform".to_string(), json!("ios"));
+    status
+        .details
+        .insert("privacyClass".to_string(), json!("raw-audio"));
+    status
+        .details
+        .insert("foregroundOnly".to_string(), json!(true));
+    status
+        .details
+        .insert("supportsBackgroundListening".to_string(), json!(false));
+    status
+        .details
+        .insert("supportsSiriReplacement".to_string(), json!(false));
+    status
+        .details
+        .insert("consentRequired".to_string(), json!(true));
+    status
+        .details
+        .insert("stopRevokeRequired".to_string(), json!(true));
+    Ok(status)
+}
+
+#[tauri::command]
+async fn aurora_ios_background_status(
+    native: State<'_, AuroraMobileNativePlugin<tauri::Wry>>,
+) -> Result<Value, AuroraCommandError> {
+    #[cfg(target_os = "ios")]
+    {
+        let payload = run_ios_plugin_command(native, "backgroundStatus", json!({}))?;
+        log_ios_native_plugin_payload("backgroundStatus", &payload);
+        Ok(payload)
+    }
+
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = native;
+        serde_json::to_value(ios_background_status()?)
+            .map_err(|_| AuroraCommandError::InvalidGatewayResponse)
+    }
+}
+
+fn ios_background_status() -> Result<NativeFeatureStatus, AuroraCommandError> {
+    let mut status = denied_native_feature_status(
+        "aurora.iosBackgroundAudio",
+        "ios.backgroundVoice",
+        "iOS does not allow Aurora to run always-on background assistant listening or replace Siri; use app-owned foreground, notification, Shortcut, App Intent, widget, share, or deep-link entrypoints.",
+    )?;
+    status.details.insert("platform".to_string(), json!("ios"));
+    status
+        .details
+        .insert("alwaysOnWake".to_string(), json!(false));
+    status
+        .details
+        .insert("supportsSiriReplacement".to_string(), json!(false));
+    status.details.insert(
+        "allowedFallbackSurfaces".to_string(),
+        json!([
+            "foreground microphone permission",
+            "user notifications",
+            "App Intents",
+            "Shortcuts",
+            "widgets",
+            "share sheet",
+            "deep links"
+        ]),
+    );
+    Ok(status)
+}
+
+#[tauri::command]
 async fn aurora_android_baseline_status() -> Result<AndroidBaselineStatus, AuroraCommandError> {
     let status = android_baseline_status();
     log_android_baseline_status(&status);
@@ -1340,6 +1434,10 @@ fn native_capability_manifest() -> NativeCapabilityManifest {
     permissions.insert("aurora.audioBridgeStatus".to_string(), true);
     permissions.insert("aurora.audioCapture".to_string(), false);
     permissions.insert("aurora.audioPlayback".to_string(), false);
+    permissions.insert("aurora.iosVoiceStatus".to_string(), true);
+    permissions.insert("aurora.iosBackgroundStatus".to_string(), true);
+    permissions.insert("aurora.iosMicrophoneCapture".to_string(), false);
+    permissions.insert("aurora.iosBackgroundAudio".to_string(), false);
     permissions.insert("aurora.iosAppIntents".to_string(), false);
     permissions.insert("aurora.iosShortcuts".to_string(), false);
     permissions.insert("aurora.iosShareExtension".to_string(), false);
@@ -1379,6 +1477,10 @@ fn native_capability_manifest() -> NativeCapabilityManifest {
     capabilities.insert("native.audio".to_string(), false);
     capabilities.insert("native.audioCapture".to_string(), false);
     capabilities.insert("native.audioPlayback".to_string(), false);
+    capabilities.insert("ios.voiceForegroundCapture".to_string(), false);
+    capabilities.insert("ios.notifications".to_string(), false);
+    capabilities.insert("ios.backgroundVoice".to_string(), false);
+    capabilities.insert("ios.appOwnedInvocation".to_string(), ios_platform);
     capabilities.insert("ios.appIntents".to_string(), ios_platform);
     capabilities.insert("ios.shortcuts".to_string(), ios_platform);
     capabilities.insert("ios.shareExtension".to_string(), ios_platform);
@@ -1401,12 +1503,44 @@ fn native_capability_manifest() -> NativeCapabilityManifest {
         "android.fallbackEntrypoints".to_string(),
         cfg!(target_os = "android"),
     );
+    let mut permission_states = ios_state_map("aurora.ios.", ios_platform);
+    permission_states.insert(
+        "aurora.iosMicrophoneCapture".to_string(),
+        "needs_native_permission".to_string(),
+    );
+    permission_states.insert(
+        "aurora.iosBackgroundAudio".to_string(),
+        "unsupported_platform".to_string(),
+    );
+    let mut capability_states = ios_state_map("ios.", ios_platform);
+    capability_states.insert(
+        "ios.voiceForegroundCapture".to_string(),
+        "needs_native_permission".to_string(),
+    );
+    capability_states.insert(
+        "ios.notifications".to_string(),
+        "needs_native_permission".to_string(),
+    );
+    capability_states.insert(
+        "ios.backgroundVoice".to_string(),
+        "unsupported_platform".to_string(),
+    );
+    capability_states.insert(
+        "ios.appOwnedInvocation".to_string(),
+        if ios_platform {
+            "available"
+        } else {
+            "needs_native_permission"
+        }
+        .to_string(),
+    );
+
     NativeCapabilityManifest {
         platform: native_platform().to_string(),
         permissions,
         capabilities,
-        permission_states: ios_state_map("aurora.ios.", ios_platform),
-        capability_states: ios_state_map("ios.", ios_platform),
+        permission_states,
+        capability_states,
         mobile_integrations: ios_mobile_integrations(ios_platform),
         platform_limitations: ios_platform_limitations(),
         ios_invocation: ios_invocation_status(ios_platform),
@@ -2192,6 +2326,8 @@ pub fn run() {
             aurora_tray_status,
             aurora_notification_status,
             aurora_notification_send,
+            aurora_ios_voice_status,
+            aurora_ios_background_status,
             aurora_dialog_status,
             aurora_audio_bridge_status,
             aurora_android_baseline_status,
@@ -2324,6 +2460,22 @@ mod tests {
             Some(&false)
         );
         assert_eq!(
+            manifest.permissions.get("aurora.iosVoiceStatus"),
+            Some(&true)
+        );
+        assert_eq!(
+            manifest.permissions.get("aurora.iosBackgroundStatus"),
+            Some(&true)
+        );
+        assert_eq!(
+            manifest.permissions.get("aurora.iosMicrophoneCapture"),
+            Some(&false)
+        );
+        assert_eq!(
+            manifest.permissions.get("aurora.iosBackgroundAudio"),
+            Some(&false)
+        );
+        assert_eq!(
             manifest.permissions.get("aurora.iosSiriReplacement"),
             Some(&false)
         );
@@ -2337,6 +2489,19 @@ mod tests {
         assert_eq!(manifest.capabilities.get("ios.shortcuts"), Some(&false));
         assert_eq!(
             manifest.capabilities.get("ios.siriReplacement"),
+            Some(&false)
+        );
+        assert_eq!(
+            manifest.capabilities.get("ios.voiceForegroundCapture"),
+            Some(&false)
+        );
+        assert_eq!(manifest.capabilities.get("ios.notifications"), Some(&false));
+        assert_eq!(
+            manifest.capabilities.get("ios.backgroundVoice"),
+            Some(&false)
+        );
+        assert_eq!(
+            manifest.capabilities.get("ios.appOwnedInvocation"),
             Some(&false)
         );
         assert!(manifest
@@ -2418,6 +2583,38 @@ mod tests {
     }
 
     #[test]
+    fn ios_statuses_preserve_apple_platform_limits() {
+        let voice = ios_voice_status().unwrap();
+        assert!(!voice.available);
+        assert_eq!(voice.permission, "aurora.iosMicrophoneCapture");
+        assert_eq!(voice.capability, "ios.voiceForegroundCapture");
+        assert_eq!(voice.details.get("privacyClass"), Some(&json!("raw-audio")));
+        assert_eq!(voice.details.get("foregroundOnly"), Some(&json!(true)));
+        assert_eq!(
+            voice.details.get("supportsBackgroundListening"),
+            Some(&json!(false))
+        );
+        assert_eq!(
+            voice.details.get("supportsSiriReplacement"),
+            Some(&json!(false))
+        );
+
+        let background = ios_background_status().unwrap();
+        assert!(!background.available);
+        assert_eq!(background.permission, "aurora.iosBackgroundAudio");
+        assert_eq!(background.capability, "ios.backgroundVoice");
+        assert_eq!(background.details.get("alwaysOnWake"), Some(&json!(false)));
+        assert_eq!(
+            background.details.get("supportsSiriReplacement"),
+            Some(&json!(false))
+        );
+        assert!(background
+            .reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("does not allow Aurora")));
+    }
+
+    #[test]
     fn native_permission_status_lists_denied_sensitive_surfaces() {
         let manifest = native_capability_manifest();
         let denied: Vec<String> = manifest
@@ -2461,6 +2658,10 @@ mod tests {
         assert!(ios_permission.contains("aurora_ios_secure_storage_status"));
         assert!(ios_permission.contains("aurora_ios_biometric_status"));
         assert!(ios_permission.contains("aurora_ios_admin_unlock"));
+        let ios_voice_permission = include_str!("../permissions/aurora-ios-voice.toml");
+        assert!(ios_capability.contains("\"aurora-ios-voice\""));
+        assert!(ios_voice_permission.contains("aurora_ios_voice_status"));
+        assert!(ios_voice_permission.contains("aurora_ios_background_status"));
 
         let swift_plugin = include_str!(
             "../ios/AuroraNativePlugin/Sources/AuroraNativePlugin/AuroraNativePlugin.swift"
@@ -2468,6 +2669,9 @@ mod tests {
         assert!(swift_plugin.contains("@_cdecl(\"init_plugin_aurora_native\")"));
         assert!(swift_plugin.contains("nativeCapabilityManifest"));
         assert!(swift_plugin.contains("invocationStatus"));
+        assert!(swift_plugin.contains("voiceStatus"));
+        assert!(swift_plugin.contains("notificationStatus"));
+        assert!(swift_plugin.contains("backgroundStatus"));
         assert!(swift_plugin.contains("iosEntrypointPayload"));
         assert!(swift_plugin.contains("invokeAuroraAction"));
         assert!(swift_plugin.contains("iosSecureStorageStatus"));
@@ -2477,6 +2681,8 @@ mod tests {
         assert!(swift_plugin.contains("\"ios.fileAssociations\": true"));
         assert!(swift_plugin.contains("\"ios.keychain.secureCredentialStorage\": true"));
         assert!(swift_plugin.contains("\"ios.biometric.adminUnlock\": true"));
+        assert!(swift_plugin.contains("\"ios.voiceForegroundCapture\": false"));
+        assert!(swift_plugin.contains("\"ios.backgroundVoice\": false"));
         assert!(swift_plugin.contains("\"aurora.iosSiriReplacement\": false"));
 
         let swift_entrypoints = include_str!(

--- a/apps/aurora-tauri/src/aurora-client.test.tsx
+++ b/apps/aurora-tauri/src/aurora-client.test.tsx
@@ -45,6 +45,8 @@ describe('Aurora Tauri runtime wrapper', () => {
     expect(markup).toContain('Native boundary')
     expect(markup).toContain('Runtime mode')
     expect(markup).toContain('Audio bridge')
+    expect(markup).toContain('iOS microphone capture')
+    expect(markup).toContain('iOS background voice')
     expect(markup).toContain('iOS Keychain')
     expect(markup).toContain('Face ID / Touch ID')
     expect(markup).toContain('Siri/Shortcuts/App Intents integration')

--- a/apps/aurora-tauri/src/aurora-client.ts
+++ b/apps/aurora-tauri/src/aurora-client.ts
@@ -4,6 +4,7 @@ import {
   MockAuroraTransport,
   TauriLocalTransport,
   type TauriAndroidBaselineStatus,
+  type TauriIosInvocationStatus,
   type TauriNativeFeatureStatus,
   type TauriNativePermissionStatus,
   type TauriSidecarStatus
@@ -19,6 +20,9 @@ export interface AuroraTauriRuntime {
   nativePermissionStatus: () => Promise<TauriNativePermissionStatus | null>
   trayStatus: () => Promise<TauriNativeFeatureStatus | null>
   notificationStatus: () => Promise<TauriNativeFeatureStatus | null>
+  iosVoiceStatus: () => Promise<TauriNativeFeatureStatus | null>
+  iosInvocationStatus: () => Promise<TauriIosInvocationStatus | null>
+  iosBackgroundStatus: () => Promise<TauriNativeFeatureStatus | null>
   dialogStatus: () => Promise<TauriNativeFeatureStatus | null>
   audioBridgeStatus: () => Promise<TauriNativeFeatureStatus | null>
   iosSecureStorageStatus: () => Promise<TauriNativeFeatureStatus | null>
@@ -39,6 +43,9 @@ export function createAuroraTauriRuntime(): AuroraTauriRuntime {
       nativePermissionStatus: () => transport.getNativePermissionStatus(),
       trayStatus: () => transport.getTrayStatus(),
       notificationStatus: () => transport.getNotificationStatus(),
+      iosVoiceStatus: () => transport.getIosVoiceStatus(),
+      iosInvocationStatus: () => transport.getIosInvocationStatus(),
+      iosBackgroundStatus: () => transport.getIosBackgroundStatus(),
       dialogStatus: () => transport.getDialogStatus(),
       audioBridgeStatus: () => transport.getAudioBridgeStatus(),
       iosSecureStorageStatus: () => transport.getIosSecureStorageStatus(),
@@ -64,6 +71,9 @@ export function createAuroraTauriRuntime(): AuroraTauriRuntime {
       nativePermissionStatus: async () => null,
       trayStatus: async () => null,
       notificationStatus: async () => null,
+      iosVoiceStatus: async () => null,
+      iosInvocationStatus: async () => null,
+      iosBackgroundStatus: async () => null,
       dialogStatus: async () => null,
       audioBridgeStatus: async () => null,
       iosSecureStorageStatus: async () => null,
@@ -82,6 +92,9 @@ export function createAuroraTauriRuntime(): AuroraTauriRuntime {
     nativePermissionStatus: async () => null,
     trayStatus: async () => null,
     notificationStatus: async () => null,
+    iosVoiceStatus: async () => null,
+    iosInvocationStatus: async () => null,
+    iosBackgroundStatus: async () => null,
     dialogStatus: async () => null,
     audioBridgeStatus: async () => null,
     iosSecureStorageStatus: async () => null,

--- a/apps/aurora-tauri/src/tauri-app.tsx
+++ b/apps/aurora-tauri/src/tauri-app.tsx
@@ -3,6 +3,7 @@ import { AppShell, RouteMatrix, StateSurface, buildShellSnapshot, loadingShellSn
 import type { AuroraShellSnapshot } from '@aurora/ui'
 import type {
   TauriAndroidBaselineStatus,
+  TauriIosInvocationStatus,
   TauriNativeFeatureStatus,
   TauriNativePermissionStatus,
   TauriSidecarStatus
@@ -15,6 +16,7 @@ export function AuroraTauriApp() {
   const [sidecar, setSidecar] = useState<TauriSidecarStatus | null>(null)
   const [nativePermissions, setNativePermissions] = useState<TauriNativePermissionStatus | null>(null)
   const [nativeFeatures, setNativeFeatures] = useState<Record<string, TauriNativeFeatureStatus | null>>({})
+  const [iosInvocationStatus, setIosInvocationStatus] = useState<TauriIosInvocationStatus | null>(null)
   const [androidBaseline, setAndroidBaseline] = useState<TauriAndroidBaselineStatus | null>(null)
 
   useEffect(() => {
@@ -35,6 +37,9 @@ export function AuroraTauriApp() {
         nextNativePermissions,
         tray,
         notifications,
+        iosVoice,
+        iosInvocation,
+        iosBackground,
         dialogs,
         audio,
         iosKeychain,
@@ -46,6 +51,9 @@ export function AuroraTauriApp() {
         runtime.nativePermissionStatus().catch(() => null),
         runtime.trayStatus().catch(() => null),
         runtime.notificationStatus().catch(() => null),
+        runtime.iosVoiceStatus().catch(() => null),
+        runtime.iosInvocationStatus().catch(() => null),
+        runtime.iosBackgroundStatus().catch(() => null),
         runtime.dialogStatus().catch(() => null),
         runtime.audioBridgeStatus().catch(() => null),
         runtime.iosSecureStorageStatus().catch(() => null),
@@ -56,7 +64,8 @@ export function AuroraTauriApp() {
         setSnapshot(nextSnapshot)
         setSidecar(nextSidecar)
         setNativePermissions(nextNativePermissions)
-        setNativeFeatures({ tray, notifications, dialogs, audio, iosKeychain, iosBiometrics })
+        setNativeFeatures({ tray, notifications, iosVoice, iosBackground, dialogs, audio, iosKeychain, iosBiometrics })
+        setIosInvocationStatus(iosInvocation)
         setAndroidBaseline(android)
       }
     }
@@ -90,11 +99,13 @@ export function AuroraTauriApp() {
             <div><dt>Native manifest</dt><dd>{snapshot.nativeAvailable ? snapshot.nativePlatform : 'unavailable'}</dd></div>
             <div><dt>Tray</dt><dd>{nativeFeatureLabel(nativeFeatures.tray)}</dd></div>
             <div><dt>Notifications</dt><dd>{nativeFeatureLabel(nativeFeatures.notifications)}</dd></div>
+            <div><dt>iOS microphone capture</dt><dd>{nativeFeatureLabel(nativeFeatures.iosVoice)}</dd></div>
+            <div><dt>iOS background voice</dt><dd>{nativeFeatureLabel(nativeFeatures.iosBackground)}</dd></div>
             <div><dt>Dialogs</dt><dd>{nativeFeatureLabel(nativeFeatures.dialogs)}</dd></div>
             <div><dt>Audio bridge</dt><dd>{nativeFeatureLabel(nativeFeatures.audio)}</dd></div>
             <div><dt>iOS Keychain</dt><dd>{nativeFeatureLabel(nativeFeatures.iosKeychain)}</dd></div>
             <div><dt>Face ID / Touch ID</dt><dd>{nativeFeatureLabel(nativeFeatures.iosBiometrics)}</dd></div>
-            <div><dt>iOS invocation</dt><dd>Siri/Shortcuts/App Intents integration; no Siri replacement claim.</dd></div>
+            <div><dt>iOS invocation</dt><dd>{iosInvocationLabel(iosInvocationStatus)}</dd></div>
             <div><dt>Android baseline</dt><dd>{androidBaselineLabel(androidBaseline)}</dd></div>
             <div><dt>Assistant role probe</dt><dd>{assistantRoleProbeLabel(androidBaseline)}</dd></div>
             <div><dt>Denied native defaults</dt><dd>{nativePermissions?.deniedByDefault.join(', ') ?? 'not available'}</dd></div>
@@ -113,6 +124,12 @@ function nativeFeatureLabel(feature: TauriNativeFeatureStatus | null | undefined
   if (!feature) return 'not available'
   if (feature.available) return `${feature.capability} available`
   return `${feature.capability} denied by default`
+}
+
+function iosInvocationLabel(status: TauriIosInvocationStatus | null | undefined): string {
+  if (!status) return 'Siri/Shortcuts/App Intents integration; no Siri replacement claim.'
+  const state = status.available ? status.surface : 'not available'
+  return `${state}; no Siri replacement claim.`
 }
 
 function androidBaselineLabel(status: TauriAndroidBaselineStatus | null): string {

--- a/packages/aurora-sdk/src/fixtures.ts
+++ b/packages/aurora-sdk/src/fixtures.ts
@@ -2964,6 +2964,10 @@ export const nativeCapabilityManifestFixture: NativeCapabilityManifest = {
     'aurora.audioBridgeStatus': true,
     'aurora.audioCapture': false,
     'aurora.audioPlayback': false,
+    'aurora.iosVoiceStatus': true,
+    'aurora.iosBackgroundStatus': true,
+    'aurora.iosMicrophoneCapture': false,
+    'aurora.iosBackgroundAudio': false,
     'aurora.iosAppIntents': false,
     'aurora.iosShortcuts': false,
     'aurora.iosShareExtension': false,
@@ -2999,6 +3003,10 @@ export const nativeCapabilityManifestFixture: NativeCapabilityManifest = {
     'native.audio': false,
     'native.audioCapture': false,
     'native.audioPlayback': false,
+    'ios.voiceForegroundCapture': false,
+    'ios.notifications': false,
+    'ios.backgroundVoice': false,
+    'ios.appOwnedInvocation': false,
     'ios.appIntents': false,
     'ios.shortcuts': false,
     'ios.shareExtension': false,
@@ -3009,6 +3017,8 @@ export const nativeCapabilityManifestFixture: NativeCapabilityManifest = {
     'ios.siriReplacement': false
   },
   permissionStates: {
+    'aurora.iosMicrophoneCapture': 'needs_native_permission',
+    'aurora.iosBackgroundAudio': 'unsupported_platform',
     'aurora.ios.appIntents': 'needs_native_permission',
     'aurora.ios.shortcuts': 'needs_native_permission',
     'aurora.ios.shareExtension': 'needs_native_permission',
@@ -3018,6 +3028,10 @@ export const nativeCapabilityManifestFixture: NativeCapabilityManifest = {
     'aurora.ios.entrypointPayload': 'needs_native_permission'
   },
   capabilityStates: {
+    'ios.voiceForegroundCapture': 'needs_native_permission',
+    'ios.notifications': 'needs_native_permission',
+    'ios.backgroundVoice': 'unsupported_platform',
+    'ios.appOwnedInvocation': 'needs_native_permission',
     'ios.appIntents': 'needs_native_permission',
     'ios.shortcuts': 'needs_native_permission',
     'ios.shareExtension': 'needs_native_permission',
@@ -3730,6 +3744,10 @@ export const iosNativeCapabilityManifestFixture: NativeCapabilityManifest = {
     'aurora.ios.widgets': true,
     'aurora.ios.fileAssociations': true,
     'aurora.ios.entrypointPayload': true,
+    'aurora.iosVoiceStatus': true,
+    'aurora.iosBackgroundStatus': true,
+    'aurora.iosMicrophoneCapture': false,
+    'aurora.iosBackgroundAudio': false,
     'aurora.iosSiriReplacement': false,
     'aurora.audioCapture': false,
     'aurora.audioPlayback': false
@@ -3742,9 +3760,39 @@ export const iosNativeCapabilityManifestFixture: NativeCapabilityManifest = {
     'ios.deepLinks': true,
     'ios.fileAssociations': true,
     'ios.entrypointPayload': true,
+    'ios.voiceForegroundCapture': false,
+    'ios.notifications': false,
+    'ios.backgroundVoice': false,
+    'ios.appOwnedInvocation': true,
     'ios.siriReplacement': false,
     'native.audioCapture': false,
     'native.audioPlayback': false
+  },
+  permissionStates: {
+    'aurora.iosAppIntents': 'available',
+    'aurora.iosShortcuts': 'available',
+    'aurora.ios.shareExtension': 'available',
+    'aurora.ios.deepLinks': 'available',
+    'aurora.ios.widgets': 'available',
+    'aurora.ios.fileAssociations': 'available',
+    'aurora.ios.entrypointPayload': 'available',
+    'aurora.iosMicrophoneCapture': 'needs_native_permission',
+    'aurora.iosBackgroundAudio': 'unsupported_platform',
+    'aurora.iosSiriReplacement': 'unsupported_platform'
+  },
+  capabilityStates: {
+    'ios.appIntents': 'available',
+    'ios.shortcuts': 'available',
+    'ios.widgets': 'available',
+    'ios.shareExtension': 'available',
+    'ios.deepLinks': 'available',
+    'ios.fileAssociations': 'available',
+    'ios.entrypointPayload': 'available',
+    'ios.voiceForegroundCapture': 'needs_native_permission',
+    'ios.notifications': 'needs_native_permission',
+    'ios.backgroundVoice': 'unsupported_platform',
+    'ios.appOwnedInvocation': 'available',
+    'ios.siriReplacement': 'unsupported_platform'
   },
   mobileIntegrations: [
     {

--- a/packages/aurora-sdk/src/tauri.ts
+++ b/packages/aurora-sdk/src/tauri.ts
@@ -47,6 +47,8 @@ export interface TauriCommandNames {
   trayStatus: string
   notificationStatus: string
   notificationSend: string
+  iosVoiceStatus: string
+  iosBackgroundStatus: string
   dialogStatus: string
   audioBridgeStatus: string
   androidBaselineStatus: string
@@ -274,6 +276,8 @@ const DEFAULT_COMMANDS: TauriCommandNames = {
   trayStatus: 'aurora_tray_status',
   notificationStatus: 'aurora_notification_status',
   notificationSend: 'aurora_notification_send',
+  iosVoiceStatus: 'aurora_ios_voice_status',
+  iosBackgroundStatus: 'aurora_ios_background_status',
   dialogStatus: 'aurora_dialog_status',
   audioBridgeStatus: 'aurora_audio_bridge_status',
   androidBaselineStatus: 'aurora_android_baseline_status',
@@ -415,6 +419,14 @@ export class TauriLocalTransport implements AuroraTransport {
 
   sendNotification(request: TauriNotificationRequest): Promise<TauriNativeFeatureStatus> {
     return this.invokeCommand<TauriNativeFeatureStatus>(this.commands.notificationSend, { request })
+  }
+
+  getIosVoiceStatus(): Promise<TauriNativeFeatureStatus> {
+    return this.invokeCommand<TauriNativeFeatureStatus>(this.commands.iosVoiceStatus)
+  }
+
+  getIosBackgroundStatus(): Promise<TauriNativeFeatureStatus> {
+    return this.invokeCommand<TauriNativeFeatureStatus>(this.commands.iosBackgroundStatus)
   }
 
   getDialogStatus(): Promise<TauriNativeFeatureStatus> {

--- a/packages/aurora-ui/src/assistant-view.tsx
+++ b/packages/aurora-ui/src/assistant-view.tsx
@@ -1284,8 +1284,10 @@ function nativeCaptureState(
   nativePermissions: Array<{ name: string; granted: boolean }>,
   nativeCapabilities: Array<{ name: string; enabled: boolean }>
 ): VoiceCapabilityChip {
-  const permission = nativePermissions.find((entry) => voiceNativeKey(entry.name))
-  const capability = nativeCapabilities.find((entry) => voiceNativeKey(entry.name))
+  const permissionCandidates = nativePermissions.filter((entry) => voiceNativeKey(entry.name))
+  const capabilityCandidates = nativeCapabilities.filter((entry) => voiceNativeKey(entry.name))
+  const permission = permissionCandidates.find((entry) => !entry.granted) ?? permissionCandidates[0]
+  const capability = capabilityCandidates.find((entry) => entry.enabled) ?? capabilityCandidates[0]
   const state = !nativeAvailable
     ? 'unsupported'
     : permission && !permission.granted
@@ -1302,7 +1304,9 @@ function nativeCaptureState(
     detail: state === 'available-local'
       ? 'SDK native manifest reports microphone or voice capture support.'
       : state === 'privacy-blocked'
-        ? 'Native capture is blocked until the platform microphone permission is granted.'
+        ? nativePlatform.toLowerCase().includes('ios')
+          ? 'iOS foreground capture is blocked until microphone permission, raw-audio consent, and a visible stop/revoke path are available.'
+          : 'Native capture is blocked until the platform microphone permission is granted.'
         : 'Tauri, Android, and iOS capture stay disabled until native manifest support lands.',
     blockers: state === 'available-local' ? [] : [permission && !permission.granted ? `native permission missing: ${permission.name}` : 'native voice capture unavailable'],
     evidence: nativeAvailable ? ['native-manifest'] : []
@@ -1387,7 +1391,7 @@ function voiceChip(
 
 function wakeDetail(nativePlatform: string, wakeControl: RouteAvailability, wakeProcess: RouteAvailability): string {
   if (nativePlatform.toLowerCase().includes('ios')) {
-    return 'iOS wake/background assistant behavior remains foreground-only or app-owned unless native capability evidence proves otherwise.'
+    return 'iOS wake/background assistant behavior remains foreground-only or app-owned through Siri/Shortcuts/App Intents, widgets, share sheet, deep links, or notifications; Aurora does not replace Siri.'
   }
   if (nativePlatform.toLowerCase().includes('android')) {
     return 'Android wake/background behavior requires foreground service and native plugin evidence.'

--- a/packages/aurora-ui/src/settings-permissions-view.tsx
+++ b/packages/aurora-ui/src/settings-permissions-view.tsx
@@ -423,7 +423,7 @@ function nativePermissionCards(
     const granted = permission?.granted ?? false
     const capabilityEnabled = capability?.enabled ?? granted
     const nativeState = capability?.nativeState ?? permission?.nativeState ?? null
-    const state = isSiriReplacementPermission(name)
+    const state = isUnsupportedIosSurface(name)
       ? 'unsupported'
       : availabilityFromNativeState(nativeState, granted, capabilityEnabled, snapshot.nativeAvailable)
     const requestEnabled = !granted && nativeRequestAvailable(name, snapshot)
@@ -435,7 +435,7 @@ function nativePermissionCards(
       capabilityEnabled,
       requestEnabled,
       detail: nativePermissionDetail(name, granted, capabilityEnabled, requestEnabled, nativeState),
-      blockers: state === 'unsupported' || granted || nativeState === 'fallback' ? [] : [`native permission missing: ${name}`],
+      blockers: nativePermissionBlockers(name, granted, state, nativeState),
       evidence: nativeRoute?.evidenceSources ?? (snapshot.nativeAvailable ? ['native-manifest'] : [])
     }
   })
@@ -491,6 +491,27 @@ function nativeIntegrationCards(snapshot: AuroraShellSnapshot): SettingsNativeIn
 
 function isSiriReplacementPermission(name: string): boolean {
   return name === 'aurora.iosSiriReplacement' || name === 'ios.siriReplacement'
+}
+
+function isUnsupportedIosSurface(name: string): boolean {
+  return isSiriReplacementPermission(name) ||
+    name === 'aurora.iosBackgroundAudio' ||
+    name === 'ios.backgroundVoice'
+}
+
+function nativePermissionBlockers(
+  name: string,
+  granted: boolean,
+  state: AvailabilityState,
+  nativeState: string | null
+): string[] {
+  if (granted || nativeState === 'fallback') return []
+  if (isSiriReplacementPermission(name)) return ['ios_siri_replacement_unavailable']
+  if (name === 'aurora.iosBackgroundAudio' || name === 'ios.backgroundVoice') {
+    return ['ios_background_voice_limited']
+  }
+  if (state === 'unsupported') return []
+  return [`native permission missing: ${name}`]
 }
 
 function nativeRequestAvailable(name: string, snapshot: AuroraShellSnapshot): boolean {
@@ -653,9 +674,17 @@ function nativePermissionLabel(name: string): string {
     'aurora.iosBiometricUnlock': 'Face ID / Touch ID admin unlock',
     'ios.keychain.secureCredentialStorage': 'iOS Keychain secure storage',
     'ios.biometric.adminUnlock': 'Face ID / Touch ID admin unlock',
+    'aurora.iosVoiceStatus': 'iOS voice status',
+    'aurora.iosBackgroundStatus': 'iOS background voice status',
+    'aurora.iosMicrophoneCapture': 'iOS microphone capture',
+    'aurora.iosBackgroundAudio': 'iOS background voice',
     'aurora.iosSiriReplacement': 'iOS Siri Replacement Unsupported',
     'aurora.iosAppIntents': 'iOS App Intents',
     'aurora.iosShortcuts': 'iOS Shortcuts',
+    'ios.voiceForegroundCapture': 'Foreground voice capture',
+    'ios.notifications': 'iOS notifications',
+    'ios.backgroundVoice': 'Background voice',
+    'ios.appOwnedInvocation': 'App-owned invocation',
     'ios.appIntents': 'App Intents',
     'ios.shortcuts': 'Shortcuts',
     'ios.shareExtension': 'Share extension',
@@ -690,6 +719,18 @@ function nativePermissionDetail(
   }
   if (name === 'ios.appIntents' || name === 'ios.shortcuts') {
     return 'Siri/Shortcuts/App Intents integration is app-owned and scoped to concrete Aurora actions.'
+  }
+  if (name === 'aurora.iosMicrophoneCapture' || name === 'ios.voiceForegroundCapture') {
+    return 'iOS microphone capture is foreground-only and requires AVAudioSession record permission, raw-audio consent, backend audio evidence, and a visible stop/revoke path.'
+  }
+  if (name === 'ios.notifications') {
+    return 'iOS notifications require user authorization and can return users to Aurora, but they cannot provide always-on assistant wake.'
+  }
+  if (name === 'aurora.iosBackgroundAudio' || name === 'ios.backgroundVoice') {
+    return 'Always-on background listening is unavailable on iOS; use foreground capture, notifications, Shortcuts, App Intents, widgets, share sheet, or deep links.'
+  }
+  if (name === 'ios.appOwnedInvocation') {
+    return 'iOS invocation stays app-owned through Siri/Shortcuts/App Intents, widgets, share sheet, and deep links; Aurora does not replace Siri.'
   }
   if (name === 'ios.shareExtension' || name === 'ios.widgets' || name === 'ios.deepLinks') {
     return 'iOS entrypoints stay inside app-owned extension, widget, share, and deep-link surfaces.'

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -493,6 +493,25 @@ describe('Aurora production shell', () => {
         expect.objectContaining({ id: 'siriReplacement', state: 'unsupported' })
       ])
     )
+    expect(model.nativePermissions.find((permission) => permission.id === 'aurora.iosMicrophoneCapture')).toEqual(
+      expect.objectContaining({
+        state: 'privacy-blocked',
+        label: 'iOS microphone capture',
+        detail: expect.stringContaining('raw-audio consent')
+      })
+    )
+    expect(model.nativePermissions.find((permission) => permission.id === 'ios.backgroundVoice')).toEqual(
+      expect.objectContaining({
+        state: 'unsupported',
+        blockers: ['ios_background_voice_limited']
+      })
+    )
+    expect(model.nativePermissions.find((permission) => permission.id === 'ios.appOwnedInvocation')).toEqual(
+      expect.objectContaining({
+        state: 'privacy-blocked',
+        detail: expect.stringContaining('Aurora does not replace Siri')
+      })
+    )
     expect(model.nativeLimitations).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -502,6 +521,9 @@ describe('Aurora production shell', () => {
       ])
     )
     expect(markup).toContain('Siri/Shortcuts/App Intents integration')
+    expect(markup).toContain('iOS microphone capture')
+    expect(markup).toContain('Always-on background listening is unavailable on iOS')
+    expect(markup).toContain('ios_background_voice_limited')
     expect(markup).toContain('iOS share extension intake')
     expect(markup).toContain('iOS file associations')
     expect(markup).toContain('Use Siri/Shortcuts/App Intents integration; do not claim Aurora replaces Siri.')


### PR DESCRIPTION
## Summary

- Added iOS voice, invocation, and background-limit status commands to the Tauri native boundary and SDK transport.
- Exposed iOS App Intents/Shortcuts/widgets/share/deep-link capability states while keeping Siri replacement, background wake, and microphone capture disabled without platform evidence.
- Added a Swift Tauri plugin skeleton for iOS status reporting and updated settings/assistant voice UX copy/tests to show iOS foreground/raw-audio consent limits.

## Validation

- `pnpm --filter @aurora/client build`
- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test`
- `pnpm --filter @aurora/ui typecheck`
- `pnpm --filter @aurora/ui test`
- `pnpm --filter @aurora/tauri-ui typecheck`
- `pnpm --filter @aurora/tauri-ui test`
- `cargo fmt --check`

## Environment-gated checks

- `cargo test ios_statuses_preserve_apple_platform_limits` could not compile the Tauri crate on this Linux host because `glib-2.0` and `gobject-2.0` pkg-config files are missing.
- `pnpm --filter @aurora/tauri-ui tauri ios build` failed because this Linux Tauri CLI surface does not expose the `ios` subcommand. macOS + Xcode validation is still required for the iOS target.
