### PR TITLE
PER-270 Make EventStream production-ready

### DIFF
--- a/app/services/gateway/fastapi_app.py
+++ b/app/services/gateway/fastapi_app.py
@@ -17,7 +17,7 @@ import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any
 
-from fastapi import Depends, FastAPI, HTTPException, Request, Security
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, Security
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 
@@ -25,6 +25,8 @@ from app.helpers.aurora_logger import log_error, log_info
 from app.services.gateway.auth import check_auth_enabled, create_scoped_auth_check
 from app.services.gateway.dependencies import get_rtc_client
 from app.shared.contracts.models.aurora import AuroraEventStreamEvent, AuroraMethods
+from app.shared.contracts.models.gateway import GatewayListEventsRequest, GatewayMethods
+from app.shared.contracts.models.orchestrator import OrchestratorMethods
 
 if TYPE_CHECKING:
     from app.messaging.bus import MessageBus
@@ -235,10 +237,7 @@ def create_gateway_app(
 
         return GetServicesResponse(services=services, mode=mode)
 
-    stream_events_auth = Security(
-        create_scoped_auth_check(method_type="manage"),
-        scopes=["Gateway.manage"],
-    )
+    stream_events_auth = Security(create_scoped_auth_check(method_type="use"), scopes=[])
 
     @app.get(
         "/api/events/stream",
@@ -253,15 +252,38 @@ def create_gateway_app(
         },
     )
     async def stream_events(
+        topic: Annotated[list[str] | None, Query()] = None,
+        kind: Annotated[list[str] | None, Query()] = None,
+        last_event_id: str | None = None,
+        replay_from: str | None = None,
+        backfill: bool = False,
+        correlation_id: str | None = None,
         _auth: Any = stream_events_auth,
     ) -> StreamingResponse:
         """Stream normalized event envelopes as Server-Sent Events."""
+        topics = topic or []
+        categories, kinds = _event_stream_filters(kind or [])
+        _authorize_event_stream_request(
+            _auth,
+            topics=topics,
+            categories=categories,
+            kinds=kinds,
+            correlation_id=correlation_id,
+        )
         queue: asyncio.Queue[AuroraEventStreamEvent] = asyncio.Queue(maxsize=100)
 
         async def on_event(envelope: Any) -> None:
             payload = envelope.payload
             if not isinstance(payload, AuroraEventStreamEvent):
                 payload = AuroraEventStreamEvent.model_validate(payload)
+            if not _event_matches_stream_request(
+                payload,
+                topics=topics,
+                categories=categories,
+                kinds=kinds,
+                correlation_id=correlation_id,
+            ):
+                return
             try:
                 queue.put_nowait(payload)
             except asyncio.QueueFull:
@@ -272,11 +294,20 @@ def create_gateway_app(
         async def event_generator():
             bus.subscribe(AuroraMethods.EVENT_STREAM, on_event)
             try:
+                if backfill or last_event_id or replay_from:
+                    async for event in _stream_backfill_events(
+                        bus,
+                        topics=topics,
+                        categories=categories,
+                        kinds=kinds,
+                        correlation_id=correlation_id,
+                        last_event_id=last_event_id,
+                        replay_from=replay_from,
+                    ):
+                        yield _sse_payload(event)
                 while True:
                     event = await queue.get()
-                    payload = event.model_dump(mode="json")
-                    data = json.dumps(payload, sort_keys=True, separators=(",", ":"))
-                    yield f"event: {event.category}\ndata: {data}\n\n"
+                    yield _sse_payload(event)
                     queue.task_done()
             finally:
                 bus.unsubscribe(AuroraMethods.EVENT_STREAM, on_event)
@@ -444,3 +475,135 @@ def create_gateway_app(
         return {"success": True}
 
     return app
+
+
+_SAFE_ASSISTANT_KINDS = {
+    "assistant",
+    "assistant.delta",
+    "assistant.completed",
+    "assistant.failed",
+    "tool.requested",
+    "tool.completed",
+}
+
+
+def _event_stream_filters(kind: list[str]) -> tuple[set[str], set[str]]:
+    categories: set[str] = set()
+    kinds: set[str] = set()
+    for item in kind:
+        normalized = item.strip()
+        if not normalized:
+            continue
+        if "." in normalized:
+            kinds.add(normalized)
+        else:
+            categories.add(normalized)
+    return categories, kinds
+
+
+def _authorize_event_stream_request(
+    identity: Any,
+    *,
+    topics: list[str],
+    categories: set[str],
+    kinds: set[str],
+    correlation_id: str | None,
+) -> None:
+    if identity.can("Gateway.manage", method_type="manage"):
+        return
+    topic_set = set(topics)
+    assistant_scoped = (
+        correlation_id is not None
+        and (not topic_set or topic_set == {OrchestratorMethods.RESPONSE})
+        and (not categories or categories <= {"assistant"})
+        and (not kinds or kinds <= _SAFE_ASSISTANT_KINDS)
+    )
+    if assistant_scoped and identity.can("Orchestrator.use", method_type="use"):
+        return
+    raise HTTPException(
+        status_code=403,
+        detail=(
+            "Gateway.manage is required for broad event streams; "
+            "Orchestrator.use may only subscribe to correlated assistant events"
+        ),
+    )
+
+
+def _event_matches_stream_request(
+    event: AuroraEventStreamEvent,
+    *,
+    topics: list[str],
+    categories: set[str],
+    kinds: set[str],
+    correlation_id: str | None,
+) -> bool:
+    if topics and event.topic not in set(topics):
+        return False
+    if categories and event.category not in categories:
+        return False
+    if kinds and event.kind not in kinds and event.category not in kinds:
+        return False
+    return not (correlation_id and event.correlation_id != correlation_id)
+
+
+async def _stream_backfill_events(
+    bus: Any,
+    *,
+    topics: list[str],
+    categories: set[str],
+    kinds: set[str],
+    correlation_id: str | None,
+    last_event_id: str | None,
+    replay_from: str | None,
+):
+    request = GatewayListEventsRequest(
+        topics=topics or None,
+        categories=list(categories) or None,
+        kinds=list(kinds) or None,
+        correlation_id=correlation_id,
+        last_event_id=last_event_id,
+        replay_from=replay_from,
+        limit=500,
+    )
+    try:
+        result = await bus.request(
+            GatewayMethods.LIST_EVENTS,
+            request,
+            timeout=2.0,
+            origin="internal",
+        )
+    except Exception as exc:
+        yield _degraded_event(f"bounded backfill unavailable: {exc}")
+        return
+    if not getattr(result, "ok", False):
+        yield _degraded_event(str(getattr(result, "error", None) or "bounded backfill unavailable"))
+        return
+    events = list(getattr(result.data, "events", []) or [])
+    for event in reversed(events):
+        yield event
+    if (last_event_id or replay_from) and not events:
+        yield _degraded_event("requested replay cursor is not present in the bounded Gateway event buffer")
+
+
+def _degraded_event(message: str) -> AuroraEventStreamEvent:
+    return AuroraEventStreamEvent(
+        event_id="stream-degraded",
+        topic=AuroraMethods.EVENT_STREAM,
+        kind="stream.degraded",
+        category="unknown",
+        action="backfill",
+        status="degraded",
+        severity="warning",
+        redacted_payload={
+            "code": "bounded_replay_unavailable",
+            "message": message,
+            "durable_replay": False,
+        },
+    )
+
+
+def _sse_payload(event: AuroraEventStreamEvent) -> str:
+    payload = event.model_dump(mode="json")
+    data = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    event_name = event.kind or event.category
+    return f"id: {event.event_id}\nevent: {event_name}\ndata: {data}\n\n"

--- a/app/services/gateway/route_generator.py
+++ b/app/services/gateway/route_generator.py
@@ -568,6 +568,7 @@ class RouteGenerator:
                     timeout=timeout,
                     origin="external",
                     principal_id=principal_id,
+                    correlation_id=payload.get("correlation_id") if isinstance(payload, dict) else None,
                 )
                 log_debug(f"Gateway received result: ok={result.ok}, data={result.data}")
 

--- a/app/services/gateway/service.py
+++ b/app/services/gateway/service.py
@@ -231,6 +231,7 @@ def _event_from_envelope(envelope: Envelope) -> GatewayEventStreamEvent:
     return GatewayEventStreamEvent(
         event_id=str(uuid.uuid4()),
         topic=envelope.type,
+        kind=_event_kind(envelope.type, payload),
         category=_event_category(envelope.type, payload),
         action=_event_action(envelope.type, payload),
         status=_event_status(envelope.type, payload),
@@ -320,6 +321,26 @@ def _event_category(topic: str, payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def _event_kind(topic: str, payload: dict[str, Any]) -> str:
+    explicit = _first_string(payload, "kind", "event_kind", "eventKind", "type")
+    if explicit:
+        return explicit
+    category = _event_category(topic, payload)
+    status = _event_status(topic, payload)
+    action = _event_action(topic, payload)
+    if topic == OrchestratorMethods.RESPONSE:
+        return "assistant.failed" if status == "failed" else "assistant.completed"
+    if category == "tool_approval":
+        return f"tool.{status or action or 'requested'}"
+    if category == "tool_execution":
+        return f"tool.{status or action or 'completed'}"
+    if category == "config":
+        return "config.updated" if status != "failed" else "config.validation_failed"
+    if category == "service":
+        return f"service.{status or action or 'updated'}"
+    return f"{category}.{action}" if category != "unknown" and action else category
+
+
 def _event_action(topic: str, payload: dict[str, Any]) -> str:
     if payload.get("action"):
         return str(payload["action"])
@@ -339,6 +360,11 @@ def _event_status(topic: str, payload: dict[str, Any]) -> str:
         return "disconnected"
     if topic == GatewayMethods.SERVICE_ANNOUNCE:
         return "connected"
+    metadata = payload.get("metadata")
+    if topic == OrchestratorMethods.RESPONSE and isinstance(metadata, dict) and metadata.get("error"):
+        return "failed"
+    if topic == OrchestratorMethods.RESPONSE:
+        return "completed"
     if payload.get("approved") is True:
         return "approved"
     if payload.get("approved") is False:
@@ -1098,10 +1124,20 @@ class GatewayService(BaseService):
         self,
         request: GatewayListEventsRequest,
     ) -> list[GatewayEventStreamEvent]:
+        topics = set(request.topics or [])
         categories = set(request.categories or [])
+        kinds = set(request.kinds or [])
         events: list[GatewayEventStreamEvent] = []
         for event in list(self._event_stream):
+            if request.last_event_id and event.event_id == request.last_event_id:
+                break
+            if request.replay_from and event.timestamp < request.replay_from:
+                continue
+            if topics and event.topic not in topics:
+                continue
             if categories and event.category not in categories:
+                continue
+            if kinds and event.kind not in kinds and event.category not in kinds:
                 continue
             if request.action and event.action != request.action:
                 continue

--- a/app/services/orchestrator/service.py
+++ b/app/services/orchestrator/service.py
@@ -225,12 +225,16 @@ class OrchestratorService(BaseService):
                 cmd.text,
                 source="external",
                 session_id=cmd.session_id,
+                request_id=cmd.request_id,
+                correlation_id=cmd.correlation_id,
                 return_response=True,  # Return the response for external API
             )
             return OrchestratorResponse(
                 text=response_text or "",
                 session_id=cmd.session_id,
-                metadata={"source": "external"},
+                request_id=cmd.request_id,
+                correlation_id=cmd.correlation_id,
+                metadata={"source": "external", "stream": cmd.stream},
             )
 
         except Exception as e:
@@ -238,7 +242,9 @@ class OrchestratorService(BaseService):
             return OrchestratorResponse(
                 text=f"Error: {e!s}",
                 session_id=cmd.session_id,
-                metadata={"source": "external", "error": True},
+                request_id=cmd.request_id,
+                correlation_id=cmd.correlation_id,
+                metadata={"source": "external", "stream": cmd.stream, "error": True},
             )
 
     @method_contract(
@@ -686,6 +692,8 @@ class OrchestratorService(BaseService):
         text: str,
         source: str,
         session_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
         return_response: bool = False,
     ) -> str | None:
         """Process user input through LangGraph agent.
@@ -727,12 +735,17 @@ class OrchestratorService(BaseService):
                     LLMResponseReady(
                         text=response_text,
                         session_id=session_id,
-                        metadata={"source": source},
+                        metadata={
+                            "source": source,
+                            "request_id": request_id,
+                            "correlation_id": correlation_id,
+                        },
                     ),
                     event=True,  # Broadcast to all subscribers (UI, TTS, etc.)
                     mesh=True,
                     priority=get_interactive_priority(),
                     origin="internal",
+                    correlation_id=correlation_id,
                 )
 
                 # Send TTS request to speak the response

--- a/app/shared/contracts/models/aurora.py
+++ b/app/shared/contracts/models/aurora.py
@@ -47,6 +47,7 @@ class AuroraEventStreamEvent(IOModel):
 
     event_id: str
     topic: str
+    kind: str = ""
     category: AuroraEventCategory = "unknown"
     action: str = ""
     status: str = ""

--- a/app/shared/contracts/models/gateway.py
+++ b/app/shared/contracts/models/gateway.py
@@ -474,10 +474,14 @@ GatewayEventStreamEvent = AuroraEventStreamEvent
 class GatewayListEventsRequest(IOModel):
     """Query the bounded Gateway event buffer."""
 
+    topics: list[str] | None = None
     categories: list[AuroraEventCategory] | None = None
+    kinds: list[str] | None = None
     action: str | None = None
     status: str | None = None
     correlation_id: str | None = None
+    last_event_id: str | None = None
+    replay_from: str | None = None
     peer_id: str | None = None
     provider_id: str | None = None
     tool_id: str | None = None

--- a/app/shared/contracts/models/orchestrator.py
+++ b/app/shared/contracts/models/orchestrator.py
@@ -54,6 +54,9 @@ class OrchestratorProcessRequest(IOModel):
     text: str
     source: str = "external"
     session_id: str | None = None
+    request_id: str | None = None
+    correlation_id: str | None = None
+    stream: bool = False
 
 
 class OrchestratorResponse(IOModel):
@@ -61,6 +64,8 @@ class OrchestratorResponse(IOModel):
 
     text: str
     session_id: str | None = None
+    request_id: str | None = None
+    correlation_id: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -725,15 +725,38 @@ export class AssistantClient {
       source: 'external'
     }
     if (input.sessionId !== undefined) payload.session_id = input.sessionId
+    const requestId = input.requestId ?? `assistant-${cryptoRandomId()}`
+    payload.request_id = requestId
+    payload.correlation_id = requestId
+    payload.stream = true
 
     let sawEvent = false
+    let requestResponse: AuroraResponse<OrchestratorResponse> | null = null
     try {
+      const requestOptions: { path: string; timeoutMs?: number } = {
+        path: routePath('Orchestrator', 'ExternalUserInput')
+      }
+      if (input.timeoutMs !== undefined) requestOptions.timeoutMs = input.timeoutMs
+      const request = await this.client.requestResult<OrchestratorResponse, OrchestratorProcessRequest>(
+        ORCHESTRATOR_METHODS.externalUserInput,
+        payload,
+        requestOptions
+      )
+      requestResponse = request
+      if (!request.ok) {
+        yield streamFailure(request.error, this.client.transport.kind)
+        return
+      }
+      const correlationId = request.data.correlation_id ?? requestId
       const stream = this.client.events.streamAssistant<Record<string, unknown>, OrchestratorProcessRequest>(payload, {
         signal: input.signal,
         lastEventId: input.lastEventId ?? null,
         replayFrom: input.replayFrom ?? input.lastEventId ?? null,
+        correlationId,
+        backfill: true,
         reconnect: { maxAttempts: 1, initialDelayMs: 250, maxDelayMs: 1_000 },
         audit: {
+          correlationId,
           method: ORCHESTRATOR_METHODS.externalUserInput,
           busTopic: ORCHESTRATOR_METHODS.externalUserInput,
           transport: this.client.transport.kind
@@ -741,7 +764,7 @@ export class AssistantClient {
       })
       for await (const event of stream) {
         sawEvent = true
-        yield assistantStreamUpdateFromEvent(event)
+        yield assistantStreamUpdateFromEvent(event, request.data)
       }
     } catch (error) {
       const normalized = normalizeError(error)
@@ -749,6 +772,24 @@ export class AssistantClient {
       if (input.signal?.aborted) return
       if (sawEvent) {
         yield streamFailure(normalized, this.client.transport.kind, 'transport_lost')
+        return
+      }
+
+      if (requestResponse?.ok) {
+        const sessionId = requestResponse.data.session_id ?? input.sessionId ?? stableSessionId()
+        const metadata = requestResponse.data.metadata ?? {}
+        yield {
+          kind: 'fallback',
+          eventId: requestResponse.audit.correlationId ?? requestId,
+          sessionId,
+          text: requestResponse.data.text,
+          textDelta: requestResponse.data.text,
+          modelLabel: metadataString(metadata, 'model') ?? metadataString(metadata, 'provider'),
+          requestId,
+          error: null,
+          audit: requestResponse.audit,
+          metadata
+        }
         return
       }
 
@@ -761,6 +802,7 @@ export class AssistantClient {
           text: fallback.data.response.text,
           textDelta: fallback.data.response.text,
           modelLabel: fallback.data.modelLabel,
+          requestId,
           error: null,
           audit: fallback.audit,
           metadata: fallback.data.metadata
@@ -799,12 +841,17 @@ function metadataString(metadata: OrchestratorResponse['metadata'] | undefined, 
   return typeof value === 'string' && value.trim() ? value : null
 }
 
-function assistantStreamUpdateFromEvent(event: import('./types.js').AuroraEvent<Record<string, unknown>>): AssistantStreamUpdate {
+function assistantStreamUpdateFromEvent(
+  event: import('./types.js').AuroraEvent<Record<string, unknown>>,
+  requestResponse?: OrchestratorResponse
+): AssistantStreamUpdate {
   const payload = event.payload ?? {}
-  const text = streamText(payload)
-  const metadata = streamMetadata(payload)
-  const sessionId = streamString(payload, 'session_id', 'sessionId') ?? null
+  const eventText = streamText(payload)
+  const metadata = { ...(requestResponse?.metadata ?? {}), ...streamMetadata(payload) }
+  const sessionId = streamString(payload, 'session_id', 'sessionId') ?? requestResponse?.session_id ?? null
+  const requestId = streamString(payload, 'request_id', 'requestId') ?? event.audit.correlationId
   const modelLabel = metadataString(metadata, 'model') ?? metadataString(metadata, 'provider')
+  const text = event.kind === 'assistant.completed' && !eventText ? requestResponse?.text ?? '' : eventText
   if (event.kind === 'assistant.completed') {
     return {
       kind: 'completed',
@@ -813,6 +860,7 @@ function assistantStreamUpdateFromEvent(event: import('./types.js').AuroraEvent<
       text,
       textDelta: text,
       modelLabel,
+      requestId,
       error: null,
       audit: event.audit,
       metadata
@@ -826,6 +874,7 @@ function assistantStreamUpdateFromEvent(event: import('./types.js').AuroraEvent<
       text,
       textDelta: '',
       modelLabel,
+      requestId,
       error: new AuroraError({
         code: 'unavailable_service',
         message: text || 'Assistant stream failed.',
@@ -846,6 +895,7 @@ function assistantStreamUpdateFromEvent(event: import('./types.js').AuroraEvent<
       text,
       textDelta: '',
       modelLabel,
+      requestId,
       error: null,
       audit: event.audit,
       metadata
@@ -858,6 +908,7 @@ function assistantStreamUpdateFromEvent(event: import('./types.js').AuroraEvent<
     text,
     textDelta: streamString(payload, 'delta', 'text_delta', 'textDelta') ?? text,
     modelLabel,
+    requestId,
     error: null,
     audit: event.audit,
     metadata
@@ -876,6 +927,7 @@ function streamFailure(
     text: error.message,
     textDelta: '',
     modelLabel: null,
+    requestId: null,
     error,
     audit: createAuditReceipt(error.detail, {
       correlationId: error.correlationId ?? null,
@@ -909,6 +961,12 @@ function streamString(payload: Record<string, unknown>, ...keys: string[]): stri
 
 function stableSessionId(): string {
   return `assistant-session-${Date.now().toString(36)}`
+}
+
+function cryptoRandomId(): string {
+  const randomUUID = globalThis.crypto?.randomUUID
+  if (randomUUID) return randomUUID.call(globalThis.crypto)
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
 }
 
 export class AdminOverviewClient {

--- a/packages/aurora-sdk/src/events.ts
+++ b/packages/aurora-sdk/src/events.ts
@@ -17,6 +17,7 @@ export interface AuroraSubscribeOptions<TPayload = unknown> {
   signal?: AbortSignal | undefined
   lastEventId?: string | null | undefined
   replayFrom?: string | null | undefined
+  correlationId?: string | null | undefined
   backfill?: boolean | undefined
   reconnect?: boolean | AuroraReconnectOptions | undefined
   audit?: Partial<AuditReceipt> | undefined
@@ -362,6 +363,7 @@ function readPayload(raw: unknown): unknown {
   if (!isObject(raw)) return raw
   if ('payload' in raw) return raw.payload
   if ('data' in raw) return raw.data
+  if ('redacted_payload' in raw) return raw.redacted_payload
   return raw
 }
 

--- a/packages/aurora-sdk/src/http.ts
+++ b/packages/aurora-sdk/src/http.ts
@@ -59,7 +59,7 @@ export class HttpGatewayTransport implements AuroraTransport {
     this.bearerToken = options.bearerToken
     this.eventSourceFactory = options.eventSourceFactory ?? defaultEventSourceFactory()
     this.webSocketFactory = options.webSocketFactory ?? defaultWebSocketFactory()
-    this.eventStreamPath = options.eventStreamPath ?? '/api/events'
+    this.eventStreamPath = options.eventStreamPath ?? '/api/events/stream'
     this.defaultTimeoutMs = options.defaultTimeoutMs ?? 30_000
   }
 
@@ -211,6 +211,7 @@ export class HttpGatewayTransport implements AuroraTransport {
     for (const kind of request.kinds) url.searchParams.append('kind', kind)
     if (request.lastEventId) url.searchParams.set('last_event_id', request.lastEventId)
     if (request.replayFrom) url.searchParams.set('replay_from', request.replayFrom)
+    if (request.correlationId) url.searchParams.set('correlation_id', request.correlationId)
     if (request.backfill) url.searchParams.set('backfill', 'true')
     return url.toString()
   }

--- a/packages/aurora-sdk/src/types.ts
+++ b/packages/aurora-sdk/src/types.ts
@@ -80,11 +80,16 @@ export interface OrchestratorProcessRequest {
   text: string
   source?: string
   session_id?: string | null
+  request_id?: string | null
+  correlation_id?: string | null
+  stream?: boolean
 }
 
 export interface OrchestratorResponse {
   text: string
   session_id?: string | null
+  request_id?: string | null
+  correlation_id?: string | null
   metadata?: JsonObject
 }
 
@@ -110,6 +115,7 @@ export interface AssistantStreamMessageRequest extends AssistantSendMessageReque
   signal?: AbortSignal
   lastEventId?: string | null
   replayFrom?: string | null
+  requestId?: string | null
 }
 
 export interface AssistantMessage {
@@ -137,6 +143,7 @@ export interface AssistantStreamUpdate {
   text: string
   textDelta: string
   modelLabel: string | null
+  requestId?: string | null
   error: AuroraError | null
   audit: AuditReceipt
   metadata: JsonObject

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -3668,7 +3668,7 @@ describe('AuroraClient', () => {
     const sseTransport = new HttpGatewayTransport({
       baseUrl: 'http://aurora.local',
       eventSourceFactory: (url) => {
-        expect(url).toContain('/api/events?stream=health')
+        expect(url).toContain('/api/events/stream?stream=health')
         sse = { onmessage: null, onerror: null, close: () => undefined }
         return sse
       }
@@ -3697,7 +3697,7 @@ describe('AuroraClient', () => {
     const wsTransport = new HttpGatewayTransport({
       baseUrl: 'https://aurora.local',
       webSocketFactory: (url) => {
-        expect(url.startsWith('wss://aurora.local/api/events?stream=assistant')).toBe(true)
+        expect(url.startsWith('wss://aurora.local/api/events/stream?stream=assistant')).toBe(true)
         socket = {
           onmessage: null,
           onerror: null,
@@ -3800,6 +3800,7 @@ describe('AuroraClient', () => {
 
 describe('AuroraClient assistant namespace', () => {
   it('streams assistant deltas, final event evidence, and model metadata', async () => {
+    const calls: Array<{ method: string; payload: unknown }> = []
     const transport = new MockAuroraTransport().stream('assistant', [
       { id: 's1', kind: 'assistant.delta', payload: { textDelta: 'Hel' }, correlation_id: 'corr-stream' },
       { id: 's2', kind: 'assistant.delta', payload: { delta: 'lo' }, correlation_id: 'corr-stream' },
@@ -3810,10 +3811,32 @@ describe('AuroraClient assistant namespace', () => {
         correlation_id: 'corr-stream'
       }
     ])
+    transport.register(ORCHESTRATOR_METHODS.externalUserInput, (request) => {
+      calls.push({ method: request.method, payload: request.payload })
+      return {
+        text: 'Hello',
+        session_id: 'session-stream',
+        correlation_id: 'corr-stream',
+        request_id: (request.payload as { request_id?: string }).request_id,
+        metadata: { model: 'mock-stream' }
+      }
+    })
     const client = new AuroraClient({ transport })
 
-    const events = await collectEvents(client.assistant.streamMessage({ text: 'hello' }), 3)
+    const events = await collectEvents(client.assistant.streamMessage({ text: 'hello', requestId: 'corr-stream' }), 3)
 
+    expect(calls).toEqual([
+      {
+        method: ORCHESTRATOR_METHODS.externalUserInput,
+        payload: {
+          text: 'hello',
+          source: 'external',
+          request_id: 'corr-stream',
+          correlation_id: 'corr-stream',
+          stream: true
+        }
+      }
+    ])
     expect(events.map((event) => event.kind)).toEqual(['delta', 'delta', 'completed'])
     expect(events[0]?.textDelta).toBe('Hel')
     expect(events[1]?.textDelta).toBe('lo')
@@ -3862,15 +3885,15 @@ describe('AuroraClient assistant namespace', () => {
   })
 
   it('closes assistant stream on external abort without falling back to sendMessage', async () => {
-    let sendCalls = 0
+    let triggerCalls = 0
     const transport = new MockAuroraTransport().stream('assistant', async function* () {
       yield { id: 's1', kind: 'assistant.delta', payload: { text: 'partial' } }
       await new Promise(() => undefined)
     })
     transport.register(ORCHESTRATOR_METHODS.externalUserInput, () => {
-      sendCalls += 1
+      triggerCalls += 1
       return {
-        text: 'fallback should not run',
+        text: 'trigger response',
         session_id: 'session-fallback',
         metadata: { model: 'fallback-model' }
       }
@@ -3888,7 +3911,7 @@ describe('AuroraClient assistant namespace', () => {
     controller.abort()
 
     await expect(raceWithTimeout(iterator.next(), 100)).resolves.toEqual({ done: true, value: undefined })
-    expect(sendCalls).toBe(0)
+    expect(triggerCalls).toBe(1)
   })
 
   it('calls the Orchestrator.Interrupt contract for cancellation through the SDK', async () => {

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -3851,6 +3851,119 @@ describe('AuroraClient assistant namespace', () => {
     )
   })
 
+  it('streams an HTTP assistant request through a correlated backend SSE envelope', async () => {
+    const requests: Array<{ url: string; body: unknown }> = []
+    const eventListeners: Record<string, (event: MessageEvent<string>) => void> = {}
+    let sourceClosed = false
+    let sourceReady: () => void = () => undefined
+    const sourceReadyPromise = new Promise<void>((resolve) => {
+      sourceReady = resolve
+    })
+    const transport = new HttpGatewayTransport({
+      baseUrl: 'http://aurora.local',
+      fetchImpl: async (input, init) => {
+        const url = String(input)
+        const body = JSON.parse(String(init?.body ?? '{}')) as unknown
+        requests.push({ url, body })
+        expect(url).toBe('http://aurora.local/api/Orchestrator/ExternalUserInput')
+        expect(init?.method).toBe('POST')
+        return new Response(
+          JSON.stringify({
+            text: 'Hello from backend',
+            session_id: 'session-http-sdk',
+            request_id: 'corr-http-sdk',
+            correlation_id: 'corr-http-sdk',
+            metadata: { model: 'http-mock' }
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+              'x-correlation-id': 'corr-http-sdk'
+            }
+          }
+        )
+      },
+      eventSourceFactory: (url) => {
+        expect(url).toBe(
+          'http://aurora.local/api/events/stream?stream=assistant&topic=Orchestrator.Response&kind=assistant.delta&kind=assistant.completed&kind=assistant.failed&kind=tool.requested&kind=tool.completed&correlation_id=corr-http-sdk&backfill=true'
+        )
+        sourceReady()
+        return {
+          onmessage: null,
+          onerror: null,
+          addEventListener(type, listener) {
+            eventListeners[type] = listener
+          },
+          close() {
+            sourceClosed = true
+          }
+        }
+      }
+    })
+    const client = new AuroraClient({ transport })
+
+    const eventsPromise = collectEvents(
+      client.assistant.streamMessage({ text: 'hello', requestId: 'corr-http-sdk' }),
+      1
+    )
+    await sourceReadyPromise
+    eventListeners['assistant.completed']?.(
+      new MessageEvent('assistant.completed', {
+        data: JSON.stringify({
+          event_id: 'evt-http-sdk-1',
+          topic: 'Orchestrator.Response',
+          kind: 'assistant.completed',
+          category: 'assistant',
+          action: 'Response',
+          status: 'completed',
+          correlation_id: 'corr-http-sdk',
+          redacted_payload: {
+            text: { redacted: true, sha256: 'text-hash' },
+            session_id: 'session-http-sdk',
+            request_id: 'corr-http-sdk',
+            metadata: { model: 'http-mock' }
+          },
+          payload_sha256: 'payload-hash'
+        }),
+        lastEventId: 'evt-http-sdk-1'
+      })
+    )
+
+    const events = await eventsPromise
+
+    expect(requests).toEqual([
+      {
+        url: 'http://aurora.local/api/Orchestrator/ExternalUserInput',
+        body: {
+          text: 'hello',
+          source: 'external',
+          request_id: 'corr-http-sdk',
+          correlation_id: 'corr-http-sdk',
+          stream: true
+        }
+      }
+    ])
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        kind: 'completed',
+        eventId: 'evt-http-sdk-1',
+        sessionId: 'session-http-sdk',
+        requestId: 'corr-http-sdk',
+        text: 'Hello from backend',
+        textDelta: 'Hello from backend',
+        modelLabel: 'http-mock',
+        audit: expect.objectContaining({
+          correlationId: 'corr-http-sdk',
+          eventKind: 'assistant.completed',
+          transport: 'http'
+        })
+      })
+    )
+    expect(events[0]?.audit.redaction?.secretsRedacted).toBe(true)
+    expect(sourceClosed).toBe(true)
+  })
+
   it('falls back to non-streaming assistant response when stream transport is unavailable before data', async () => {
     const client = new AuroraClient({ transport: new MockAuroraTransport() })
 

--- a/tests/unit/gateway/test_event_stream_route.py
+++ b/tests/unit/gateway/test_event_stream_route.py
@@ -1,17 +1,52 @@
 from __future__ import annotations
 
+from typing import Any
+
+import pytest
 from fastapi.testclient import TestClient
 
-from app.services.gateway.fastapi_app import create_gateway_app
-from app.shared.contracts.models.aurora import AuroraMethods
+from app.messaging.bus import QueryResult
+from app.services.gateway.fastapi_app import (
+    _sse_payload,
+    _stream_backfill_events,
+    create_gateway_app,
+)
+from app.shared.contracts.models.aurora import AuroraEventStreamEvent, AuroraMethods
+from app.shared.contracts.models.auth import AuthMethods
+from app.shared.contracts.models.gateway import GatewayListEventsResponse, GatewayMethods
 
 
 class _DummyBus:
+    def __init__(self, *, events: list[AuroraEventStreamEvent] | None = None) -> None:
+        self.events = events or []
+        self.requests: list[tuple[str, Any]] = []
+
     def subscribe(self, topic, handler) -> None:
         pass
 
     def unsubscribe(self, topic, handler) -> None:
         pass
+
+    async def request(self, topic, payload, **kwargs):
+        self.requests.append((topic, payload))
+        if topic == AuthMethods.VALIDATE_TOKEN:
+            return QueryResult(
+                ok=True,
+                data={
+                    "valid": True,
+                    "principal_id": "principal-sdk",
+                    "principal_name": "SDK",
+                    "is_admin": False,
+                    "permissions": ["Orchestrator.use"],
+                    "effective_perms": ["Orchestrator.use"],
+                },
+            )
+        if topic == GatewayMethods.LIST_EVENTS:
+            return QueryResult(
+                ok=True,
+                data=GatewayListEventsResponse(events=self.events, total=len(self.events)),
+            )
+        return QueryResult(ok=False, error=f"unexpected topic {topic}")
 
 
 class _DummyRegistry:
@@ -58,3 +93,61 @@ def test_event_stream_route_is_documented_as_sse_builtin():
     assert route_schema["summary"] == "Stream unified Aurora events"
     assert route_schema["responses"]["200"]["content"]["text/event-stream"]
     assert AuroraMethods.EVENT_STREAM == "Aurora.EventStream"
+
+
+@pytest.mark.asyncio
+async def test_event_stream_backfill_formats_filtered_sse_events():
+    event = AuroraEventStreamEvent(
+        event_id="evt-1",
+        topic="Orchestrator.Response",
+        kind="assistant.completed",
+        category="assistant",
+        action="Response",
+        status="completed",
+        correlation_id="corr-1",
+        redacted_payload={
+            "text": {"redacted": True, "sha256": "abc"},
+            "session_id": "session-1",
+            "request_id": "corr-1",
+        },
+        payload_sha256="hash",
+    )
+    bus = _DummyBus(events=[event])
+    events = [
+        item
+        async for item in _stream_backfill_events(
+            bus,
+            topics=["Orchestrator.Response"],
+            categories=set(),
+            kinds={"assistant.completed"},
+            correlation_id="corr-1",
+            last_event_id=None,
+            replay_from=None,
+        )
+    ]
+    sse = _sse_payload(events[0])
+
+    assert sse.startswith("id: evt-1\nevent: assistant.completed\n")
+    assert '"correlation_id":"corr-1"' in sse
+    assert bus.requests[0][0] == GatewayMethods.LIST_EVENTS
+    assert bus.requests[0][1].topics == ["Orchestrator.Response"]
+    assert bus.requests[0][1].kinds == ["assistant.completed"]
+    assert bus.requests[0][1].correlation_id == "corr-1"
+
+
+def test_event_stream_route_denies_broad_stream_without_gateway_manage():
+    app = create_gateway_app(
+        bus=_DummyBus(),
+        registry=_DummyRegistry(),
+        auth_enabled=True,
+        auth_api_keys=[],
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/events/stream?kind=audit&backfill=true",
+            headers={"Authorization": "Bearer sdk-token"},
+        )
+
+    assert response.status_code == 403
+    assert "Gateway.manage is required" in response.json()["error"]

--- a/tests/unit/gateway/test_event_stream_route.py
+++ b/tests/unit/gateway/test_event_stream_route.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -64,6 +65,10 @@ class _DummyRegistry:
 
     async def get_external_methods(self):
         return []
+
+
+class _StopStreamingError(Exception):
+    pass
 
 
 def test_event_stream_route_is_auth_gated_when_gateway_auth_enabled():
@@ -151,3 +156,79 @@ def test_event_stream_route_denies_broad_stream_without_gateway_manage():
 
     assert response.status_code == 403
     assert "Gateway.manage is required" in response.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_event_stream_route_delivers_backfilled_event_over_http_sse():
+    event = AuroraEventStreamEvent(
+        event_id="evt-http-1",
+        topic="Orchestrator.Response",
+        kind="assistant.completed",
+        category="assistant",
+        action="Response",
+        status="completed",
+        correlation_id="corr-http-1",
+        redacted_payload={
+            "text": {"redacted": True, "sha256": "text-hash"},
+            "session_id": "session-http",
+            "request_id": "corr-http-1",
+        },
+        payload_sha256="payload-hash",
+    )
+    app = create_gateway_app(
+        bus=_DummyBus(events=[event]),
+        registry=_DummyRegistry(),
+        auth_enabled=False,
+    )
+
+    messages: list[dict[str, Any]] = []
+    request_sent = False
+    never_disconnect = asyncio.Event()
+
+    async def receive() -> dict[str, Any]:
+        nonlocal request_sent
+        if not request_sent:
+            request_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await never_disconnect.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, Any]) -> None:
+        messages.append(message)
+        if message["type"] == "http.response.body" and message.get("body"):
+            raise _StopStreamingError
+
+    with pytest.raises(_StopStreamingError):
+        await app(
+            {
+                "type": "http",
+                "asgi": {"version": "3.0"},
+                "http_version": "1.1",
+                "method": "GET",
+                "scheme": "http",
+                "path": "/api/events/stream",
+                "raw_path": b"/api/events/stream",
+                "query_string": (
+                    b"topic=Orchestrator.Response"
+                    b"&kind=assistant.completed"
+                    b"&correlation_id=corr-http-1"
+                    b"&backfill=true"
+                ),
+                "headers": [],
+                "client": ("testclient", 50000),
+                "server": ("testserver", 80),
+            },
+            receive,
+            send,
+        )
+
+    start = next(message for message in messages if message["type"] == "http.response.start")
+    body = next(message["body"] for message in messages if message["type"] == "http.response.body")
+    lines = body.decode().splitlines()
+
+    assert start["status"] == 200
+    assert lines[0] == "id: evt-http-1"
+    assert lines[1] == "event: assistant.completed"
+    assert '"correlation_id":"corr-http-1"' in lines[2]
+    assert '"payload_sha256":"payload-hash"' in lines[2]
+    assert '"redacted":true' in lines[2]

--- a/tests/unit/gateway/test_mesh_observability.py
+++ b/tests/unit/gateway/test_mesh_observability.py
@@ -307,6 +307,42 @@ async def test_gateway_capture_republishes_normalized_aurora_event_stream():
     assert service.bus.publish.await_args.kwargs["mesh"] is False
 
 
+@pytest.mark.asyncio
+async def test_gateway_list_events_filters_topic_kind_and_last_event_id():
+    service = GatewayService()
+    old_event = _event_from_envelope(
+        Envelope(
+            type="Orchestrator.Response",
+            payload={"text": "old", "correlation_id": "corr-stream"},
+            correlation_id="corr-stream",
+        )
+    )
+    old_event.event_id = "old-event"
+    new_event = _event_from_envelope(
+        Envelope(
+            type="Orchestrator.Response",
+            payload={"text": "new", "correlation_id": "corr-stream"},
+            correlation_id="corr-stream",
+        )
+    )
+    new_event.event_id = "new-event"
+    service._event_stream.appendleft(old_event)
+    service._event_stream.appendleft(new_event)
+
+    response = await service.list_events(
+        GatewayListEventsRequest(
+            topics=["Orchestrator.Response"],
+            kinds=["assistant.completed"],
+            correlation_id="corr-stream",
+            last_event_id="old-event",
+        )
+    )
+
+    assert response.total == 1
+    assert response.events[0].event_id == "new-event"
+    assert response.events[0].kind == "assistant.completed"
+
+
 def test_gateway_event_categories_cover_config_and_pairing():
     config_event = _event_from_envelope(
         Envelope(

--- a/tests/unit/orchestrator/test_service.py
+++ b/tests/unit/orchestrator/test_service.py
@@ -198,7 +198,13 @@ class TestOrchestratorServiceUserInputHandling:
             OrchestratorResponse,
         )
 
-        request = OrchestratorProcessRequest(text="External command", session_id="external-session")
+        request = OrchestratorProcessRequest(
+            text="External command",
+            session_id="external-session",
+            request_id="request-1",
+            correlation_id="corr-1",
+            stream=True,
+        )
 
         with patch.object(
             orchestrator_service, "_process_input", new_callable=AsyncMock
@@ -211,10 +217,15 @@ class TestOrchestratorServiceUserInputHandling:
             assert isinstance(response, OrchestratorResponse)
             assert response.text == "Test response"
             assert response.session_id == "external-session"
+            assert response.request_id == "request-1"
+            assert response.correlation_id == "corr-1"
+            assert response.metadata["stream"] is True
             mock_process.assert_called_once_with(
                 "External command",
                 source="external",
                 session_id="external-session",
+                request_id="request-1",
+                correlation_id="corr-1",
                 return_response=True,
             )
 


### PR DESCRIPTION
## Summary
- add filtered/backfilled `/api/events/stream` SSE support with event ids, typed event names, replay cursors, and scoped authorization
- propagate request and correlation ids through Gateway-generated requests and Orchestrator responses/events
- update the Aurora SDK assistant streaming flow to request once, subscribe to correlated EventStream updates, and avoid duplicate prompt sends on fallback
- add backend route-level HTTP/SSE evidence and SDK HTTP assistant request-to-correlated-SSE evidence for the PER-270 merge gate

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check app/shared/contracts/models/aurora.py app/shared/contracts/models/gateway.py app/shared/contracts/models/orchestrator.py app/services/gateway/fastapi_app.py app/services/gateway/service.py app/services/gateway/route_generator.py app/services/orchestrator/service.py tests/unit/gateway/test_event_stream_route.py tests/unit/gateway/test_mesh_observability.py tests/unit/orchestrator/test_service.py`
- `git diff --check`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/gateway/test_event_stream_route.py tests/unit/gateway/test_mesh_observability.py tests/unit/orchestrator/test_service.py::TestOrchestratorServiceUserInputHandling::test_on_external_input -q`
- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test -- --runInBand packages/aurora-sdk/tests/client.test.ts`

## Additional Integration Evidence
- `tests/unit/gateway/test_event_stream_route.py::test_event_stream_route_delivers_backfilled_event_over_http_sse` invokes the FastAPI ASGI app at `/api/events/stream` with topic/kind/correlation/backfill query parameters and verifies the first streamed SSE frame contains `id:`, `event: assistant.completed`, correlation ID, payload hash, and redacted payload.
- `packages/aurora-sdk/tests/client.test.ts` includes `streams an HTTP assistant request through a correlated backend SSE envelope`, which uses `HttpGatewayTransport` to POST `Orchestrator.ExternalUserInput`, verifies the generated `/api/events/stream` EventSource URL, emits a backend-shaped `assistant.completed` SSE envelope, and asserts the SDK produces the final assistant UI update without a duplicate prompt request.
