### PR TITLE
PER-229: Add QA-008 transport parity gate

### DIFF
--- a/.github/workflows/transport-parity.yml
+++ b/.github/workflows/transport-parity.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install uv
-          uv sync --extra dev --extra test-e2e
+          uv sync --extra gateway --extra mode-processes --extra test-e2e
 
       - name: Install workspace packages
         run: pnpm install --frozen-lockfile
@@ -48,7 +48,7 @@ jobs:
         env:
           REDIS_URL: redis://localhost:6379
           AURORA_ARCHITECTURE_MODE: processes
-        run: uv run python scripts/transport_parity_gate.py --execute-commands --output-dir .omx/reports/transport-parity/ci
+        run: uv run --extra gateway --extra mode-processes --extra test-e2e python scripts/transport_parity_gate.py --execute-commands --output-dir .omx/reports/transport-parity/ci
 
       - name: Upload QA-008 transport parity artifacts
         if: always()

--- a/.github/workflows/transport-parity.yml
+++ b/.github/workflows/transport-parity.yml
@@ -1,0 +1,58 @@
+name: QA-008 Transport Parity Gate
+
+on:
+  workflow_dispatch:
+
+jobs:
+  transport-parity:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11.11"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.25.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install Python dependencies
+        run: |
+          pip install uv
+          uv sync --extra dev --extra test-e2e
+
+      - name: Install workspace packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Run QA-008 transport parity gate
+        env:
+          REDIS_URL: redis://localhost:6379
+          AURORA_ARCHITECTURE_MODE: processes
+        run: uv run python scripts/transport_parity_gate.py --execute-commands --output-dir .omx/reports/transport-parity/ci
+
+      - name: Upload QA-008 transport parity artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-008-transport-parity
+          path: .omx/reports/transport-parity/ci

--- a/.omx/plans/PER-229-transport-parity-gate.md
+++ b/.omx/plans/PER-229-transport-parity-gate.md
@@ -1,0 +1,43 @@
+# PER-229 / QA-008 Transport Parity Gate Plan
+
+## Requirements Summary
+
+- Source of truth: Multica PER-229 / QA-008 and `.omx/specs/ui-production-tasks/tasks/QA-008-build-thread-process-mesh-transport-parity-gate.md`.
+- Relevant guidance read: root `AGENTS.md`, `tests/AGENTS.md`, `app/messaging/AGENTS.md`, `app/services/gateway/AGENTS.md`, `app/shared/AGENTS.md`, `app/shared/contracts/AGENTS.md`.
+- UI/SDK context read: `.omx/specs/ui-refinement/*`, `.omx/specs/ui-production-tasks/index.md`, `.omx/specs/ui-production-tasks/backend-gap-crosswalk.md`, `.omx/specs/mesh-ui-roadmap-integration-review.md`, `modules/ui-mock-reference/README.md`, `modules/ui-mock-reference/lib/aurora/data.ts`, and `modules/ui-mock-reference/components/aurora/assistant/route-sheet.tsx`.
+- Existing evidence to reuse: `scripts/mesh_gap_e2e_harness.py`, `tests/e2e/test_mesh_gap_e2e_harness.py`, and `packages/aurora-sdk/tests/conformance.test.ts`.
+
+## Acceptance Criteria
+
+- Emit a single QA-008 matrix artifact with rows for thread/local, process/Redis, server HTTP, desktop Tauri local, mesh/WebRTC, Android thin/local-light, and iOS thin/local-light.
+- Every row records pass/fail/skipped-with-rationale, owner, command(s), artifact path(s), and coverage claims.
+- The gate must not pass on mock-only SDK evidence: live/hermetic transport rows and SDK/UI command evidence are tracked separately, and missing live evidence blocks release readiness.
+- Process/Redis, Android, and iOS environment gaps are explicit skipped/blocked rows with the exact command needed to produce evidence.
+- Artifacts redact Redis URLs, local host paths, tokens, peer secrets, and secret-like diagnostics.
+
+## Implementation Steps
+
+1. Add `scripts/transport_parity_gate.py` as the QA-008 release wrapper around the existing two-peer harness and SDK/UI command evidence.
+2. Add e2e tests for matrix shape, row status semantics, redaction, and "mock evidence alone cannot pass".
+3. Add a concise runbook for local/CI execution and artifact expectations.
+4. Add a GitHub Actions workflow/manual gate entry if the repo does not already have a QA-008 workflow.
+5. Verify targeted Python tests and run the lightest available SDK/UI commands locally.
+
+## Risks And Mitigations
+
+- Redis/Docker/mobile runners may be unavailable locally. Mitigation: mark rows `skipped-with-rationale`, keep `blocks_release=true`, and record exact commands/follow-up evidence.
+- Mock SDK tests can hide transport failures. Mitigation: the report has separate `mock_only_evidence_passed` and `release_ready` fields; release readiness requires real/hermetic transport rows.
+- Secrets can leak through diagnostics. Mitigation: reuse the mesh harness redaction posture and add release-gate redaction tests.
+
+## Verification Steps
+
+- `uv run pytest tests/e2e/test_transport_parity_gate.py -q`
+- `uv run pytest tests/e2e/test_mesh_gap_e2e_harness.py -q`
+- `pnpm --filter @aurora/client build`
+- `pnpm --filter @aurora/client test`
+- `pnpm --filter @aurora/ui test`
+- `pnpm --filter @aurora/tauri-ui test`
+
+## Stop Rule
+
+Hand off to QA when the report generator, tests, docs/workflow, and local verification are committed and a PR exists. Do not trigger the batch-tail autopilot until QA and architect gates complete for PER-227 and PER-229.

--- a/.omx/ultragoal/PER-229-checkpoints.md
+++ b/.omx/ultragoal/PER-229-checkpoints.md
@@ -1,0 +1,19 @@
+# PER-229 Ultragoal Checkpoints
+
+## G001 - Source Context
+
+Status: complete
+
+Evidence: Read PER-229 issue, empty comment history, metadata, root/test/messaging/gateway/shared/contracts AGENTS guidance, UI refinement specs, QA-008 task file, SDK-014 task file, process-mode docs, docker-compose process mode, and UI mock references.
+
+## G002 - Plan
+
+Status: complete
+
+Evidence: `.omx/plans/PER-229-transport-parity-gate.md` records source docs, acceptance criteria, risks, and verification strategy.
+
+## G003 - Implementation
+
+Status: complete
+
+Evidence: Added `scripts/transport_parity_gate.py`, `tests/e2e/test_transport_parity_gate.py`, `docs/TRANSPORT_PARITY_GATE.md`, and `.github/workflows/transport-parity.yml`. Local executed report generated at `.omx/reports/transport-parity/local-executed/transport_parity_report.json`; summary is blocked only by explicit process/Redis and iOS environment rows, with thread/HTTP/Tauri/mesh/Android rows passing.

--- a/.omx/ultragoal/PER-229-checkpoints.md
+++ b/.omx/ultragoal/PER-229-checkpoints.md
@@ -17,3 +17,11 @@ Evidence: `.omx/plans/PER-229-transport-parity-gate.md` records source docs, acc
 Status: complete
 
 Evidence: Added `scripts/transport_parity_gate.py`, `tests/e2e/test_transport_parity_gate.py`, `docs/TRANSPORT_PARITY_GATE.md`, and `.github/workflows/transport-parity.yml`. Local executed report generated at `.omx/reports/transport-parity/local-executed/transport_parity_report.json`; summary is blocked only by explicit process/Redis and iOS environment rows, with thread/HTTP/Tauri/mesh/Android rows passing.
+
+## G004 - QA Rejection Fix: Script Entrypoint
+
+Status: complete
+
+Evidence: QA reproduced `python scripts/transport_parity_gate.py ...` failing before report generation with `ModuleNotFoundError: No module named 'scripts'`.
+
+Resolution: Added file-entrypoint import bootstrapping and a direct `python scripts/transport_parity_gate.py --help` regression. Reran the rejected full gate command; it now writes `.omx/reports/transport-parity/qa-local/transport_parity_report.json` and exits through the structured `blocked` summary for process/Android/iOS release-evidence gaps instead of crashing before report generation.

--- a/.omx/ultragoal/PER-229-checkpoints.md
+++ b/.omx/ultragoal/PER-229-checkpoints.md
@@ -25,3 +25,11 @@ Status: complete
 Evidence: QA reproduced `python scripts/transport_parity_gate.py ...` failing before report generation with `ModuleNotFoundError: No module named 'scripts'`.
 
 Resolution: Added file-entrypoint import bootstrapping and a direct `python scripts/transport_parity_gate.py --help` regression. Reran the rejected full gate command; it now writes `.omx/reports/transport-parity/qa-local/transport_parity_report.json` and exits through the structured `blocked` summary for process/Android/iOS release-evidence gaps instead of crashing before report generation.
+
+## G005 - Architect Rejection Fix: Workflow Extras
+
+Status: complete
+
+Evidence: Architect reproduced the workflow-level Python environment failing before report generation with `ModuleNotFoundError: No module named 'fastapi'` because the manual workflow installed only `dev` and `test-e2e` extras while the gate imports the Gateway/mesh harness and process-mode dependencies.
+
+Resolution: Updated `.github/workflows/transport-parity.yml` so dependency sync and gate execution both include `gateway`, `mode-processes`, and `test-e2e` extras. Verified from a fresh uv project environment at `/tmp/per229-workflow-venv-qa008`; the workflow-equivalent command wrote `.omx/reports/transport-parity/workflow-equivalent/transport_parity_report.json` and exited through the structured `blocked` summary instead of crashing before report generation.

--- a/.omx/ultragoal/PER-229-checkpoints.md
+++ b/.omx/ultragoal/PER-229-checkpoints.md
@@ -33,3 +33,11 @@ Status: complete
 Evidence: Architect reproduced the workflow-level Python environment failing before report generation with `ModuleNotFoundError: No module named 'fastapi'` because the manual workflow installed only `dev` and `test-e2e` extras while the gate imports the Gateway/mesh harness and process-mode dependencies.
 
 Resolution: Updated `.github/workflows/transport-parity.yml` so dependency sync and gate execution both include `gateway`, `mode-processes`, and `test-e2e` extras. Verified from a fresh uv project environment at `/tmp/per229-workflow-venv-qa008`; the workflow-equivalent command wrote `.omx/reports/transport-parity/workflow-equivalent/transport_parity_report.json` and exited through the structured `blocked` summary instead of crashing before report generation.
+
+## G006 - Architect Rejection Fix: Runbook Extras
+
+Status: complete
+
+Evidence: Architect found `docs/TRANSPORT_PARITY_GATE.md` still documented bare `uv run python scripts/transport_parity_gate.py ...` commands, which are not a clean-environment contract because Gateway and process dependencies live behind optional extras.
+
+Resolution: Updated every documented local/manual gate invocation to use `gateway`, `mode-processes`, and `test-e2e` extras and added the matching clean setup command. Verified the documented setup, report-only command, and full local gate command from a fresh uv project environment at `/tmp/per229-runbook-venv-qa008`; both gate commands wrote `.omx/reports/transport-parity/local/transport_parity_report.json` and exited through structured `blocked` summaries instead of dependency/import failures.

--- a/docs/TRANSPORT_PARITY_GATE.md
+++ b/docs/TRANSPORT_PARITY_GATE.md
@@ -1,0 +1,36 @@
+# QA-008 Transport Parity Gate
+
+`scripts/transport_parity_gate.py` is the release gate for PER-229 / QA-008. It combines:
+
+- `scripts/mesh_gap_e2e_harness.py` for thread/LocalBus, process/BullMQ+Redis, HTTP Gateway, Tauri local command smoke, and real two-peer Mesh/WebRTC DataChannel evidence.
+- `pnpm --filter @aurora/client build` so package tests consume the SDK `dist/` entrypoint.
+- `pnpm --filter @aurora/client test` for the shared AuroraClient conformance suite across mock, HTTP, Tauri command, and mesh mock transports.
+- `pnpm --filter @aurora/ui test` for SDK-bound user-flow smoke models.
+- `pnpm --filter @aurora/tauri-ui test` for the desktop local/Tauri wrapper boundary.
+- Android/iOS rows with explicit skipped-with-rationale status until Android emulator/device smoke or macOS/Xcode runner evidence is attached. The non-strict Android release report is useful evidence, but does not by itself pass the Android row.
+
+Run the local report without executing package commands:
+
+```bash
+uv run python scripts/transport_parity_gate.py --output-dir .omx/reports/transport-parity/local
+```
+
+Run the full local gate where Node dependencies and platform tools are installed:
+
+```bash
+pnpm install
+pnpm --filter @aurora/client build
+uv run python scripts/transport_parity_gate.py --execute-commands --output-dir .omx/reports/transport-parity/local
+```
+
+Expected artifacts:
+
+- `.omx/reports/transport-parity/local/transport_parity_report.json`
+- `.omx/reports/transport-parity/local/mesh-gap-e2e/report.json`
+- `.omx/reports/transport-parity/local/mesh-gap-e2e/events.ndjson`
+- `.omx/reports/transport-parity/local/mesh-gap-e2e/support_bundle.json`
+- `.omx/reports/transport-parity/local/commands/*.log` when `--execute-commands` is used
+
+The release is not ready unless `summary.status` is `pass`. A process/Redis dependency gap, missing SDK/UI command evidence, Android/iOS platform skip, or any failed row keeps `release_ready=false`.
+
+The report redacts Redis URLs, host paths, tokens, peer secrets, and secret-like fields. Mock transport conformance is useful evidence, but `mock_only_evidence_sufficient` is always `false`; a mock-only pass cannot satisfy QA-008.

--- a/docs/TRANSPORT_PARITY_GATE.md
+++ b/docs/TRANSPORT_PARITY_GATE.md
@@ -9,18 +9,23 @@
 - `pnpm --filter @aurora/tauri-ui test` for the desktop local/Tauri wrapper boundary.
 - Android/iOS rows with explicit skipped-with-rationale status until Android emulator/device smoke or macOS/Xcode runner evidence is attached. The non-strict Android release report is useful evidence, but does not by itself pass the Android row.
 
+Install the required Python extras before any local/manual gate run:
+
+```bash
+uv sync --extra gateway --extra mode-processes --extra test-e2e
+```
+
 Run the local report without executing package commands:
 
 ```bash
-uv run python scripts/transport_parity_gate.py --output-dir .omx/reports/transport-parity/local
+uv run --extra gateway --extra mode-processes --extra test-e2e python scripts/transport_parity_gate.py --output-dir .omx/reports/transport-parity/local
 ```
 
 Run the full local gate where Node dependencies and platform tools are installed:
 
 ```bash
-pnpm install
-pnpm --filter @aurora/client build
-uv run python scripts/transport_parity_gate.py --execute-commands --output-dir .omx/reports/transport-parity/local
+pnpm install --frozen-lockfile
+uv run --extra gateway --extra mode-processes --extra test-e2e python scripts/transport_parity_gate.py --execute-commands --output-dir .omx/reports/transport-parity/local
 ```
 
 Expected artifacts:

--- a/scripts/transport_parity_gate.py
+++ b/scripts/transport_parity_gate.py
@@ -12,11 +12,15 @@ import argparse
 import json
 import platform
 import subprocess
+import sys
 from collections.abc import Callable, Sequence
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.mesh_gap_e2e_harness import HarnessReport, run_harness
 

--- a/scripts/transport_parity_gate.py
+++ b/scripts/transport_parity_gate.py
@@ -1,0 +1,496 @@
+"""QA-008 transport parity release gate.
+
+The gate combines executable transport evidence from the two-peer mesh harness
+with SDK/UI command evidence into one redacted matrix artifact.  Missing live
+Redis, Android, or iOS evidence is explicit and blocks release readiness rather
+than being hidden by mock transport tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.mesh_gap_e2e_harness import HarnessReport, run_harness
+
+REPORT_ROOT = Path(".omx/reports/transport-parity")
+
+SENSITIVE_KEY_FRAGMENTS = (
+    "api_key",
+    "authorization",
+    "bearer",
+    "file_path",
+    "password",
+    "private_key",
+    "redis_url",
+    "secret",
+    "token",
+)
+
+
+@dataclass(frozen=True)
+class GateCommand:
+    command_id: str
+    owner: str
+    command: tuple[str, ...]
+    required_for_release: bool = True
+    rationale: str = ""
+
+
+@dataclass
+class CommandResult:
+    command_id: str
+    owner: str
+    command: list[str]
+    status: str
+    artifact_path: str | None
+    returncode: int | None = None
+    rationale: str = ""
+
+
+@dataclass
+class MatrixRow:
+    row_id: str
+    label: str
+    owner: str
+    status: str
+    commands: list[str]
+    artifact_paths: list[str]
+    coverage: list[str]
+    blocks_release: bool
+    rationale: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+GATE_COMMANDS: tuple[GateCommand, ...] = (
+    GateCommand(
+        command_id="sdk_build",
+        owner="sdk",
+        command=("pnpm", "--filter", "@aurora/client", "build"),
+        rationale="Builds the SDK dist entry consumed by UI and Tauri package tests.",
+    ),
+    GateCommand(
+        command_id="sdk_conformance",
+        owner="sdk",
+        command=("pnpm", "--filter", "@aurora/client", "test"),
+        rationale="Runs the shared AuroraClient behavior suite across mock, HTTP, Tauri command, and mesh mock transports.",
+    ),
+    GateCommand(
+        command_id="ui_flow_smoke",
+        owner="frontend",
+        command=("pnpm", "--filter", "@aurora/ui", "test"),
+        rationale="Covers SDK-bound onboarding, assistant, admin topology, route sheet, diagnostics, and denied-state render models.",
+    ),
+    GateCommand(
+        command_id="tauri_local_smoke",
+        owner="desktop",
+        command=("pnpm", "--filter", "@aurora/tauri-ui", "test"),
+        rationale="Covers the Tauri local wrapper, offline fallback, and sidecar state boundary without inventing backend truth.",
+    ),
+    GateCommand(
+        command_id="android_release_gate",
+        owner="mobile",
+        command=("pnpm", "--filter", "@aurora/tauri-ui", "android:release-gate"),
+        required_for_release=False,
+        rationale="Produces Android thin/local-light matrix evidence when Android SDK/emulator inputs exist.",
+    ),
+)
+
+
+def run_transport_parity_gate(
+    *,
+    output_dir: Path = REPORT_ROOT,
+    execute_commands: bool = False,
+    command_runner: Callable[[GateCommand, Path], CommandResult] | None = None,
+    harness_runner: Callable[[Path], HarnessReport] = run_harness,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    harness_dir = output_dir / "mesh-gap-e2e"
+    harness_report = harness_runner(output_dir=harness_dir)
+    command_results = [
+        _run_gate_command(command, output_dir, command_runner)
+        if execute_commands or command_runner
+        else _not_run_result(command)
+        for command in GATE_COMMANDS
+    ]
+    rows = _build_rows(harness_report, command_results)
+    summary = _build_summary(rows, command_results, harness_report)
+    report = {
+        "gate_id": "QA-008",
+        "issue": "PER-229",
+        "generated_at": _now(),
+        "release_ready": summary["status"] == "pass",
+        "summary": summary,
+        "rows": [asdict(row) for row in rows],
+        "command_results": [asdict(result) for result in command_results],
+        "artifacts": {
+            "report": str(output_dir / "transport_parity_report.json"),
+            "mesh_harness_report": harness_report.artifacts["report"],
+            "mesh_harness_events": harness_report.artifacts["events"],
+            "mesh_harness_support_bundle": harness_report.artifacts["support_bundle"],
+        },
+        "secrets_redacted": True,
+    }
+    report_path = output_dir / "transport_parity_report.json"
+    report_path.write_text(json.dumps(_redact(report), indent=2, sort_keys=True), encoding="utf-8")
+    return report
+
+
+def _run_gate_command(
+    command: GateCommand,
+    output_dir: Path,
+    command_runner: Callable[[GateCommand, Path], CommandResult] | None,
+) -> CommandResult:
+    if command_runner is not None:
+        return command_runner(command, output_dir)
+
+    log_dir = output_dir / "commands"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"{command.command_id}.log"
+    completed = subprocess.run(
+        command.command,
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        timeout=900,
+        check=False,
+    )
+    log_path.write_text(
+        _redact_text(
+            "\n".join(
+                [
+                    f"$ {' '.join(command.command)}",
+                    f"returncode={completed.returncode}",
+                    completed.stdout,
+                    completed.stderr,
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+    return CommandResult(
+        command_id=command.command_id,
+        owner=command.owner,
+        command=list(command.command),
+        status="pass" if completed.returncode == 0 else "fail",
+        artifact_path=str(log_path),
+        returncode=completed.returncode,
+        rationale=command.rationale,
+    )
+
+
+def _not_run_result(command: GateCommand) -> CommandResult:
+    return CommandResult(
+        command_id=command.command_id,
+        owner=command.owner,
+        command=list(command.command),
+        status="not_run",
+        artifact_path=None,
+        rationale=command.rationale,
+    )
+
+
+def _build_rows(
+    harness_report: HarnessReport,
+    command_results: Sequence[CommandResult],
+) -> list[MatrixRow]:
+    harness_rows = [_row_from_harness_mode(harness_report, mode["mode_id"]) for mode in harness_report.modes]
+    command_map = {result.command_id: result for result in command_results}
+    harness_by_id = {row.row_id: row for row in harness_rows}
+
+    sdk_build = command_map["sdk_build"]
+    for row_id in ("http_gateway_thin_client", "tauri_local_native", "mesh_webrtc"):
+        row = harness_by_id[row_id]
+        row.commands.append(_format_command(sdk_build.command))
+        _merge_command_status(row, sdk_build)
+
+    desktop = harness_by_id["tauri_local_native"]
+    desktop.commands.extend(
+        [
+            _format_command(command_map["tauri_local_smoke"].command),
+            "pnpm --filter @aurora/tauri-ui build",
+        ]
+    )
+    _merge_command_status(desktop, command_map["tauri_local_smoke"])
+
+    http = harness_by_id["http_gateway_thin_client"]
+    http.commands.append(_format_command(command_map["sdk_conformance"].command))
+    _merge_command_status(http, command_map["sdk_conformance"])
+
+    ui_command = command_map["ui_flow_smoke"]
+    for row_id in ("thread_localbus", "http_gateway_thin_client", "tauri_local_native", "mesh_webrtc"):
+        row = harness_by_id[row_id]
+        row.commands.append(_format_command(ui_command.command))
+        _merge_command_status(row, ui_command)
+
+    android = _mobile_row(command_map["android_release_gate"])
+    ios = _ios_row()
+    return [
+        harness_by_id["thread_localbus"],
+        harness_by_id["process_bullmq_redis"],
+        harness_by_id["http_gateway_thin_client"],
+        harness_by_id["tauri_local_native"],
+        harness_by_id["mesh_webrtc"],
+        android,
+        ios,
+    ]
+
+
+def _row_from_harness_mode(harness_report: HarnessReport, mode_id: str) -> MatrixRow:
+    mode = next(mode for mode in harness_report.modes if mode["mode_id"] == mode_id)
+    results = [result for result in harness_report.results if result["mode_id"] == mode_id]
+    statuses = {result["status"] for result in results}
+    if statuses == {"pass"}:
+        status = "pass"
+        blocks_release = False
+        rationale = "All required harness scenarios passed for this transport."
+    elif "fail" in statuses:
+        status = "fail"
+        blocks_release = True
+        rationale = "At least one required harness scenario failed for this transport."
+    elif statuses == {"dependency_gap"}:
+        status = "skipped-with-rationale"
+        blocks_release = True
+        rationale = "Live dependency was unavailable; this row must be rerun in an environment with its required runtime."
+    else:
+        status = "blocked"
+        blocks_release = True
+        rationale = f"Mixed harness statuses: {sorted(statuses)}"
+
+    return MatrixRow(
+        row_id=mode_id,
+        label=mode["label"],
+        owner=_owner_for_mode(mode_id),
+        status=status,
+        commands=[
+            f"uv run python scripts/mesh_gap_e2e_harness.py --mode {mode_id}",
+        ],
+        artifact_paths=[
+            harness_report.artifacts["report"],
+            harness_report.artifacts["events"],
+            harness_report.artifacts["support_bundle"],
+        ],
+        coverage=_coverage_for_mode(mode_id),
+        blocks_release=blocks_release,
+        rationale=rationale,
+        evidence={
+            "result_count": len(results),
+            "passed": sum(1 for result in results if result["status"] == "pass"),
+            "dependency_gap": sum(1 for result in results if result["status"] == "dependency_gap"),
+            "failed": sum(1 for result in results if result["status"] == "fail"),
+            "transport": mode["transport"],
+            "bus": mode["bus"],
+        },
+    )
+
+
+def _mobile_row(android_command: CommandResult) -> MatrixRow:
+    emulator_smoke_path = Path("apps/aurora-tauri/reports/android-emulator-smoke.json")
+    has_emulator_smoke = emulator_smoke_path.exists()
+    status = "pass" if android_command.status == "pass" and has_emulator_smoke else "skipped-with-rationale"
+    blocks_release = status != "pass"
+    return MatrixRow(
+        row_id="android_thin_local_light",
+        label="Android thin/local-light",
+        owner="mobile",
+        status=status,
+        commands=[_format_command(android_command.command), "pnpm --filter @aurora/tauri-ui android:smoke"],
+        artifact_paths=[
+            path
+            for path in [
+                android_command.artifact_path,
+                "apps/aurora-tauri/reports/android-release-gate.json",
+                str(emulator_smoke_path) if has_emulator_smoke else None,
+            ]
+            if path
+        ],
+        coverage=[
+            "native capability manifest",
+            "thin gateway routing",
+            "local-light availability",
+            "assistant-role fallback",
+            "permission denied state",
+        ],
+        blocks_release=blocks_release,
+        rationale=(
+            "Android release-gate and emulator smoke evidence exist."
+            if status == "pass"
+            else "Android SDK/emulator/device evidence is environment-gated; release-gate output is attached when available, but run the listed smoke command on an Android-capable runner."
+        ),
+        evidence={
+            "command_status": android_command.status,
+            "emulator_smoke_attached": has_emulator_smoke,
+            "platform": "android",
+        },
+    )
+
+
+def _ios_row() -> MatrixRow:
+    macos = platform.system().lower() == "darwin"
+    status = "skipped-with-rationale"
+    return MatrixRow(
+        row_id="ios_thin_local_light",
+        label="iOS thin/local-light",
+        owner="mobile",
+        status=status,
+        commands=[
+            "pnpm --filter @aurora/tauri-ui tauri ios build --target aarch64-sim --config src-tauri/tauri.ios.conf.json",
+            "swift .github/scripts/ios_app_intent_smoke.swift",
+            "swift .github/scripts/ios_entrypoint_payload_smoke.swift",
+        ],
+        artifact_paths=["GitHub Actions: Tauri iOS Baseline workflow artifacts"],
+        coverage=[
+            "native capability manifest",
+            "thin gateway routing",
+            "local-light availability",
+            "App Intents/Shortcuts handoff",
+            "permission denied state",
+        ],
+        blocks_release=True,
+        rationale=(
+            "This runner is macOS-capable but iOS build evidence was not attached to this local gate run."
+            if macos
+            else "iOS simulator/build evidence requires a macOS/Xcode runner; run the Tauri iOS Baseline workflow."
+        ),
+        evidence={"platform": "ios", "runner": platform.system()},
+    )
+
+
+def _merge_command_status(row: MatrixRow, result: CommandResult) -> None:
+    if result.artifact_path:
+        row.artifact_paths.append(result.artifact_path)
+    row.evidence.setdefault("command_results", {})[result.command_id] = result.status
+    if result.status == "fail":
+        row.status = "fail"
+        row.blocks_release = True
+        row.rationale = f"{row.rationale} Command {result.command_id} failed."
+    elif result.status == "not_run" and row.status == "pass":
+        row.status = "blocked"
+        row.blocks_release = True
+        row.rationale = f"{row.rationale} Command {result.command_id} was not run in this gate invocation."
+
+
+def _build_summary(
+    rows: Sequence[MatrixRow],
+    command_results: Sequence[CommandResult],
+    harness_report: HarnessReport,
+) -> dict[str, Any]:
+    blocking_rows = [row.row_id for row in rows if row.blocks_release]
+    failed_rows = [row.row_id for row in rows if row.status == "fail"]
+    skipped_rows = [row.row_id for row in rows if row.status == "skipped-with-rationale"]
+    not_run_required = [
+        result.command_id
+        for result in command_results
+        if result.status == "not_run"
+        and next(command for command in GATE_COMMANDS if command.command_id == result.command_id).required_for_release
+    ]
+    status = "pass"
+    if failed_rows:
+        status = "fail"
+    elif blocking_rows or not_run_required or harness_report.summary["status"] == "blocked":
+        status = "blocked"
+    return {
+        "status": status,
+        "row_count": len(rows),
+        "passed_rows": [row.row_id for row in rows if row.status == "pass"],
+        "failed_rows": failed_rows,
+        "skipped_with_rationale_rows": skipped_rows,
+        "blocking_rows": sorted(set(blocking_rows + not_run_required)),
+        "mock_only_evidence_passed": any(result.command_id == "sdk_conformance" and result.status == "pass" for result in command_results),
+        "mock_only_evidence_sufficient": False,
+        "mesh_final_proof": harness_report.summary["final_mesh_mode_status"],
+        "process_redis_dependency_gap": "process_bullmq_redis" in harness_report.summary["dependency_gap_modes"],
+        "secrets_redacted": True,
+    }
+
+
+def _owner_for_mode(mode_id: str) -> str:
+    return {
+        "thread_localbus": "backend",
+        "process_bullmq_redis": "backend/ops",
+        "http_gateway_thin_client": "sdk",
+        "tauri_local_native": "desktop",
+        "mesh_webrtc": "mesh",
+    }[mode_id]
+
+
+def _coverage_for_mode(mode_id: str) -> list[str]:
+    common = [
+        "registry",
+        "capability catalog",
+        "route explain",
+        "aggregate tools",
+        "approval",
+        "AdminAction boundary",
+        "event stream",
+        "diagnostics",
+        "audit receipt",
+    ]
+    extras = {
+        "thread_localbus": ["LocalBus request/reply", "assistant basics"],
+        "process_bullmq_redis": ["BullMQBus", "Redis request/reply", "Docker/process mode smoke"],
+        "http_gateway_thin_client": ["Gateway HTTP routes", "native-only degraded state"],
+        "tauri_local_native": ["Tauri command bridge", "offline fallback", "sidecar crash boundary"],
+        "mesh_webrtc": ["two-peer WebRTC DataChannel", "remote approval", "provider provenance"],
+    }
+    return common + extras[mode_id]
+
+
+def _format_command(command: Sequence[str]) -> str:
+    return " ".join(command)
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: ("[redacted]" if _is_sensitive_key(key) and key != "secrets_redacted" else _redact(item))
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, str):
+        return _redact_text(value)
+    return value
+
+
+def _redact_text(value: str) -> str:
+    if "redis://" in value or "/home/" in value or "secret-token" in value:
+        return "[redacted]"
+    return value
+
+
+def _is_sensitive_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(fragment in lowered for fragment in SENSITIVE_KEY_FRAGMENTS)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, default=REPORT_ROOT)
+    parser.add_argument(
+        "--execute-commands",
+        action="store_true",
+        help="Run SDK/UI/native command gates instead of recording them as not_run.",
+    )
+    args = parser.parse_args()
+    report = run_transport_parity_gate(
+        output_dir=args.output_dir,
+        execute_commands=args.execute_commands,
+    )
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    return 0 if report["summary"]["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/test_transport_parity_gate.py
+++ b/tests/e2e/test_transport_parity_gate.py
@@ -1,0 +1,233 @@
+"""QA-008 transport parity release gate tests."""
+
+import json
+
+import pytest
+
+from scripts.mesh_gap_e2e_harness import HarnessReport
+from scripts.transport_parity_gate import CommandResult, GateCommand, run_transport_parity_gate
+
+
+@pytest.mark.e2e
+def test_transport_parity_gate_emits_required_rows_and_artifacts(tmp_path):
+    report = run_transport_parity_gate(
+        output_dir=tmp_path,
+        command_runner=_passing_command,
+        harness_runner=_fake_harness_report,
+    )
+
+    required_rows = {
+        "thread_localbus",
+        "process_bullmq_redis",
+        "http_gateway_thin_client",
+        "tauri_local_native",
+        "mesh_webrtc",
+        "android_thin_local_light",
+        "ios_thin_local_light",
+    }
+    rows = {row["row_id"]: row for row in report["rows"]}
+
+    assert set(rows) == required_rows
+    assert report["summary"]["row_count"] == len(required_rows)
+    assert report["summary"]["mock_only_evidence_sufficient"] is False
+    assert report["summary"]["mesh_final_proof"] == "pass"
+    assert report["secrets_redacted"] is True
+
+    for row in rows.values():
+        assert row["owner"]
+        assert row["commands"]
+        assert row["artifact_paths"]
+        assert row["status"] in {"pass", "fail", "blocked", "skipped-with-rationale"}
+        assert row["coverage"]
+        assert row["rationale"]
+
+    assert rows["thread_localbus"]["status"] == "pass"
+    assert rows["http_gateway_thin_client"]["status"] == "pass"
+    assert rows["tauri_local_native"]["status"] == "pass"
+    assert rows["mesh_webrtc"]["status"] == "pass"
+    assert rows["ios_thin_local_light"]["status"] == "skipped-with-rationale"
+    assert rows["ios_thin_local_light"]["blocks_release"] is True
+
+    persisted = json.loads((tmp_path / "transport_parity_report.json").read_text(encoding="utf-8"))
+    assert persisted["summary"] == report["summary"]
+
+
+@pytest.mark.e2e
+def test_transport_parity_gate_blocks_when_required_commands_are_not_run(tmp_path):
+    report = run_transport_parity_gate(output_dir=tmp_path, harness_runner=_fake_harness_report)
+
+    assert report["summary"]["status"] == "blocked"
+    assert report["release_ready"] is False
+    assert {"sdk_conformance", "ui_flow_smoke", "tauri_local_smoke"}.issubset(
+        set(report["summary"]["blocking_rows"])
+    )
+
+    rows = {row["row_id"]: row for row in report["rows"]}
+    assert rows["http_gateway_thin_client"]["status"] == "blocked"
+    assert rows["mesh_webrtc"]["status"] == "blocked"
+
+
+@pytest.mark.e2e
+def test_transport_parity_gate_does_not_allow_mock_only_success_to_pass(tmp_path):
+    def only_sdk_passes(command: GateCommand, output_dir):
+        status = "pass" if command.command_id == "sdk_conformance" else "not_run"
+        artifact = output_dir / f"{command.command_id}.log"
+        artifact.write_text("ok", encoding="utf-8")
+        return CommandResult(
+            command_id=command.command_id,
+            owner=command.owner,
+            command=list(command.command),
+            status=status,
+            artifact_path=str(artifact),
+            returncode=0 if status == "pass" else None,
+            rationale=command.rationale,
+        )
+
+    report = run_transport_parity_gate(
+        output_dir=tmp_path,
+        command_runner=only_sdk_passes,
+        harness_runner=_fake_harness_report,
+    )
+
+    assert report["summary"]["mock_only_evidence_passed"] is True
+    assert report["summary"]["mock_only_evidence_sufficient"] is False
+    assert report["summary"]["status"] == "blocked"
+    assert report["release_ready"] is False
+
+
+@pytest.mark.e2e
+def test_transport_parity_gate_redacts_sensitive_artifacts(tmp_path):
+    report = run_transport_parity_gate(
+        output_dir=tmp_path,
+        command_runner=_passing_command,
+        harness_runner=_fake_harness_report,
+    )
+    serialized = json.dumps(report) + (tmp_path / "transport_parity_report.json").read_text(
+        encoding="utf-8"
+    )
+
+    assert "redis://localhost:6379" not in serialized
+    assert "secret-token" not in serialized
+    assert "/home/" not in serialized
+    assert report["summary"]["secrets_redacted"] is True
+
+
+def _passing_command(command: GateCommand, output_dir):
+    artifact = output_dir / f"{command.command_id}.log"
+    artifact.write_text("ok", encoding="utf-8")
+    return CommandResult(
+        command_id=command.command_id,
+        owner=command.owner,
+        command=list(command.command),
+        status="pass",
+        artifact_path=str(artifact),
+        returncode=0,
+        rationale=command.rationale,
+    )
+
+
+def _fake_harness_report(output_dir):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "report.json"
+    events_path = output_dir / "events.ndjson"
+    support_bundle_path = output_dir / "support_bundle.json"
+    report_path.write_text("{}", encoding="utf-8")
+    events_path.write_text("", encoding="utf-8")
+    support_bundle_path.write_text("{}", encoding="utf-8")
+
+    modes = [
+        {
+            "mode_id": "thread_localbus",
+            "label": "thread mode / LocalBus",
+            "bus": "LocalBus",
+            "transport": "in-process SDK contract",
+            "profile": "ci-dev",
+            "execution": "component",
+            "final_mesh_proof": False,
+            "notes": [],
+        },
+        {
+            "mode_id": "process_bullmq_redis",
+            "label": "process mode / BullMQBus / Redis",
+            "bus": "BullMQBus",
+            "transport": "Redis-backed process request/reply",
+            "profile": "ci-dev-live",
+            "execution": "component",
+            "final_mesh_proof": False,
+            "notes": [],
+        },
+        {
+            "mode_id": "http_gateway_thin_client",
+            "label": "HTTP Gateway thin client",
+            "bus": "Gateway",
+            "transport": "HTTP contract",
+            "profile": "ci-dev",
+            "execution": "component",
+            "final_mesh_proof": False,
+            "notes": [],
+        },
+        {
+            "mode_id": "tauri_local_native",
+            "label": "Tauri local/native transport",
+            "bus": "LocalBus",
+            "transport": "Tauri command contract smoke",
+            "profile": "ci-dev",
+            "execution": "component",
+            "final_mesh_proof": False,
+            "notes": [],
+        },
+        {
+            "mode_id": "mesh_webrtc",
+            "label": "Mesh/WebRTC transport",
+            "bus": "MeshBus",
+            "transport": "WebRTC DataChannel JSON-RPC",
+            "profile": "ci-dev",
+            "execution": "component",
+            "final_mesh_proof": True,
+            "notes": [],
+        },
+    ]
+    scenarios = [{"scenario_id": "required_flow", "title": "Required flow", "categories": ["audit"], "assertion": "passes"}]
+    results = [
+        {
+            "scenario_id": "required_flow",
+            "mode_id": mode["mode_id"],
+            "status": "pass",
+            "assertion": "passes",
+            "evidence": {"transport_path": mode["transport"]},
+            "correlation_id": f"{mode['mode_id']}-required_flow",
+            "events": [],
+        }
+        for mode in modes
+    ]
+    summary = {
+        "status": "pass",
+        "passed": len(results),
+        "failed": 0,
+        "preflight": 0,
+        "dependency_gap": 0,
+        "scenario_count": 1,
+        "mode_count": len(modes),
+        "result_count": len(results),
+        "component_modes": [mode["mode_id"] for mode in modes],
+        "dependency_gap_modes": [],
+        "required_scenarios_passed": True,
+        "final_mesh_mode_included": True,
+        "final_mesh_mode_status": "pass",
+        "preflight_not_counted_as_final_proof": True,
+    }
+    return HarnessReport(
+        harness_id="fake",
+        generated_at="2026-06-27T00:00:00Z",
+        consumer_peer_id="consumer-peer",
+        provider_peer_id="provider-peer",
+        modes=modes,
+        scenarios=scenarios,
+        results=results,
+        summary=summary,
+        artifacts={
+            "report": str(report_path),
+            "events": str(events_path),
+            "support_bundle": str(support_bundle_path),
+        },
+    )

--- a/tests/e2e/test_transport_parity_gate.py
+++ b/tests/e2e/test_transport_parity_gate.py
@@ -1,11 +1,28 @@
 """QA-008 transport parity release gate tests."""
 
 import json
+import subprocess
+import sys
 
 import pytest
 
 from scripts.mesh_gap_e2e_harness import HarnessReport
 from scripts.transport_parity_gate import CommandResult, GateCommand, run_transport_parity_gate
+
+
+@pytest.mark.e2e
+def test_transport_parity_gate_script_entrypoint_imports_from_file_path():
+    completed = subprocess.run(
+        [sys.executable, "scripts/transport_parity_gate.py", "--help"],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "transport_parity_gate.py" in completed.stdout
+    assert "--execute-commands" in completed.stdout
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## Summary
- Adds the QA-008 transport parity gate script and report format covering thread, process, HTTP gateway, Tauri, mesh, Android, and iOS rows.
- Adds regression coverage for blocking/skipped semantics, mock-only evidence handling, report artifacts, and redaction.
- Adds a manual GitHub Actions workflow and runbook for release-gate execution.

## Verification
- UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run --extra test-e2e pytest tests/e2e/test_transport_parity_gate.py -q
- UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run --extra dev ruff check scripts/transport_parity_gate.py tests/e2e/test_transport_parity_gate.py
- pnpm install --frozen-lockfile
- pnpm --filter @aurora/client test
- pnpm --filter @aurora/client build
- pnpm --filter @aurora/ui test
- pnpm --filter @aurora/tauri-ui test
- UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run --extra gateway --extra mode-processes --extra test-e2e python -c "from pathlib import Path; from scripts.transport_parity_gate import run_transport_parity_gate; report=run_transport_parity_gate(output_dir=Path('.omx/reports/transport-parity/local-executed'), execute_commands=True); print(report['summary'])"
- UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run --extra gateway --extra mode-processes --extra test-e2e pytest tests/e2e/test_mesh_gap_e2e_harness.py -q

## Notes
- Local executed gate report is intentionally blocked until Redis-backed process evidence and platform-specific Android/iOS smoke evidence are available.
- The workflow is manual and uploads the parity report artifacts for QA/release review.
