### PR TITLE
QA-006 release packaging operator gate

### DIFF
--- a/.github/workflows/release-packaging-operator-gate.yml
+++ b/.github/workflows/release-packaging-operator-gate.yml
@@ -1,0 +1,43 @@
+name: Release Packaging Operator Gate
+
+on:
+  pull_request:
+    paths:
+      - "scripts/release_packaging_operator_gate.py"
+      - "tests/e2e/test_release_packaging_operator_gate.py"
+      - "docs/RELEASE_PACKAGING_OPERATOR_RUNBOOK.md"
+      - "apps/aurora-tauri/package.json"
+      - ".github/workflows/release-packaging-operator-gate.yml"
+  workflow_dispatch:
+
+jobs:
+  qa006-release-packaging:
+    name: QA-006 release packaging evidence
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install gate dependencies
+        run: uv sync --extra test-e2e --extra gateway --extra mode-processes
+
+      - name: Generate release packaging gate artifacts
+        run: uv run python scripts/release_packaging_operator_gate.py --print-summary
+
+      - name: Test release packaging gate
+        run: uv run pytest tests/e2e/test_release_packaging_operator_gate.py -q
+
+      - name: Upload QA-006 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: aurora-release-packaging-operator-gate
+          path: .omx/reports/release-packaging-operator/latest/
+          retention-days: 30

--- a/apps/aurora-tauri/package.json
+++ b/apps/aurora-tauri/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "tsc --noEmit --incremental false && vite build",
-    "build:bundle": "pnpm prepare:sidecar && pnpm tauri build --config src-tauri/tauri.release.conf.json",
+    "build:bundle": "pnpm prepare:sidecar && pnpm tauri build --config src-tauri/tauri.conf.json",
     "android:init": "tauri android init --ci --skip-targets-install && node ./scripts/install-android-native-plugin.mjs",
     "android:build:apk": "tauri android build --apk",
     "android:build:apk:x86_64": "tauri android build --apk --target x86_64",

--- a/docs/RELEASE_PACKAGING_OPERATOR_RUNBOOK.md
+++ b/docs/RELEASE_PACKAGING_OPERATOR_RUNBOOK.md
@@ -1,0 +1,88 @@
+# Release Packaging And Operator Runbook
+
+This runbook is the human-readable PER-227 / QA-006 release gate companion. The generated gate artifacts live under `.omx/reports/release-packaging-operator/latest/`:
+
+- `release_packaging_gate.json`
+- `release_packaging_gate.md`
+- `runbook.md`
+
+Run the generator locally with:
+
+```bash
+uv run python scripts/release_packaging_operator_gate.py --print-summary
+uv run pytest tests/e2e/test_release_packaging_operator_gate.py -q
+```
+
+## Install
+
+Prepare Python, JavaScript, Tauri, and platform toolchains before collecting evidence:
+
+```bash
+uv sync --extra test-e2e --extra gateway --extra mode-processes
+pnpm install --frozen-lockfile
+```
+
+Native packaging also requires the relevant platform prerequisites: Tauri Linux WebKit packages, Windows signing/WebDriver tooling, macOS Xcode, Android SDK/NDK, and Apple signing inputs where applicable.
+
+## Update
+
+Release candidates must attach package artifacts and logs for the target platforms:
+
+- Python/server: `python scripts/build.py --target wheel --clean`.
+- Docker process mode: `make docker-process-mode` or the release Docker workflow digest output.
+- Desktop local: `pnpm --filter @aurora/tauri-ui prepare:sidecar` and `pnpm --filter @aurora/tauri-ui build:bundle`.
+- Android: `pnpm --filter @aurora/tauri-ui android:release-gate:strict` and signed APK/AAB evidence.
+- iOS: `pnpm --filter @aurora/tauri-ui ios:policy` plus macOS/Xcode/TestFlight or App Store dry-run evidence.
+
+Every update artifact must include version, commit SHA, package checksum, signing/notarization or upload receipt where applicable, smoke log, owner, and skipped-row rationale.
+
+## Backup
+
+Before update or rollback rehearsal:
+
+1. Capture AdminAction-gated config backup.
+2. Capture DB/RAG export inventory and provenance where policy allows it.
+3. Record model/runtime artifact inventory.
+4. Run restore rehearsal on an isolated profile.
+5. Store the backup manifest with the release candidate artifacts.
+
+Do not attach secrets, raw tokens, Redis URLs, host paths, raw audio, or unredacted RAG records.
+
+## Diagnostics
+
+Collect the automated gate artifacts:
+
+```bash
+uv run python scripts/release_packaging_operator_gate.py
+uv run python scripts/multi_mode_e2e_matrix.py
+uv run python scripts/security_privacy_regression_gate.py
+uv run python scripts/mesh_gap_e2e_harness.py
+```
+
+Attach:
+
+- `.omx/reports/release-packaging-operator/latest/release_packaging_gate.json`
+- `.omx/reports/release-packaging-operator/latest/release_packaging_gate.md`
+- `.omx/reports/release-packaging-operator/latest/runbook.md`
+- `.omx/reports/multi-mode-e2e/latest/matrix.json`
+- `.omx/reports/security-privacy-regression/latest/security_privacy_gate.json`
+- `.omx/reports/mesh-gap-e2e/latest/support_bundle.json`
+
+The support bundle must include correlation IDs and redaction assertions. It must not include raw credentials, Redis URLs, host paths, raw audio, or raw RAG records.
+
+## Rollback
+
+Rollback requires:
+
+1. Previous signed package, sidecar bundle, web deployment artifact, or Docker image digest.
+2. Backup manifest and restore rehearsal log.
+3. AdminAction confirmation for config/data restore.
+4. Re-run of package smoke, security/privacy smoke, diagnostics generation, and restore checks.
+5. Redacted diagnostics bundle with correlation IDs for any rollback failure.
+
+## Production Guardrails
+
+- Mock transport artifacts are fixture evidence only, never production release proof.
+- Android emulator-only evidence remains partial until physical/OEM assistant-role matrix evidence is attached.
+- iOS simulator-only evidence remains partial until TestFlight/real-device evidence is attached; iOS must not claim default-assistant or Siri replacement behavior.
+- Process-mode skips must name the missing Redis/BullMQ dependency, owner, follow-up, and attempted command.

--- a/scripts/release_packaging_operator_gate.py
+++ b/scripts/release_packaging_operator_gate.py
@@ -1,0 +1,543 @@
+"""Generate PER-227 release packaging and operator runbook artifacts.
+
+The QA-006 gate is intentionally evidence-oriented. It records the platform
+packaging commands, required logs, accepted skips, owners, security/privacy
+negative gates, and install/update/backup/diagnostics/rollback operator steps
+required before Aurora can claim production release readiness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPORT_ROOT = Path(".omx/reports/release-packaging-operator")
+
+
+@dataclass(frozen=True)
+class PackagingCommand:
+    """One command or workflow that contributes package evidence."""
+
+    command_id: str
+    platform: str
+    command: str
+    workflow: str
+    artifact: str
+    log_artifact: str
+    owner: str
+    required_for_release: bool = True
+    manual: bool = False
+    skip_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class PlatformReleaseRow:
+    """One platform/package release gate row."""
+
+    row_id: str
+    label: str
+    support_code: str
+    owner: str
+    modes: tuple[str, ...]
+    commands: tuple[PackagingCommand, ...]
+    required_upstream_gates: tuple[str, ...]
+    release_blockers: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OperatorRunbookSection:
+    """One operator runbook section required by QA-006."""
+
+    section_id: str
+    title: str
+    owner: str
+    steps: tuple[str, ...]
+    required_artifact: str
+
+
+@dataclass(frozen=True)
+class NegativeGate:
+    """Security/privacy or release-safety negative gate."""
+
+    gate_id: str
+    category: str
+    assertion: str
+    proving_artifact: str
+    owner: str
+    source_task_ids: tuple[str, ...]
+
+
+@dataclass
+class ReleasePackagingReport:
+    """Serializable top-level PER-227 gate report."""
+
+    report_id: str
+    generated_at: str
+    issue: str
+    branch: str
+    source_docs: list[str]
+    platform_rows: list[dict[str, Any]]
+    negative_gates: list[dict[str, Any]]
+    runbook_sections: list[dict[str, Any]]
+    final_readiness_checklist: list[dict[str, Any]]
+    summary: dict[str, Any]
+    artifacts: dict[str, str]
+    secrets_redacted: bool = True
+
+
+PLATFORM_ROWS: tuple[PlatformReleaseRow, ...] = (
+    PlatformReleaseRow(
+        "python-server",
+        "Python package and process-mode services",
+        "supported",
+        "release-ops",
+        ("thread_localbus", "process_bullmq_redis", "server_web"),
+        (
+            PackagingCommand(
+                "python-wheel",
+                "linux",
+                "python scripts/build.py --target wheel --clean",
+                ".github/workflows/release.yml#validate",
+                "dist/*.whl and dist/*.tar.gz",
+                ".omx/reports/release-packaging-operator/latest/python-wheel.log",
+                "release-ops",
+            ),
+            PackagingCommand(
+                "docker-process-services",
+                "linux",
+                "make docker-process-mode",
+                ".github/workflows/release.yml#docker-build",
+                "Docker service image digests for config/auth/gateway/db/orchestrator/tooling/scheduler/audio services",
+                ".omx/reports/release-packaging-operator/latest/docker-process-services.log",
+                "release-ops",
+            ),
+        ),
+        ("QA-001", "QA-002", "QA-003", "QA-005", "QA-008"),
+        notes=(
+            "Process-mode release evidence must include Redis/BullMQ health or a dependency-gap skip.",
+        ),
+    ),
+    PlatformReleaseRow(
+        "desktop-tauri",
+        "Tauri desktop local package, sidecar, and updater",
+        "partial",
+        "tauri-native",
+        ("desktop_local", "desktop_thin", "tauri_local_native"),
+        (
+            PackagingCommand(
+                "desktop-sidecar",
+                "linux/windows/macos",
+                "pnpm --filter @aurora/tauri-ui prepare:sidecar",
+                ".github/workflows/tauri-desktop.yml#linux-tauri",
+                "apps/aurora-tauri/reports/qa-005-sidecar-smoke.log",
+                "apps/aurora-tauri/reports/qa-005-sidecar-smoke.log",
+                "tauri-native",
+            ),
+            PackagingCommand(
+                "desktop-bundle",
+                "linux/windows/macos",
+                "pnpm --filter @aurora/tauri-ui build:bundle",
+                ".github/workflows/tauri-desktop.yml#linux-tauri plus release runners for Windows/macOS",
+                "Tauri AppImage/deb/rpm/dmg/msi/nsis bundles and updater manifests",
+                ".omx/reports/release-packaging-operator/latest/desktop-bundle.log",
+                "tauri-native",
+            ),
+        ),
+        ("TAURI-006", "QA-004", "QA-005"),
+        release_blockers=(
+            "Final production desktop release still needs signed Windows/macOS artifacts and updater endpoint verification from release runners.",
+        ),
+    ),
+    PlatformReleaseRow(
+        "android-tauri",
+        "Android APK/AAB, signing, and assistant-role device matrix",
+        "partial",
+        "android-native",
+        ("android_thin", "android_local_light"),
+        (
+            PackagingCommand(
+                "android-emulator-apk",
+                "android",
+                "pnpm --filter @aurora/tauri-ui android:build:apk:x86_64:debug && pnpm --filter @aurora/tauri-ui android:smoke",
+                ".github/workflows/tauri-android.yml#android-tauri",
+                "aurora-tauri-android-apk and emulator smoke logs",
+                ".omx/reports/release-packaging-operator/latest/android-emulator.log",
+                "android-native",
+            ),
+            PackagingCommand(
+                "android-signed-release",
+                "android",
+                "pnpm --filter @aurora/tauri-ui android:release-gate:strict && pnpm --filter @aurora/tauri-ui android:build:aab",
+                "manual-device-lab/android",
+                "signed Android App Bundle, Play upload receipt, and physical/OEM assistant-role matrix",
+                "device-lab/android-assistant-role-and-oem-matrix.md",
+                "android-native",
+                manual=True,
+                skip_reason="Emulator-only CI cannot prove production assistant-role behavior.",
+            ),
+        ),
+        ("AND-009", "QA-002", "QA-003"),
+        release_blockers=(
+            "Physical/OEM assistant-role matrix is required before Android production-complete status.",
+        ),
+    ),
+    PlatformReleaseRow(
+        "ios-tauri",
+        "iOS App Store/TestFlight package and app-owned integration matrix",
+        "partial",
+        "ios-native",
+        ("ios_thin", "ios_local_light"),
+        (
+            PackagingCommand(
+                "ios-policy",
+                "ios",
+                "pnpm --filter @aurora/tauri-ui ios:policy",
+                ".github/workflows/tauri-ios-release.yml#ios-policy",
+                "iOS release gate policy log",
+                ".omx/reports/release-packaging-operator/latest/ios-policy.log",
+                "ios-native",
+            ),
+            PackagingCommand(
+                "ios-app-store-dry-run",
+                "ios",
+                "pnpm --filter @aurora/tauri-ui ios:build:app-store",
+                ".github/workflows/tauri-ios-release.yml#ios-macos-xcode",
+                "IPA, App Store Connect dry-run/upload evidence, and TestFlight real-device matrix",
+                "device-lab/ios-testflight-real-device-matrix.md",
+                "ios-native",
+                manual=True,
+                skip_reason="Simulator-only CI cannot prove real-device/TestFlight behavior.",
+            ),
+        ),
+        ("IOS-008", "QA-002", "QA-003"),
+        release_blockers=(
+            "Real-device/TestFlight matrix is required before iOS production-complete status.",
+        ),
+        notes=("iOS must not claim default-assistant or Siri replacement behavior.",),
+    ),
+)
+
+
+NEGATIVE_GATES: tuple[NegativeGate, ...] = (
+    NegativeGate(
+        "security-privacy-negative-suite",
+        "security_privacy",
+        "QA-003 negative cases pass before release packaging can be promoted.",
+        ".omx/reports/security-privacy-regression/latest/security_privacy_gate.json",
+        "qa-release",
+        ("QA-003",),
+    ),
+    NegativeGate(
+        "mock-transport-not-release-proof",
+        "release_safety",
+        "Mock transport and fixture-only evidence are rejected as production release proof.",
+        ".omx/reports/multi-mode-e2e/latest/matrix.json",
+        "qa-release",
+        ("QA-002", "SDK-014"),
+    ),
+    NegativeGate(
+        "emulator-only-mobile-not-production-complete",
+        "release_safety",
+        "Android emulator and iOS simulator evidence stay partial until physical/TestFlight matrices are attached.",
+        "device-lab/android-assistant-role-and-oem-matrix.md and device-lab/ios-testflight-real-device-matrix.md",
+        "release-ops",
+        ("AND-009", "IOS-008", "QA-006"),
+    ),
+    NegativeGate(
+        "diagnostics-redaction-required",
+        "credential",
+        "Diagnostics bundles must omit raw tokens, Redis URLs, host paths, raw audio, and raw RAG records.",
+        ".omx/reports/mesh-gap-e2e/latest/support_bundle.json",
+        "qa-release",
+        ("ADM-009", "QA-003", "QA-006"),
+    ),
+)
+
+
+RUNBOOK_SECTIONS: tuple[OperatorRunbookSection, ...] = (
+    OperatorRunbookSection(
+        "install",
+        "Install",
+        "release-ops",
+        (
+            "Install Python dependencies with `uv sync --extra test-e2e --extra gateway --extra mode-processes`.",
+            "Install frontend/native dependencies with `pnpm install --frozen-lockfile`.",
+            "Install platform prerequisites before native packaging: Tauri Linux WebKit packages, Windows Edge WebDriver/signing tooling, macOS Xcode, Android SDK/NDK, or Apple signing tools as applicable.",
+        ),
+        "dependency installation logs and platform prerequisite summary",
+    ),
+    OperatorRunbookSection(
+        "update",
+        "Update",
+        "release-ops",
+        (
+            "Build Python/server artifacts, Docker process-mode images, Tauri desktop bundles, Android APK/AAB, and iOS IPA/TestFlight artifacts for the target release candidate.",
+            "Attach version, commit SHA, package checksums, signing/notarization/upload receipts, updater manifest, and smoke logs.",
+            "Run QA-001 through QA-006 gates and record every skipped row with owner and accepted rationale.",
+        ),
+        ".omx/reports/release-packaging-operator/latest/release_packaging_gate.json",
+    ),
+    OperatorRunbookSection(
+        "backup",
+        "Backup",
+        "release-ops",
+        (
+            "Create AdminAction-gated backups for config, DB/RAG, and model/runtime inventory before upgrade.",
+            "Record provenance, namespace, retention, and redaction policy for each backup artifact.",
+            "Run restore rehearsal on an isolated profile before promoting the release candidate.",
+        ),
+        "backup manifest, restore rehearsal log, and AdminAction audit receipt",
+    ),
+    OperatorRunbookSection(
+        "diagnostics",
+        "Diagnostics",
+        "qa-release",
+        (
+            "Generate QA-002, QA-003, QA-004, QA-005, QA-006, and mesh support-bundle artifacts.",
+            "Attach Gateway/Auth/Config/Supervisor/Mesh/Orchestrator/Tooling evidence only through public SDK or documented release commands.",
+            "Verify `secrets_redacted=true` and correlation IDs for failures before sharing support bundles.",
+        ),
+        ".omx/reports/release-packaging-operator/latest/runbook.md",
+    ),
+    OperatorRunbookSection(
+        "rollback",
+        "Rollback",
+        "release-ops",
+        (
+            "Select the previous release whose QA-001 through QA-006 artifacts are complete for the affected platform.",
+            "Restore the previous package/sidecar/web deployment and updater manifest; restore config/data only after AdminAction confirmation.",
+            "Rerun package smoke, security/privacy smoke, diagnostics bundle generation, and restore checks before declaring rollback complete.",
+        ),
+        "rollback checklist, restored package checksums, restore audit receipt, and redacted diagnostics bundle",
+    ),
+)
+
+
+def build_report(output_dir: Path) -> ReleasePackagingReport:
+    """Build and persist the PER-227 release packaging gate artifacts."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = {
+        "json": str(output_dir / "release_packaging_gate.json"),
+        "markdown": str(output_dir / "release_packaging_gate.md"),
+        "runbook": str(output_dir / "runbook.md"),
+    }
+    manual_items = [
+        command
+        for row in PLATFORM_ROWS
+        for command in row.commands
+        if command.manual
+    ]
+    release_blockers = [
+        blocker
+        for row in PLATFORM_ROWS
+        for blocker in row.release_blockers
+    ]
+    report = ReleasePackagingReport(
+        report_id="PER-227-QA-006-release-packaging-operator-runbooks",
+        generated_at=datetime.now(UTC).isoformat(),
+        issue="PER-227",
+        branch="multica/QA-006-release-packaging-operator-runbooks",
+        source_docs=[
+            ".omx/specs/ui-production-tasks/tasks/QA-006-build-release-packaging-and-operator-runbooks.md",
+            "docs/MULTI_MODE_E2E_RELEASE_RUNBOOK.md",
+            "docs/SECURITY_PRIVACY_REGRESSION_RUNBOOK.md",
+            "docs/QA-005_PERFORMANCE_OFFLINE_RESILIENCE_RUNBOOK.md",
+            ".omx/specs/ui-refinement/aurora-ui-sdk-contract.md",
+        ],
+        platform_rows=[asdict(row) for row in PLATFORM_ROWS],
+        negative_gates=[asdict(gate) for gate in NEGATIVE_GATES],
+        runbook_sections=[asdict(section) for section in RUNBOOK_SECTIONS],
+        final_readiness_checklist=_readiness_checklist(release_blockers),
+        summary={
+            "platform_count": len(PLATFORM_ROWS),
+            "platforms": [row.row_id for row in PLATFORM_ROWS],
+            "required_commands": [
+                command.command_id for row in PLATFORM_ROWS for command in row.commands
+            ],
+            "manual_device_lab_items": [command.command_id for command in manual_items],
+            "accepted_skips": {
+                command.command_id: command.skip_reason
+                for command in manual_items
+                if command.skip_reason
+            },
+            "release_blockers": release_blockers,
+            "runbook_sections": [section.section_id for section in RUNBOOK_SECTIONS],
+            "negative_gate_count": len(NEGATIVE_GATES),
+            "mock_transport_release_evidence_allowed": False,
+            "production_complete": not release_blockers,
+        },
+        artifacts=artifacts,
+    )
+    (output_dir / "release_packaging_gate.json").write_text(
+        json.dumps(asdict(report), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "release_packaging_gate.md").write_text(
+        _render_gate_markdown(report),
+        encoding="utf-8",
+    )
+    (output_dir / "runbook.md").write_text(_render_runbook_markdown(report), encoding="utf-8")
+    return report
+
+
+def _readiness_checklist(release_blockers: list[str]) -> list[dict[str, Any]]:
+    return [
+        {
+            "task_id": "QA-001",
+            "requirement": "SDK/backend contract conformance CI is green.",
+            "artifact": ".github/workflows/sdk-backend-contract-conformance.yml",
+            "status": "required",
+        },
+        {
+            "task_id": "QA-002",
+            "requirement": "Multi-mode E2E matrix is generated and release blockers are understood.",
+            "artifact": ".omx/reports/multi-mode-e2e/latest/matrix.json",
+            "status": "required",
+        },
+        {
+            "task_id": "QA-003",
+            "requirement": "Security/privacy negative cases pass before packaging promotion.",
+            "artifact": ".omx/reports/security-privacy-regression/latest/security_privacy_gate.json",
+            "status": "required",
+        },
+        {
+            "task_id": "QA-004",
+            "requirement": "Screen-level accessibility, responsive, and visual evidence is attached.",
+            "artifact": "docs/QA-004-accessibility-responsive-visual-runbook.md",
+            "status": "required",
+        },
+        {
+            "task_id": "QA-005",
+            "requirement": "Performance, offline, resilience, and Tauri sidecar smoke evidence is attached.",
+            "artifact": "docs/QA-005_PERFORMANCE_OFFLINE_RESILIENCE_RUNBOOK.md",
+            "status": "required",
+        },
+        {
+            "task_id": "QA-006",
+            "requirement": "Release packaging gate records commands, logs, platforms, skipped tests, owners, and operator runbook sections.",
+            "artifact": ".omx/reports/release-packaging-operator/latest/release_packaging_gate.json",
+            "status": "covered",
+        },
+        {
+            "task_id": "QA-007",
+            "requirement": "Final readiness audit consumes QA-001 through QA-006 artifacts.",
+            "artifact": ".omx/specs/ui-production-tasks/tasks/QA-007-final-production-readiness-audit-and-task-board-closure.md",
+            "status": "required",
+        },
+        {
+            "task_id": "DEVICE-LAB",
+            "requirement": "Physical Android/OEM and iOS TestFlight evidence is attached.",
+            "artifact": "device-lab/*.md",
+            "status": "blocked" if release_blockers else "covered",
+            "blockers": release_blockers,
+        },
+    ]
+
+
+def _render_gate_markdown(report: ReleasePackagingReport) -> str:
+    lines = [
+        "# PER-227 Release Packaging And Operator Gate",
+        "",
+        f"Generated: {report.generated_at}",
+        "",
+        "| Platform | Support | Owner | Modes | Commands | Release blockers |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in report.platform_rows:
+        commands = "<br>".join(command["command_id"] for command in row["commands"])
+        blockers = "<br>".join(row["release_blockers"]) if row["release_blockers"] else "None"
+        lines.append(
+            "| {label} | {support} | {owner} | {modes} | {commands} | {blockers} |".format(
+                label=row["label"],
+                support=row["support_code"],
+                owner=row["owner"],
+                modes=", ".join(row["modes"]),
+                commands=commands,
+                blockers=blockers,
+            )
+        )
+    lines.extend(["", "## Commands", ""])
+    for row in report.platform_rows:
+        for command in row["commands"]:
+            skip = f" Skip: {command['skip_reason']}" if command["skip_reason"] else ""
+            lines.append(
+                f"- `{command['command_id']}` `{command['platform']}` owner `{command['owner']}`: "
+                f"`{command['command']}` -> artifact `{command['artifact']}`, log "
+                f"`{command['log_artifact']}`.{skip}"
+            )
+    lines.extend(["", "## Negative Gates", ""])
+    for gate in report.negative_gates:
+        lines.append(
+            f"- `{gate['gate_id']}` `{gate['category']}`: {gate['assertion']} "
+            f"Artifact: `{gate['proving_artifact']}`."
+        )
+    lines.extend(["", "## Readiness Checklist", ""])
+    for item in report.final_readiness_checklist:
+        lines.append(
+            f"- `{item['task_id']}` `{item['status']}`: {item['requirement']} "
+            f"Artifact: `{item['artifact']}`."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _render_runbook_markdown(report: ReleasePackagingReport) -> str:
+    lines = [
+        "# PER-227 Operator Release Runbook",
+        "",
+        (
+            "This runbook records the install, update, backup, diagnostics, and rollback "
+            "steps required by QA-006. It is a gate artifact, not final production approval "
+            "while platform blockers remain."
+        ),
+        "",
+    ]
+    for section in report.runbook_sections:
+        lines.extend([f"## {section['title']}", "", f"Owner: `{section['owner']}`", ""])
+        for step in section["steps"]:
+            lines.append(f"- {step}")
+        lines.extend(["", f"Required artifact: `{section['required_artifact']}`", ""])
+    lines.extend(
+        [
+            "## Release Guardrails",
+            "",
+            "- Mock transport artifacts are fixture evidence only and must not be attached as production proof.",
+            "- Android emulator-only and iOS simulator-only evidence remain partial until physical/TestFlight matrices are attached.",
+            "- Redacted diagnostics must omit raw credentials, Redis URLs, host paths, raw audio, and raw RAG records.",
+            "- Rollback must use a prior release whose QA-001 through QA-006 artifacts are complete for the affected platform.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPORT_ROOT / "latest",
+        help="Directory for release_packaging_gate.json, release_packaging_gate.md, and runbook.md.",
+    )
+    parser.add_argument(
+        "--print-summary",
+        action="store_true",
+        help="Print the generated summary JSON.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_report(args.output_dir)
+    if args.print_summary:
+        print(json.dumps(report.summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/test_release_packaging_operator_gate.py
+++ b/tests/e2e/test_release_packaging_operator_gate.py
@@ -1,0 +1,108 @@
+"""PER-227 release packaging and operator runbook gate tests."""
+
+import json
+
+import pytest
+
+from scripts.release_packaging_operator_gate import (
+    NEGATIVE_GATES,
+    PLATFORM_ROWS,
+    RUNBOOK_SECTIONS,
+    build_report,
+)
+
+
+@pytest.mark.e2e
+def test_release_packaging_gate_records_platforms_commands_and_artifacts(tmp_path):
+    build_report(tmp_path)
+
+    gate_json = tmp_path / "release_packaging_gate.json"
+    gate_md = tmp_path / "release_packaging_gate.md"
+    runbook = tmp_path / "runbook.md"
+
+    assert gate_json.exists()
+    assert gate_md.exists()
+    assert runbook.exists()
+
+    persisted = json.loads(gate_json.read_text(encoding="utf-8"))
+    expected_platforms = {row.row_id for row in PLATFORM_ROWS}
+    expected_commands = {
+        command.command_id for row in PLATFORM_ROWS for command in row.commands
+    }
+    assert {row["row_id"] for row in persisted["platform_rows"]} == expected_platforms
+    assert set(persisted["summary"]["required_commands"]) == expected_commands
+    assert persisted["summary"]["platform_count"] == len(PLATFORM_ROWS)
+    assert persisted["summary"]["mock_transport_release_evidence_allowed"] is False
+    assert persisted["summary"]["production_complete"] is False
+    assert persisted["secrets_redacted"] is True
+
+
+@pytest.mark.e2e
+def test_release_packaging_gate_documents_skips_owners_and_manual_device_lab(tmp_path):
+    report = build_report(tmp_path)
+    manual_items = set(report.summary["manual_device_lab_items"])
+    accepted_skips = report.summary["accepted_skips"]
+    owners = {
+        command["owner"]
+        for row in report.platform_rows
+        for command in row["commands"]
+    }
+
+    assert {"android-signed-release", "ios-app-store-dry-run"}.issubset(manual_items)
+    assert "Emulator-only CI cannot prove production assistant-role behavior." in accepted_skips[
+        "android-signed-release"
+    ]
+    assert "Simulator-only CI cannot prove real-device/TestFlight behavior." in accepted_skips[
+        "ios-app-store-dry-run"
+    ]
+    assert {"release-ops", "tauri-native", "android-native", "ios-native"}.issubset(owners)
+
+
+@pytest.mark.e2e
+def test_release_packaging_gate_requires_security_privacy_negative_cases(tmp_path):
+    report = build_report(tmp_path)
+    gates = {gate["gate_id"]: gate for gate in report.negative_gates}
+
+    assert set(gates) == {gate.gate_id for gate in NEGATIVE_GATES}
+    assert gates["security-privacy-negative-suite"]["category"] == "security_privacy"
+    assert gates["mock-transport-not-release-proof"]["category"] == "release_safety"
+    assert gates["emulator-only-mobile-not-production-complete"]["category"] == "release_safety"
+    assert gates["diagnostics-redaction-required"]["category"] == "credential"
+    assert "QA-003" in gates["security-privacy-negative-suite"]["source_task_ids"]
+
+
+@pytest.mark.e2e
+def test_release_operator_runbook_has_required_operations_and_no_secret_leaks(tmp_path):
+    report = build_report(tmp_path)
+    section_ids = {section["section_id"] for section in report.runbook_sections}
+
+    assert section_ids == {section.section_id for section in RUNBOOK_SECTIONS}
+    assert {"install", "update", "backup", "diagnostics", "rollback"}.issubset(section_ids)
+
+    serialized = json.dumps(report.__dict__, default=str)
+    for forbidden in (
+        "secret-token",
+        "redis://localhost:6379",
+        "/home/developer",
+        "mock transport is production",
+    ):
+        assert forbidden not in serialized
+
+    runbook = (tmp_path / "runbook.md").read_text(encoding="utf-8")
+    assert "Install" in runbook
+    assert "Update" in runbook
+    assert "Backup" in runbook
+    assert "Diagnostics" in runbook
+    assert "Rollback" in runbook
+    assert "Mock transport artifacts are fixture evidence only" in runbook
+
+
+@pytest.mark.e2e
+def test_release_readiness_checklist_crosslinks_qa_task_ids(tmp_path):
+    report = build_report(tmp_path)
+    checklist = {item["task_id"]: item for item in report.final_readiness_checklist}
+
+    required = {"QA-001", "QA-002", "QA-003", "QA-004", "QA-005", "QA-006", "QA-007"}
+    assert required.issubset(checklist)
+    assert checklist["QA-006"]["status"] == "covered"
+    assert checklist["DEVICE-LAB"]["status"] == "blocked"


### PR DESCRIPTION
## Summary

- adds the PER-227 / QA-006 release packaging operator gate generator
- adds the operator runbook covering install, update, backup, diagnostics, and rollback
- adds a focused E2E test and CI workflow that generate/upload QA-006 artifacts
- fixes the Tauri desktop `build:bundle` script to use the existing committed release-capable config

## Impact

The release gate now records platform commands, logs/artifacts, owners, accepted skips, upstream QA cross-links, security/privacy negative gates, and manual device-lab blockers without claiming mock-only or emulator-only readiness as production complete.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache-per227 uv run python scripts/release_packaging_operator_gate.py --print-summary`
- `UV_CACHE_DIR=/tmp/uv-cache-per227 uv run --extra test pytest tests/e2e/test_release_packaging_operator_gate.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache-per227 uv run --extra dev ruff check scripts/release_packaging_operator_gate.py tests/e2e/test_release_packaging_operator_gate.py`

## Known Boundaries

- Production complete remains `false` until signed Windows/macOS desktop artifacts, updater endpoint verification, Android physical/OEM assistant-role evidence, and iOS TestFlight/real-device evidence are attached.
- Mock transport artifacts are fixture evidence only.
