### PR TITLE
PER-274: Add event-flow transport parity gate evidence

### DIFF
--- a/.omx/plans/PER-274-event-flow-parity-gate.md
+++ b/.omx/plans/PER-274-event-flow-parity-gate.md
@@ -1,0 +1,40 @@
+# PER-274 Event-Flow Transport Parity Gate Plan
+
+## Requirements Summary
+
+- Source of truth: Multica PER-274 and `docs/PER-269-tauri-ui-production-readiness-report.md`.
+- Prior QA-008 baseline: `.omx/plans/PER-229-transport-parity-gate.md`, `.omx/ultragoal/PER-229-checkpoints.md`, `scripts/transport_parity_gate.py`, and `tests/e2e/test_transport_parity_gate.py`.
+- Relevant guidance read: root `AGENTS.md`, `tests/AGENTS.md`, `app/messaging/AGENTS.md`, `app/services/gateway/AGENTS.md`, `app/shared/AGENTS.md`, and `app/shared/contracts/AGENTS.md`.
+- UI/SDK context read: `.omx/specs/ui-refinement/index.md`, `.omx/specs/ui-refinement/aurora-ui-sdk-contract.md`, `.omx/specs/ui-refinement/aurora-ui-ux-flows.md`, `.omx/specs/ui-refinement/feature-service-availability-graph.md`, `.omx/specs/ui-production-tasks/index.md`, `.omx/specs/ui-production-tasks/backend-gap-crosswalk.md`, `.omx/specs/ui-production-tasks/tasks/QA-008-build-thread-process-mesh-transport-parity-gate.md`, and `.omx/specs/mesh-ui-roadmap-integration-review.md`.
+
+## Acceptance Criteria
+
+- The existing QA-008 report records explicit event-flow requirements per transport row, not only broad coverage strings.
+- Thread, process, HTTP, Tauri, and mesh rows require evidence for registry/capability load, assistant request/stream/cancel basics, config/service-health event delivery, denied/privacy-blocked state, and audit/correlation redaction.
+- Mesh-specific provenance evidence is required for the Mesh/WebRTC row and recorded as not applicable for non-mesh rows with rationale.
+- Rows cannot pass when event-flow evidence is missing, mock-only, or only static build evidence.
+- The SDK command in the gate matches PER-274: `pnpm --filter @aurora/client test -- --runInBand`.
+
+## Implementation Steps
+
+1. Extend `scripts/transport_parity_gate.py` with structured event-flow requirement metadata and row status gating.
+2. Derive event-flow evidence from existing harness scenarios and SDK/UI/Tauri command results.
+3. Update e2e tests to assert required event-flow shape, missing-evidence blocking, and the `--runInBand` SDK command.
+4. Update `docs/TRANSPORT_PARITY_GATE.md` to document the PER-274 event-flow gate expectations and artifacts.
+5. Run targeted Python tests and the SDK test command where local dependencies allow.
+
+## Risks And Mitigations
+
+- Some rows remain environment-gated. Keep skipped rows blocking release readiness and record the exact command required to produce evidence.
+- Existing harness scenarios are deterministic component evidence, not full device-lab proof. The matrix must label command/artifact sources so QA can distinguish component, CI, and platform-runner evidence.
+- Tauri local event support may still be incomplete. The row must block if Tauri command event evidence is not run or fails.
+
+## Verification Steps
+
+- `uv run pytest tests/e2e/test_transport_parity_gate.py -q`
+- `pnpm --filter @aurora/client test -- --runInBand`
+- `uv run --extra gateway --extra mode-processes --extra test-e2e python scripts/transport_parity_gate.py --output-dir .omx/reports/transport-parity/per274-local`
+
+## Stop Rule
+
+Hand off to QA after the script, tests, docs, commit, and PR exist, with exact local verification and any environment-gated rows called out.

--- a/.omx/ultragoal/PER-274-checkpoints.md
+++ b/.omx/ultragoal/PER-274-checkpoints.md
@@ -1,0 +1,30 @@
+# PER-274 Ultragoal Checkpoints
+
+## G001 - Source Context
+
+Status: complete
+
+Evidence: Read PER-274 issue, empty comment history and metadata, root/test/messaging/gateway/shared/contracts guidance, UI refinement specs, QA-008 task file, PER-269 readiness report, and prior PER-229 QA-008 plan/checkpoints.
+
+## G002 - Plan
+
+Status: complete
+
+Evidence: `.omx/plans/PER-274-event-flow-parity-gate.md` records source docs, event-flow acceptance criteria, implementation steps, risks, verification, and stop rule.
+
+## G003 - Implementation
+
+Status: complete
+
+Evidence: Extended `scripts/transport_parity_gate.py` with row-level `event_flow` requirements for registry/capability graph, assistant request/stream/cancel basics, config/service-health event delivery, mesh provenance where applicable, denied/privacy-blocked states, and redacted audit/correlation evidence. Updated the SDK command to `pnpm --filter @aurora/client test -- --runInBand`. Updated `tests/e2e/test_transport_parity_gate.py` and `docs/TRANSPORT_PARITY_GATE.md`.
+
+## G004 - Verification
+
+Status: complete
+
+Evidence:
+
+- `UV_CACHE_DIR=/home/developer/multica_workspaces/8ba5e156-5ff4-4990-b201-7f5d435fdcef/f79b9f33/workdir/.uv-cache uv run --extra gateway --extra mode-processes --extra test-e2e pytest tests/e2e/test_transport_parity_gate.py -q` passed: 6 passed.
+- `pnpm --filter @aurora/client test -- --runInBand` passed: 4 files, 98 tests.
+- `UV_CACHE_DIR=/home/developer/multica_workspaces/8ba5e156-5ff4-4990-b201-7f5d435fdcef/f79b9f33/workdir/.uv-cache uv run --extra gateway --extra mode-processes --extra test-e2e python scripts/transport_parity_gate.py --execute-commands --output-dir .omx/reports/transport-parity/per274-executed` generated the report and exited blocked as designed: thread, HTTP, Tauri, and mesh rows passed; process/Redis, Android, and iOS rows remain release-blocking environment/platform evidence gaps.
+- `UV_CACHE_DIR=/home/developer/multica_workspaces/8ba5e156-5ff4-4990-b201-7f5d435fdcef/f79b9f33/workdir/.uv-cache uv run --extra dev ruff check scripts/transport_parity_gate.py tests/e2e/test_transport_parity_gate.py` passed.

--- a/docs/TRANSPORT_PARITY_GATE.md
+++ b/docs/TRANSPORT_PARITY_GATE.md
@@ -1,10 +1,10 @@
 # QA-008 Transport Parity Gate
 
-`scripts/transport_parity_gate.py` is the release gate for PER-229 / QA-008. It combines:
+`scripts/transport_parity_gate.py` is the release gate for PER-274 / QA-008. It combines:
 
 - `scripts/mesh_gap_e2e_harness.py` for thread/LocalBus, process/BullMQ+Redis, HTTP Gateway, Tauri local command smoke, and real two-peer Mesh/WebRTC DataChannel evidence.
 - `pnpm --filter @aurora/client build` so package tests consume the SDK `dist/` entrypoint.
-- `pnpm --filter @aurora/client test` for the shared AuroraClient conformance suite across mock, HTTP, Tauri command, and mesh mock transports.
+- `pnpm --filter @aurora/client test -- --runInBand` for the shared AuroraClient conformance suite across mock, HTTP, Tauri command, and mesh mock transports.
 - `pnpm --filter @aurora/ui test` for SDK-bound user-flow smoke models.
 - `pnpm --filter @aurora/tauri-ui test` for the desktop local/Tauri wrapper boundary.
 - Android/iOS rows with explicit skipped-with-rationale status until Android emulator/device smoke or macOS/Xcode runner evidence is attached. The non-strict Android release report is useful evidence, but does not by itself pass the Android row.
@@ -37,5 +37,20 @@ Expected artifacts:
 - `.omx/reports/transport-parity/local/commands/*.log` when `--execute-commands` is used
 
 The release is not ready unless `summary.status` is `pass`. A process/Redis dependency gap, missing SDK/UI command evidence, Android/iOS platform skip, or any failed row keeps `release_ready=false`.
+
+## PER-274 event-flow evidence
+
+Every matrix row now contains an `event_flow` array. Broad `coverage` labels and build-only command results are not sufficient for production-readiness approval.
+
+Required event-flow checks per supported row:
+
+- `registry_capability_graph` - SDK/client path can load registry or capability graph evidence.
+- `assistant_request_stream_cancel` - assistant request/stream/cancel basics ran through SDK/UI/Tauri command evidence, or the row is blocked with an explicit degraded reason.
+- `config_or_service_health_event` - a config or service-health event reaches the UI/SDK event subscriber.
+- `denied_or_privacy_blocked_state` - a denied or privacy-blocked action surfaces a typed state.
+- `audit_correlation_redacted` - audit/correlation IDs are present and redacted.
+- `mesh_provenance_event` - required only for rows that claim mesh support; non-mesh rows record `not_applicable` with rationale.
+
+A required event-flow item with `missing`, `not_run`, `dependency_gap`, `blocked`, or `fail` blocks that row. Mock-only SDK conformance still records useful evidence, but cannot pass the gate unless the live/hermetic transport row also has the required event-flow artifacts.
 
 The report redacts Redis URLs, host paths, tokens, peer secrets, and secret-like fields. Mock transport conformance is useful evidence, but `mock_only_evidence_sufficient` is always `false`; a mock-only pass cannot satisfy QA-008.

--- a/scripts/transport_parity_gate.py
+++ b/scripts/transport_parity_gate.py
@@ -71,6 +71,7 @@ class MatrixRow:
     blocks_release: bool
     rationale: str
     evidence: dict[str, Any] = field(default_factory=dict)
+    event_flow: list[dict[str, Any]] = field(default_factory=list)
 
 
 GATE_COMMANDS: tuple[GateCommand, ...] = (
@@ -83,8 +84,8 @@ GATE_COMMANDS: tuple[GateCommand, ...] = (
     GateCommand(
         command_id="sdk_conformance",
         owner="sdk",
-        command=("pnpm", "--filter", "@aurora/client", "test"),
-        rationale="Runs the shared AuroraClient behavior suite across mock, HTTP, Tauri command, and mesh mock transports.",
+        command=("pnpm", "--filter", "@aurora/client", "test", "--", "--runInBand"),
+        rationale="Runs the shared AuroraClient event-flow suite across mock, HTTP, Tauri command, and mesh mock transports.",
     ),
     GateCommand(
         command_id="ui_flow_smoke",
@@ -128,7 +129,8 @@ def run_transport_parity_gate(
     summary = _build_summary(rows, command_results, harness_report)
     report = {
         "gate_id": "QA-008",
-        "issue": "PER-229",
+        "issue": "PER-274",
+        "supersedes_issue": "PER-229",
         "generated_at": _now(),
         "release_ready": summary["status"] == "pass",
         "summary": summary,
@@ -243,7 +245,7 @@ def _build_rows(
 
     android = _mobile_row(command_map["android_release_gate"])
     ios = _ios_row()
-    return [
+    rows = [
         harness_by_id["thread_localbus"],
         harness_by_id["process_bullmq_redis"],
         harness_by_id["http_gateway_thin_client"],
@@ -252,6 +254,8 @@ def _build_rows(
         android,
         ios,
     ]
+    _attach_event_flow_evidence(rows, harness_report, command_map)
+    return rows
 
 
 def _row_from_harness_mode(harness_report: HarnessReport, mode_id: str) -> MatrixRow:
@@ -381,6 +385,241 @@ def _ios_row() -> MatrixRow:
     )
 
 
+def _attach_event_flow_evidence(
+    rows: Sequence[MatrixRow],
+    harness_report: HarnessReport,
+    command_map: dict[str, CommandResult],
+) -> None:
+    for row in rows:
+        row.event_flow = _event_flow_for_row(row, harness_report, command_map)
+        _apply_event_flow_gate(row)
+
+
+def _event_flow_for_row(
+    row: MatrixRow,
+    harness_report: HarnessReport,
+    command_map: dict[str, CommandResult],
+) -> list[dict[str, Any]]:
+    if row.row_id in {"android_thin_local_light", "ios_thin_local_light"}:
+        return _mobile_event_flow(row)
+
+    assistant_commands = ["sdk_conformance", "ui_flow_smoke"]
+    if row.row_id == "tauri_local_native":
+        assistant_commands.append("tauri_local_smoke")
+
+    return [
+        _scenario_requirement(
+            harness_report,
+            row.row_id,
+            requirement_id="registry_capability_graph",
+            label="SDK client loads registry/capability graph",
+            scenario_ids=("catalog_local_remote_blocked", "route_explain"),
+        ),
+        _command_requirement(
+            command_map,
+            requirement_id="assistant_request_stream_cancel",
+            label="Assistant request/stream/cancel basics are exercised or explicitly degraded",
+            command_ids=tuple(assistant_commands),
+        ),
+        _scenario_requirement(
+            harness_report,
+            row.row_id,
+            requirement_id="config_or_service_health_event",
+            label="A config or service-health event reaches the UI/SDK event subscriber",
+            scenario_ids=("unified_event_stream",),
+        ),
+        _mesh_requirement(row, harness_report),
+        _scenario_requirement(
+            harness_report,
+            row.row_id,
+            requirement_id="denied_or_privacy_blocked_state",
+            label="A denied or privacy-blocked action surfaces a typed state",
+            scenario_ids=(
+                "auth_config_denied",
+                "dangerous_local_approval",
+                "streaming_audio_consent",
+            ),
+        ),
+        _scenario_requirement(
+            harness_report,
+            row.row_id,
+            requirement_id="audit_correlation_redacted",
+            label="Audit/correlation IDs are present and redacted",
+            scenario_ids=("support_bundle",),
+        ),
+    ]
+
+
+def _mobile_event_flow(row: MatrixRow) -> list[dict[str, Any]]:
+    status = "pass" if row.status == "pass" else "dependency_gap"
+    rationale = (
+        "Mobile platform event-flow evidence is attached for this row."
+        if row.status == "pass"
+        else row.rationale
+    )
+    return [
+        {
+            "requirement_id": requirement_id,
+            "label": label,
+            "status": status,
+            "required": True,
+            "source": "mobile-platform-smoke",
+            "rationale": rationale,
+        }
+        for requirement_id, label in (
+            ("registry_capability_graph", "SDK client loads registry/capability graph"),
+            (
+                "assistant_request_stream_cancel",
+                "Assistant request/stream/cancel basics are exercised or explicitly degraded",
+            ),
+            (
+                "config_or_service_health_event",
+                "A config or service-health event reaches the UI/SDK event subscriber",
+            ),
+            (
+                "denied_or_privacy_blocked_state",
+                "A denied or privacy-blocked action surfaces a typed state",
+            ),
+            ("audit_correlation_redacted", "Audit/correlation IDs are present and redacted"),
+        )
+    ] + [
+        {
+            "requirement_id": "mesh_provenance_event",
+            "label": "Mesh/provenance event proves source/target peer behavior where mesh is available",
+            "status": "not_applicable",
+            "required": False,
+            "source": "mobile-platform-smoke",
+            "rationale": "Mobile thin/local-light rows do not claim two-peer mesh support without a platform mesh smoke.",
+        }
+    ]
+
+
+def _scenario_requirement(
+    harness_report: HarnessReport,
+    mode_id: str,
+    *,
+    requirement_id: str,
+    label: str,
+    scenario_ids: tuple[str, ...],
+) -> dict[str, Any]:
+    results = [
+        result
+        for result in harness_report.results
+        if result["mode_id"] == mode_id and result["scenario_id"] in scenario_ids
+    ]
+    found = {result["scenario_id"] for result in results}
+    missing = sorted(set(scenario_ids) - found)
+    statuses = {result["status"] for result in results}
+    if missing:
+        status = "missing"
+        rationale = f"Missing harness scenarios: {missing}"
+    elif statuses == {"pass"}:
+        status = "pass"
+        rationale = "Required harness scenario evidence passed."
+    elif "fail" in statuses:
+        status = "fail"
+        rationale = "At least one required harness scenario failed."
+    elif statuses == {"dependency_gap"}:
+        status = "dependency_gap"
+        rationale = "Required runtime dependency was unavailable for this row."
+    else:
+        status = "blocked"
+        rationale = f"Mixed required harness statuses: {sorted(statuses)}"
+    return {
+        "requirement_id": requirement_id,
+        "label": label,
+        "status": status,
+        "required": True,
+        "source": "mesh_gap_e2e_harness",
+        "scenario_ids": list(scenario_ids),
+        "correlation_ids": [
+            result.get("correlation_id") for result in results if result.get("correlation_id")
+        ],
+        "rationale": rationale,
+    }
+
+
+def _command_requirement(
+    command_map: dict[str, CommandResult],
+    *,
+    requirement_id: str,
+    label: str,
+    command_ids: tuple[str, ...],
+) -> dict[str, Any]:
+    statuses = {
+        command_id: command_map[command_id].status
+        for command_id in command_ids
+        if command_id in command_map
+    }
+    missing = sorted(set(command_ids) - set(statuses))
+    if missing:
+        status = "missing"
+        rationale = f"Missing command results: {missing}"
+    elif all(command_status == "pass" for command_status in statuses.values()):
+        status = "pass"
+        rationale = "Required SDK/UI event-flow command evidence passed."
+    elif any(command_status == "fail" for command_status in statuses.values()):
+        status = "fail"
+        rationale = "At least one required SDK/UI event-flow command failed."
+    elif any(command_status == "not_run" for command_status in statuses.values()):
+        status = "not_run"
+        rationale = "Required SDK/UI event-flow command was not run."
+    else:
+        status = "blocked"
+        rationale = f"Unexpected command statuses: {statuses}"
+    return {
+        "requirement_id": requirement_id,
+        "label": label,
+        "status": status,
+        "required": True,
+        "source": "sdk_ui_commands",
+        "command_ids": list(command_ids),
+        "command_statuses": statuses,
+        "rationale": rationale,
+    }
+
+
+def _mesh_requirement(row: MatrixRow, harness_report: HarnessReport) -> dict[str, Any]:
+    if row.row_id != "mesh_webrtc":
+        return {
+            "requirement_id": "mesh_provenance_event",
+            "label": "Mesh/provenance event proves source/target peer behavior where mesh is available",
+            "status": "not_applicable",
+            "required": False,
+            "source": "mesh_gap_e2e_harness",
+            "rationale": "This row does not claim mesh/WebRTC transport support.",
+        }
+    return _scenario_requirement(
+        harness_report,
+        row.row_id,
+        requirement_id="mesh_provenance_event",
+        label="Mesh/provenance event proves source/target peer behavior where mesh is available",
+        scenario_ids=("safe_remote_tool", "route_explain", "support_bundle"),
+    )
+
+
+def _apply_event_flow_gate(row: MatrixRow) -> None:
+    required = [item for item in row.event_flow if item.get("required", True)]
+    failed = [item["requirement_id"] for item in required if item["status"] == "fail"]
+    blocked = [
+        item["requirement_id"]
+        for item in required
+        if item["status"] in {"blocked", "dependency_gap", "missing", "not_run"}
+    ]
+    row.evidence["event_flow_requirements"] = {
+        item["requirement_id"]: item["status"] for item in row.event_flow
+    }
+    if failed:
+        row.status = "fail"
+        row.blocks_release = True
+        row.rationale = f"{row.rationale} Event-flow requirement(s) failed: {failed}."
+    elif blocked:
+        row.blocks_release = True
+        if row.status == "pass":
+            row.status = "blocked"
+        row.rationale = f"{row.rationale} Event-flow requirement(s) incomplete: {blocked}."
+
+
 def _merge_command_status(row: MatrixRow, result: CommandResult) -> None:
     if result.artifact_path:
         row.artifact_paths.append(result.artifact_path)
@@ -430,6 +669,25 @@ def _build_summary(
             for result in command_results
         ),
         "mock_only_evidence_sufficient": False,
+        "event_flow_gate": {
+            "required_requirements": [
+                "registry_capability_graph",
+                "assistant_request_stream_cancel",
+                "config_or_service_health_event",
+                "denied_or_privacy_blocked_state",
+                "audit_correlation_redacted",
+            ],
+            "mesh_required_when_available": "mesh_provenance_event",
+            "missing_or_incomplete": {
+                row.row_id: [
+                    item["requirement_id"]
+                    for item in row.event_flow
+                    if item.get("required", True)
+                    and item["status"] in {"blocked", "dependency_gap", "missing", "not_run"}
+                ]
+                for row in rows
+            },
+        },
         "mesh_final_proof": harness_report.summary["final_mesh_mode_status"],
         "process_redis_dependency_gap": "process_bullmq_redis"
         in harness_report.summary["dependency_gap_modes"],

--- a/tests/e2e/test_transport_parity_gate.py
+++ b/tests/e2e/test_transport_parity_gate.py
@@ -47,6 +47,9 @@ def test_transport_parity_gate_emits_required_rows_and_artifacts(tmp_path):
     assert set(rows) == required_rows
     assert report["summary"]["row_count"] == len(required_rows)
     assert report["summary"]["mock_only_evidence_sufficient"] is False
+    assert report["summary"]["event_flow_gate"]["mesh_required_when_available"] == (
+        "mesh_provenance_event"
+    )
     assert report["summary"]["mesh_final_proof"] == "pass"
     assert report["secrets_redacted"] is True
 
@@ -57,16 +60,46 @@ def test_transport_parity_gate_emits_required_rows_and_artifacts(tmp_path):
         assert row["status"] in {"pass", "fail", "blocked", "skipped-with-rationale"}
         assert row["coverage"]
         assert row["rationale"]
+        assert {item["requirement_id"] for item in row["event_flow"]} == {
+            "registry_capability_graph",
+            "assistant_request_stream_cancel",
+            "config_or_service_health_event",
+            "mesh_provenance_event",
+            "denied_or_privacy_blocked_state",
+            "audit_correlation_redacted",
+        }
 
     assert rows["thread_localbus"]["status"] == "pass"
     assert rows["http_gateway_thin_client"]["status"] == "pass"
     assert rows["tauri_local_native"]["status"] == "pass"
     assert rows["mesh_webrtc"]["status"] == "pass"
+    mesh_flow = {
+        item["requirement_id"]: item for item in rows["mesh_webrtc"]["event_flow"]
+    }
+    assert mesh_flow["mesh_provenance_event"]["status"] == "pass"
+    assert mesh_flow["mesh_provenance_event"]["required"] is True
+    thread_flow = {
+        item["requirement_id"]: item for item in rows["thread_localbus"]["event_flow"]
+    }
+    assert thread_flow["mesh_provenance_event"]["status"] == "not_applicable"
+    assert thread_flow["mesh_provenance_event"]["required"] is False
     assert rows["ios_thin_local_light"]["status"] == "skipped-with-rationale"
     assert rows["ios_thin_local_light"]["blocks_release"] is True
 
     persisted = json.loads((tmp_path / "transport_parity_report.json").read_text(encoding="utf-8"))
     assert persisted["summary"] == report["summary"]
+    assert any(
+        command["command_id"] == "sdk_conformance"
+        and command["command"] == [
+            "pnpm",
+            "--filter",
+            "@aurora/client",
+            "test",
+            "--",
+            "--runInBand",
+        ]
+        for command in persisted["command_results"]
+    )
 
 
 @pytest.mark.e2e
@@ -82,6 +115,7 @@ def test_transport_parity_gate_blocks_when_required_commands_are_not_run(tmp_pat
     rows = {row["row_id"]: row for row in report["rows"]}
     assert rows["http_gateway_thin_client"]["status"] == "blocked"
     assert rows["mesh_webrtc"]["status"] == "blocked"
+    assert rows["http_gateway_thin_client"]["event_flow"][1]["status"] == "not_run"
 
 
 @pytest.mark.e2e
@@ -110,6 +144,32 @@ def test_transport_parity_gate_does_not_allow_mock_only_success_to_pass(tmp_path
     assert report["summary"]["mock_only_evidence_sufficient"] is False
     assert report["summary"]["status"] == "blocked"
     assert report["release_ready"] is False
+    rows = {row["row_id"]: row for row in report["rows"]}
+    assert rows["thread_localbus"]["event_flow"][1]["status"] == "not_run"
+
+
+@pytest.mark.e2e
+def test_transport_parity_gate_blocks_missing_event_flow_scenarios(tmp_path):
+    def incomplete_harness(output_dir):
+        report = _fake_harness_report(output_dir)
+        report.results = [
+            result
+            for result in report.results
+            if result["scenario_id"] != "unified_event_stream"
+        ]
+        return report
+
+    report = run_transport_parity_gate(
+        output_dir=tmp_path,
+        command_runner=_passing_command,
+        harness_runner=incomplete_harness,
+    )
+
+    rows = {row["row_id"]: row for row in report["rows"]}
+    assert report["summary"]["status"] == "blocked"
+    assert rows["thread_localbus"]["status"] == "blocked"
+    flow = {item["requirement_id"]: item for item in rows["thread_localbus"]["event_flow"]}
+    assert flow["config_or_service_health_event"]["status"] == "missing"
 
 
 @pytest.mark.e2e
@@ -204,25 +264,37 @@ def _fake_harness_report(output_dir):
             "notes": [],
         },
     ]
+    required_scenarios = (
+        "catalog_local_remote_blocked",
+        "route_explain",
+        "unified_event_stream",
+        "safe_remote_tool",
+        "support_bundle",
+        "auth_config_denied",
+        "dangerous_local_approval",
+        "streaming_audio_consent",
+    )
     scenarios = [
         {
-            "scenario_id": "required_flow",
-            "title": "Required flow",
+            "scenario_id": scenario_id,
+            "title": scenario_id.replace("_", " ").title(),
             "categories": ["audit"],
             "assertion": "passes",
         }
+        for scenario_id in required_scenarios
     ]
     results = [
         {
-            "scenario_id": "required_flow",
+            "scenario_id": scenario["scenario_id"],
             "mode_id": mode["mode_id"],
             "status": "pass",
             "assertion": "passes",
             "evidence": {"transport_path": mode["transport"]},
-            "correlation_id": f"{mode['mode_id']}-required_flow",
+            "correlation_id": f"{mode['mode_id']}-{scenario['scenario_id']}",
             "events": [],
         }
         for mode in modes
+        for scenario in scenarios
     ]
     summary = {
         "status": "pass",
@@ -230,7 +302,7 @@ def _fake_harness_report(output_dir):
         "failed": 0,
         "preflight": 0,
         "dependency_gap": 0,
-        "scenario_count": 1,
+        "scenario_count": len(scenarios),
         "mode_count": len(modes),
         "result_count": len(results),
         "component_modes": [mode["mode_id"] for mode in modes],


### PR DESCRIPTION
## Summary

- Extends the QA-008 transport parity gate with row-level PER-274 `event_flow` requirements.
- Blocks rows when required event-flow evidence is missing, not run, dependency-gated, or failed.
- Aligns the SDK conformance command with the issue requirement: `pnpm --filter @aurora/client test -- --runInBand`.
- Documents the new event-flow matrix contract and adds PER-274 OMX plan/checkpoint artifacts.

## Verification

- `UV_CACHE_DIR=/home/developer/multica_workspaces/8ba5e156-5ff4-4990-b201-7f5d435fdcef/f79b9f33/workdir/.uv-cache uv run --extra gateway --extra mode-processes --extra test-e2e pytest tests/e2e/test_transport_parity_gate.py -q` passed: 6 passed.
- `pnpm --filter @aurora/client test -- --runInBand` passed: 4 files, 98 tests.
- `UV_CACHE_DIR=/home/developer/multica_workspaces/8ba5e156-5ff4-4990-b201-7f5d435fdcef/f79b9f33/workdir/.uv-cache uv run --extra gateway --extra mode-processes --extra test-e2e python scripts/transport_parity_gate.py --execute-commands --output-dir .omx/reports/transport-parity/per274-executed` generated the matrix and exited blocked as designed.
- `UV_CACHE_DIR=/home/developer/multica_workspaces/8ba5e156-5ff4-4990-b201-7f5d435fdcef/f79b9f33/workdir/.uv-cache uv run --extra dev ruff check scripts/transport_parity_gate.py tests/e2e/test_transport_parity_gate.py` passed.

## Matrix Evidence

- Artifact: `.omx/reports/transport-parity/per274-executed/transport_parity_report.json`
- Passing rows: `thread_localbus`, `http_gateway_thin_client`, `tauri_local_native`, `mesh_webrtc`
- Blocking rows by design in this local environment: `process_bullmq_redis`, `android_thin_local_light`, `ios_thin_local_light`
- `release_ready=false` because process/Redis and mobile platform evidence remain environment-gated.
