### PR TITLE
PER-272 voice audio runtime event readiness

### DIFF
--- a/.omx/plans/PER-272-voice-audio-native-runtime-readiness.md
+++ b/.omx/plans/PER-272-voice-audio-native-runtime-readiness.md
@@ -1,0 +1,28 @@
+# PER-272 Voice, Audio, And Native Runtime Readiness Plan
+
+## Source Scope
+
+- Multica issue: PER-272 `[UI-GAP] Close voice, audio, and native runtime event readiness gaps`.
+- Required specs read: `.omx/specs/ui-refinement/index.md`, `aurora-ui-sdk-contract.md`, `aurora-ui-ux-flows.md`, `feature-service-availability-graph.md`, `.omx/specs/ui-production-tasks/index.md`, `backend-gap-crosswalk.md`, and `.omx/specs/mesh-ui-roadmap-integration-review.md`.
+- Code paths: `packages/aurora-sdk/src/events.ts`, `packages/aurora-sdk/src/types.ts`, `packages/aurora-sdk/src/client.ts`, `packages/aurora-ui/src/assistant-view.tsx`, `packages/aurora-ui/src/shell-data.ts`, `packages/aurora-ui/tests/shell.test.tsx`, and SDK tests.
+
+## Constraints
+
+- Keep voice/audio states driven by backend/native evidence, not static UI fixtures.
+- Preserve privacy defaults: raw audio, wakeword, remote microphone, and remote playback remain target/consent/policy gated.
+- Do not claim iOS default assistant replacement or mobile/native success from static fixtures when runtime manifest evidence exists.
+- Do not add backend models unless existing STT/TTS/AudioSession contracts lack a required topic or payload. Current read shows STT session/partial/final/error/timeout, TTS lifecycle, and AudioSession consent/event models already exist.
+
+## Implementation Steps
+
+1. Add SDK types and normalization helpers for voice/audio evidence events covering `voice.session.started`, `voice.session.ended`, STT partial/final/error/timeout/cancelled/disconnected, TTS started/stopped/paused/resumed/error, and AudioSession consent/policy events.
+2. Add an SDK `assistant.streamVoiceEvents()` or equivalent focused surface that subscribes to typed STT/TTS/AudioSession topics and preserves session ID, correlation ID, peer/device provenance, privacy class, policy/consent, and transport audit fields.
+3. Update assistant voice UI model to accept normalized voice evidence rows and render actual event statuses/details when provided; keep the existing unsupported/pending rows as explicit no-evidence fallback.
+4. Extend tests for SDK voice event normalization and UI event-driven state mapping, including partial/final transcription, TTS control evidence, denied/disconnected outcomes, and native runtime capability truth.
+5. Run targeted `pnpm --filter @aurora/client typecheck`, `pnpm --filter @aurora/client test -- --runInBand`, `pnpm --filter @aurora/ui test:qa004`, and focused UI tests if full QA004 is too broad for the environment.
+
+## Verification Strategy
+
+- SDK unit tests prove raw backend/Tauri/mock events normalize without inventing missing success.
+- UI tests prove visible voice states can be backend/native-evidence-driven.
+- Native hardware/device-lab coverage remains explicitly deferred; manifest/runtime payload tests are the local proof.

--- a/.omx/ultragoal/PER-272-voice-audio-native-runtime-readiness.md
+++ b/.omx/ultragoal/PER-272-voice-audio-native-runtime-readiness.md
@@ -1,0 +1,15 @@
+# PER-272 Ultragoal Checkpoint
+
+## Goal
+
+Close voice, audio, and native runtime event readiness gaps for UI/SDK evidence handling without broadening beyond PER-272.
+
+## Checkpoints
+
+- [x] Read issue, metadata, comments, AGENTS, and UI production specs.
+- [x] Isolate branch/worktree: `multica/PER-272-voice-audio-runtime-readiness`.
+- [x] Implement SDK voice/audio event normalization.
+- [x] Wire assistant voice model to normalized event evidence.
+- [x] Add SDK/UI tests.
+- [x] Run targeted verification.
+- [ ] Commit, push, open PR, and hand off to QA.

--- a/packages/aurora-sdk/src/client.ts
+++ b/packages/aurora-sdk/src/client.ts
@@ -38,6 +38,7 @@ import {
   type ToolApprovalDecisionResult,
   type ToolCatalogResponse
 } from './tools.js'
+import { normalizeVoiceRuntimeEvent, VOICE_EVENT_KINDS, VOICE_EVENT_TOPICS } from './voice.js'
 import type {
   AdminOverviewManifest,
   AdminOverviewManifestInput,
@@ -130,6 +131,7 @@ import type {
   TokenRevokeResponse,
   WebRTCDiagnosticsResponse
 } from './types.js'
+import type { VoiceRuntimeEvent } from './voice.js'
 import type {
   EffectivePermissionInput,
   PermissionAccessDecision,
@@ -768,6 +770,26 @@ export class AssistantClient {
         return
       }
       yield streamFailure(fallback.error, this.client.transport.kind, 'fallback')
+    }
+  }
+
+  async *streamVoiceEvents(
+    options: AuroraSubscribeOptions = {}
+  ): AsyncIterable<VoiceRuntimeEvent> {
+    const stream = this.client.events.subscribe<unknown>({
+      stream: 'voice',
+      topics: [...VOICE_EVENT_TOPICS],
+      kinds: [...VOICE_EVENT_KINDS],
+      reconnect: { maxAttempts: 1, initialDelayMs: 250, maxDelayMs: 1_000 },
+      ...options,
+      audit: {
+        ...options.audit,
+        transport: this.client.transport.kind
+      }
+    })
+    for await (const event of stream) {
+      const normalized = normalizeVoiceRuntimeEvent(event)
+      if (normalized) yield normalized
     }
   }
 

--- a/packages/aurora-sdk/src/index.ts
+++ b/packages/aurora-sdk/src/index.ts
@@ -127,6 +127,11 @@ export {
   toolCatalogFixture,
   uiMockReferenceFixtureSummary
 } from './fixtures.js'
+export {
+  normalizeVoiceRuntimeEvent,
+  VOICE_EVENT_KINDS,
+  VOICE_EVENT_TOPICS
+} from './voice.js'
 export type * from './types.js'
 export type * from './admin.js'
 export type * from './backup.js'
@@ -134,6 +139,7 @@ export type * from './memory.js'
 export type * from './scheduler.js'
 export type * from './tools.js'
 export type * from './transport.js'
+export type * from './voice.js'
 export type {
   AuroraEventStreamKind,
   AuroraEventStreamTransport,

--- a/packages/aurora-sdk/src/voice.ts
+++ b/packages/aurora-sdk/src/voice.ts
@@ -1,0 +1,191 @@
+import type { AuroraEvent, AuditReceipt, JsonObject, PrivacyClass } from './types.js'
+
+export type VoiceRuntimeEventKind =
+  | 'session_started'
+  | 'session_ended'
+  | 'transcription_partial'
+  | 'transcription_final'
+  | 'stt_timeout'
+  | 'stt_error'
+  | 'tts_started'
+  | 'tts_stopped'
+  | 'tts_paused'
+  | 'tts_resumed'
+  | 'tts_error'
+  | 'audio_consent_requested'
+  | 'audio_denied'
+  | 'audio_started'
+  | 'audio_stopped'
+  | 'audio_disconnected'
+  | 'audio_cancelled'
+
+export type VoiceRuntimeState =
+  | 'idle'
+  | 'listening'
+  | 'processing'
+  | 'speaking'
+  | 'paused'
+  | 'cancelled'
+  | 'timeout'
+  | 'denied'
+  | 'disconnected'
+  | 'error'
+
+export interface VoiceRuntimeEvent {
+  id: string | null
+  kind: VoiceRuntimeEventKind
+  topic: string | null
+  sessionId: string | null
+  correlationId: string | null
+  sourcePeerId: string | null
+  targetPeerId: string | null
+  targetDeviceId: string | null
+  consentDecision: string | null
+  policyDecisionId: string | null
+  privacyClass: PrivacyClass | 'raw-audio' | 'microphone' | string
+  state: VoiceRuntimeState
+  text: string | null
+  reason: string | null
+  redacted: boolean
+  occurredAt: string
+  audit: AuditReceipt
+  raw: JsonObject
+}
+
+export const VOICE_EVENT_TOPICS = [
+  'STTCoordinator.SessionStarted',
+  'STTCoordinator.SessionEnded',
+  'STTCoordinator.Partial',
+  'STTCoordinator.Final',
+  'STTCoordinator.Error',
+  'STTCoordinator.Timeout',
+  'Transcription.Result',
+  'Transcription.Error',
+  'TTS.Started',
+  'TTS.Stopped',
+  'TTS.Paused',
+  'TTS.Resumed',
+  'TTS.Error',
+  'AudioSession.Events'
+] as const
+
+export const VOICE_EVENT_KINDS = [
+  'voice.session.started',
+  'voice.session.ended',
+  'voice.transcription.partial',
+  'voice.transcription.final',
+  'voice.timeout',
+  'voice.cancelled',
+  'voice.denied',
+  'voice.disconnected',
+  'tts.started',
+  'tts.stopped',
+  'tts.paused',
+  'tts.resumed',
+  'tts.error',
+  'audio.consent.requested',
+  'audio.denied',
+  'audio.started',
+  'audio.stopped',
+  'audio.disconnected',
+  'audio.cancelled'
+] as const
+
+export function normalizeVoiceRuntimeEvent(event: AuroraEvent<unknown>): VoiceRuntimeEvent | null {
+  const raw = objectPayload(event.payload)
+  const topic = event.topic ?? event.busTopic ?? event.method
+  const source = event.kind || topic || readString(raw, 'event_type', 'type', 'kind') || ''
+  const audioEventType = readString(raw, 'event_type', 'type', 'status')
+  const kind = runtimeKindFor(source, topic, audioEventType)
+  if (!kind) return null
+  const text = readString(raw, 'text', 'transcript', 'partial', 'final', 'current_text')
+  const reason = readString(raw, 'reason', 'error', 'message', 'status')
+  const privacyClass = readString(raw, 'privacy_class', 'privacyClass') ?? inferPrivacyClass(kind)
+  const correlationId = readString(raw, 'correlation_id', 'correlationId') ?? event.audit.correlationId
+  return {
+    id: event.id,
+    kind,
+    topic,
+    sessionId: readString(raw, 'session_id', 'sessionId') ?? null,
+    correlationId,
+    sourcePeerId: readString(raw, 'source_peer_id', 'sourcePeerId', 'caller_peer_id', 'callerPeerId') ?? event.audit.peerId,
+    targetPeerId: readString(raw, 'target_peer_id', 'targetPeerId') ?? event.audit.targetPeerId,
+    targetDeviceId: readString(raw, 'target_device_id', 'targetDeviceId') ?? null,
+    consentDecision: readString(raw, 'consent_decision', 'consentDecision', 'consent_status', 'status') ?? null,
+    policyDecisionId: readString(raw, 'policy_decision_id', 'policyDecisionId') ?? null,
+    privacyClass,
+    state: runtimeStateFor(kind, readString(raw, 'status', 'state')),
+    text: text ?? null,
+    reason: reason ?? null,
+    redacted: readBoolean(raw, 'redacted', 'secrets_redacted', 'secretsRedacted') ?? event.redaction.secretsRedacted,
+    occurredAt: readString(raw, 'occurred_at', 'timestamp', 'created_at') ?? event.receivedAt,
+    audit: event.audit,
+    raw
+  }
+}
+
+function runtimeKindFor(source: string, topic: string | null, audioEventType: string | null): VoiceRuntimeEventKind | null {
+  const key = `${source} ${topic ?? ''} ${audioEventType ?? ''}`.toLowerCase()
+  if (key.includes('sessionstarted') || key.includes('session.started')) return 'session_started'
+  if (key.includes('sessionended') || key.includes('session.ended')) return 'session_ended'
+  if (key.includes('partial')) return 'transcription_partial'
+  if (key.includes('final') || key.includes('transcription.result')) return 'transcription_final'
+  if (key.includes('timeout')) return 'stt_timeout'
+  if (key.includes('tts.started')) return 'tts_started'
+  if (key.includes('tts.stopped')) return 'tts_stopped'
+  if (key.includes('tts.paused')) return 'tts_paused'
+  if (key.includes('tts.resumed')) return 'tts_resumed'
+  if (key.includes('tts.error')) return 'tts_error'
+  if (key.includes('consent') && key.includes('request')) return 'audio_consent_requested'
+  if (key.includes('denied')) return 'audio_denied'
+  if (key.includes('disconnected') || key.includes('disconnect')) return 'audio_disconnected'
+  if (key.includes('cancelled') || key.includes('canceled')) return 'audio_cancelled'
+  if (key.includes('audio') && key.includes('started')) return 'audio_started'
+  if (key.includes('audio') && (key.includes('stopped') || key.includes('ended'))) return 'audio_stopped'
+  if (key.includes('sttcoordinator.error') || key.includes('transcription.error')) return 'stt_error'
+  return null
+}
+
+function runtimeStateFor(kind: VoiceRuntimeEventKind, status: string | null): VoiceRuntimeState {
+  const normalized = status?.toLowerCase()
+  if (normalized === 'denied') return 'denied'
+  if (normalized === 'cancelled' || normalized === 'canceled') return 'cancelled'
+  if (normalized === 'disconnected') return 'disconnected'
+  if (kind === 'session_started' || kind === 'audio_started') return 'listening'
+  if (kind === 'transcription_partial' || kind === 'transcription_final') return 'processing'
+  if (kind === 'tts_started') return 'speaking'
+  if (kind === 'tts_paused') return 'paused'
+  if (kind === 'stt_timeout') return 'timeout'
+  if (kind === 'audio_denied') return 'denied'
+  if (kind === 'audio_disconnected') return 'disconnected'
+  if (kind === 'audio_cancelled') return 'cancelled'
+  if (kind === 'stt_error' || kind === 'tts_error') return 'error'
+  return 'idle'
+}
+
+function inferPrivacyClass(kind: VoiceRuntimeEventKind): string {
+  if (kind.startsWith('tts_')) return 'personal'
+  return 'raw-audio'
+}
+
+function objectPayload(value: unknown): JsonObject {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) return value as JsonObject
+  return {}
+}
+
+function readString(source: JsonObject, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = source[key]
+    if (typeof value === 'string' && value.trim()) return value
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  }
+  return null
+}
+
+function readBoolean(source: JsonObject, ...keys: string[]): boolean | null {
+  for (const key of keys) {
+    const value = source[key]
+    if (typeof value === 'boolean') return value
+  }
+  return null
+}

--- a/packages/aurora-sdk/tests/client.test.ts
+++ b/packages/aurora-sdk/tests/client.test.ts
@@ -38,6 +38,7 @@ import {
   ORCHESTRATOR_MODEL_METHODS,
   permissionLabel,
   normalizeToolCatalog,
+  normalizeVoiceRuntimeEvent,
   routeExplainFixture,
   resolveEffectivePermissions,
   supportBundleFixture,
@@ -3585,6 +3586,109 @@ describe('AuroraClient', () => {
         redaction: expect.objectContaining({ secretsRedacted: true })
       })
     )
+  })
+
+  it('normalizes voice runtime events with session correlation and peer provenance', () => {
+    const partial = normalizeVoiceRuntimeEvent(createAuroraEvent('voice.transcription.partial', {
+      id: 'evt-voice-1',
+      topic: 'STTCoordinator.Partial',
+      session_id: 'voice-session-1',
+      correlation_id: 'corr-voice-1',
+      source_peer_id: 'peer-handset',
+      target_peer_id: 'peer-kitchen',
+      target_device_id: 'mic-1',
+      privacy_class: 'raw-audio',
+      text: 'turn on',
+      redacted: true
+    }, {
+      busTopic: 'STTCoordinator.Partial',
+      transport: 'mock'
+    }))
+
+    expect(partial).toEqual(expect.objectContaining({
+      id: 'evt-voice-1',
+      kind: 'transcription_partial',
+      topic: 'STTCoordinator.Partial',
+      sessionId: 'voice-session-1',
+      correlationId: 'corr-voice-1',
+      sourcePeerId: 'peer-handset',
+      targetPeerId: 'peer-kitchen',
+      targetDeviceId: 'mic-1',
+      privacyClass: 'raw-audio',
+      state: 'processing',
+      text: 'turn on',
+      redacted: true
+    }))
+
+    const denied = normalizeVoiceRuntimeEvent(createAuroraEvent('audio.denied', {
+      id: 'evt-voice-2',
+      topic: 'AudioSession.Events',
+      event_type: 'denied',
+      session_id: 'voice-session-2',
+      status: 'denied',
+      reason: 'policy_denied',
+      policy_decision_id: 'policy-7',
+      consent_decision: 'rejected',
+      target_peer_id: 'peer-den'
+    }, {
+      busTopic: 'AudioSession.Events',
+      transport: 'mock'
+    }))
+
+    expect(denied).toEqual(expect.objectContaining({
+      kind: 'audio_denied',
+      state: 'denied',
+      consentDecision: 'rejected',
+      policyDecisionId: 'policy-7',
+      reason: 'policy_denied',
+      targetPeerId: 'peer-den'
+    }))
+  })
+
+  it('streams normalized voice events through the assistant SDK surface', async () => {
+    const transport = new MockAuroraTransport()
+    transport.stream('voice', [
+      {
+        id: 'voice-1',
+        kind: 'voice.transcription.final',
+        topic: 'STTCoordinator.Final',
+        payload: {
+          session_id: 'session-final',
+          text: 'lights on',
+          target_peer_id: 'peer-kitchen',
+          correlation_id: 'corr-final',
+          privacy_class: 'raw-audio'
+        }
+      },
+      {
+        id: 'voice-2',
+        kind: 'tts.started',
+        topic: 'TTS.Started',
+        payload: {
+          session_id: 'session-final',
+          current_text: 'Turning lights on',
+          correlation_id: 'corr-tts',
+          privacy_class: 'personal'
+        }
+      }
+    ])
+    const client = new AuroraClient({ transport })
+
+    const events = await collectEvents(client.assistant.streamVoiceEvents(), 2)
+
+    expect(events.map((event) => event.kind)).toEqual(['transcription_final', 'tts_started'])
+    expect(events[0]).toEqual(expect.objectContaining({
+      sessionId: 'session-final',
+      targetPeerId: 'peer-kitchen',
+      correlationId: 'corr-final',
+      text: 'lights on',
+      state: 'processing'
+    }))
+    expect(events[1]).toEqual(expect.objectContaining({
+      privacyClass: 'personal',
+      state: 'speaking',
+      text: 'Turning lights on'
+    }))
   })
 
   it('subscribes to mock event streams with filtered event envelopes', async () => {

--- a/packages/aurora-ui/src/assistant-view.tsx
+++ b/packages/aurora-ui/src/assistant-view.tsx
@@ -14,7 +14,8 @@ import type {
   AssistantStreamUpdate,
   AuroraClient,
   AuroraError,
-  AuroraResponse
+  AuroraResponse,
+  VoiceRuntimeEvent
 } from '@aurora/client'
 import type { AssistantVoiceRoutes, RouteAvailability } from './shell-data'
 import { RouteSheet } from './route-sheet'
@@ -29,6 +30,7 @@ export interface AssistantViewProps {
   nativeAvailable?: boolean | undefined
   nativePermissions?: Array<{ name: string; granted: boolean }> | undefined
   nativeCapabilities?: Array<{ name: string; enabled: boolean }> | undefined
+  recentVoiceEvents?: VoiceRuntimeEvent[] | undefined
   storageKey?: string
 }
 
@@ -154,6 +156,7 @@ export function AssistantView({
   nativeAvailable = false,
   nativePermissions = [],
   nativeCapabilities = [],
+  recentVoiceEvents = [],
   storageKey = defaultStorageKey
 }: AssistantViewProps) {
   const [session, setSession] = useState<AssistantSessionSnapshot>(() => emptyAssistantSession())
@@ -170,6 +173,7 @@ export function AssistantView({
   const [streamState, setStreamState] = useState<AssistantStreamState>(() => idleAssistantStreamState())
   const [voiceConsentGranted, setVoiceConsentGranted] = useState(false)
   const [voiceCaptureStatus, setVoiceCaptureStatus] = useState<VoiceCaptureStatus>('idle')
+  const [voiceEvents, setVoiceEvents] = useState<VoiceRuntimeEvent[]>(recentVoiceEvents)
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
   const abortRef = useRef<AbortController | null>(null)
   const voiceStreamRef = useRef<MediaStream | null>(null)
@@ -196,7 +200,8 @@ export function AssistantView({
       nativePermissions,
       nativeCapabilities,
       captureStatus: voiceCaptureStatus,
-      consentGranted: voiceConsentGranted
+      consentGranted: voiceConsentGranted,
+      voiceEvents
     }),
     [
       client,
@@ -207,7 +212,8 @@ export function AssistantView({
       nativePermissions,
       nativeCapabilities,
       voiceCaptureStatus,
-      voiceConsentGranted
+      voiceConsentGranted,
+      voiceEvents
     ]
   )
 
@@ -223,6 +229,32 @@ export function AssistantView({
     abortRef.current?.abort()
     stopLocalCapture()
   }, [])
+
+  useEffect(() => {
+    setVoiceEvents(recentVoiceEvents)
+  }, [recentVoiceEvents])
+
+  useEffect(() => {
+    if (recentVoiceEvents.length > 0) return
+    const controller = new AbortController()
+    let active = true
+    void (async () => {
+      try {
+        for await (const event of client.assistant.streamVoiceEvents({ signal: controller.signal })) {
+          if (!active) return
+          setVoiceEvents((current) => [event, ...current].slice(0, 12))
+        }
+      } catch {
+        if (active) {
+          setVoiceEvents((current) => current)
+        }
+      }
+    })()
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [client, recentVoiceEvents.length])
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -804,6 +836,7 @@ export function buildAssistantVoiceModel(input: {
   nativeCapabilities?: Array<{ name: string; enabled: boolean }> | undefined
   captureStatus: VoiceCaptureStatus
   consentGranted: boolean
+  voiceEvents?: VoiceRuntimeEvent[] | undefined
 }): AssistantVoiceModel {
   const transcription = input.voiceRoutes?.transcription ?? missingVoiceRoute('voice-transcription', 'Remote transcription', 'Transcription.Transcribe', 'raw-audio')
   const wakeProcess = input.voiceRoutes?.wakeProcess ?? missingVoiceRoute('voice-wake-process', 'Wake audio processing', 'WakeWord.ProcessAudio', 'raw-audio')
@@ -865,7 +898,7 @@ export function buildAssistantVoiceModel(input: {
       voiceAction('tts-synthesize', 'Synthesize speech', ttsSynthesize, input.captureStatus, input.consentGranted),
       voiceAction('playback-stop', 'Stop playback', ttsStop, input.captureStatus, input.consentGranted)
     ],
-    events: voiceEventRows(input.captureStatus, transcription),
+    events: voiceEventRows(input.captureStatus, transcription, input.voiceEvents ?? []),
     routeSheetRoute: remoteAudioRoute,
     remoteAudioRoute,
     waveformBars: waveformBars(input.captureStatus)
@@ -1454,22 +1487,78 @@ function voiceAction(
   }
 }
 
-function voiceEventRows(captureStatus: VoiceCaptureStatus, transcription: RouteAvailability): VoiceEventRow[] {
+function voiceEventRows(
+  captureStatus: VoiceCaptureStatus,
+  transcription: RouteAvailability,
+  voiceEvents: VoiceRuntimeEvent[]
+): VoiceEventRow[] {
   const captureFailure: VoiceEventRow | null =
     captureStatus === 'permission-denied'
       ? { id: 'permission-loss', label: 'Local permission loss', state: 'denied', detail: 'Browser or native microphone permission was lost or denied.' }
       : captureStatus === 'no-device' || captureStatus === 'error'
         ? { id: 'capture-error', label: 'Capture error', state: captureStatus === 'no-device' ? 'unsupported' : 'degraded', detail: 'Local capture failed before audio could be routed.' }
         : null
-  return [
+  const rows = [
     { id: 'partial', label: 'Partial transcription', state: transcription.disabled ? 'unsupported' : 'pending', detail: 'Incremental text remains tied to backend stream events.' },
     { id: 'final', label: 'Final transcription', state: transcription.disabled ? 'unsupported' : transcription.state, detail: 'Final text must come from Transcription backend evidence.' },
+    { id: 'tts-started', label: 'TTS started', state: 'pending', detail: 'Playback start waits for TTS.Started evidence.' },
+    { id: 'tts-stopped', label: 'TTS stopped', state: 'pending', detail: 'Stop/cancel controls require TTS.Stopped or interrupt evidence.' },
     { id: 'timeout', label: 'Timeout', state: 'degraded', detail: 'Timeouts remain visible as retryable voice session outcomes.' },
     { id: 'cancelled', label: 'Cancelled', state: 'pending', detail: 'Cancellation must revoke or stop the current audio session.' },
     { id: 'remote-denied', label: 'Remote denial', state: 'denied', detail: 'Policy, selector, or peer denial is shown without silent fallback.' },
     { id: 'peer-disconnect', label: 'Peer disconnect', state: 'stale', detail: 'Remote peer loss makes the current provider unselectable.' },
     ...(captureFailure ? [captureFailure] : [])
-  ]
+  ] satisfies VoiceEventRow[]
+  return applyVoiceEvidenceRows(rows, voiceEvents)
+}
+
+function applyVoiceEvidenceRows(rows: VoiceEventRow[], voiceEvents: VoiceRuntimeEvent[]): VoiceEventRow[] {
+  if (voiceEvents.length === 0) return rows
+  const latestByRow = new Map<string, VoiceRuntimeEvent>()
+  for (const event of voiceEvents) {
+    const rowId = voiceEventRowId(event)
+    if (!rowId || latestByRow.has(rowId)) continue
+    latestByRow.set(rowId, event)
+  }
+  return rows.map((row) => {
+    const event = latestByRow.get(row.id)
+    if (!event) return row
+    return {
+      ...row,
+      state: availabilityForVoiceEvent(event, row.state),
+      detail: voiceEvidenceDetail(event)
+    }
+  })
+}
+
+function voiceEventRowId(event: VoiceRuntimeEvent): string | null {
+  if (event.kind === 'transcription_partial') return 'partial'
+  if (event.kind === 'transcription_final') return 'final'
+  if (event.kind === 'tts_started') return 'tts-started'
+  if (event.kind === 'tts_stopped' || event.kind === 'tts_paused' || event.kind === 'tts_resumed') return 'tts-stopped'
+  if (event.kind === 'stt_timeout') return 'timeout'
+  if (event.kind === 'audio_cancelled' || event.kind === 'session_ended') return 'cancelled'
+  if (event.kind === 'audio_denied' || event.kind === 'stt_error' || event.kind === 'tts_error') return 'remote-denied'
+  if (event.kind === 'audio_disconnected') return 'peer-disconnect'
+  return null
+}
+
+function availabilityForVoiceEvent(event: VoiceRuntimeEvent, fallback: VoiceEventRow['state']): VoiceEventRow['state'] {
+  if (event.state === 'denied' || event.state === 'error') return 'denied'
+  if (event.state === 'disconnected') return 'stale'
+  if (event.state === 'timeout') return 'degraded'
+  if (event.state === 'cancelled') return 'pending'
+  if (event.state === 'listening' || event.state === 'processing' || event.state === 'speaking' || event.state === 'paused') return 'available-local'
+  return fallback
+}
+
+function voiceEvidenceDetail(event: VoiceRuntimeEvent): string {
+  const text = event.text ? ` / ${event.text}` : ''
+  const reason = event.reason ? ` / ${event.reason}` : ''
+  const peer = event.targetPeerId ?? event.sourcePeerId ?? 'local'
+  const session = event.sessionId ?? 'no-session'
+  const correlation = event.correlationId ?? 'no-correlation'
+  return `${event.topic ?? event.kind} evidence from ${peer}; session ${session}; correlation ${correlation}; privacy ${event.privacyClass}${text}${reason}`
 }
 
 function waveformBars(captureStatus: VoiceCaptureStatus): number[] {

--- a/packages/aurora-ui/tests/qa-004-accessibility-responsive-visual.test.tsx
+++ b/packages/aurora-ui/tests/qa-004-accessibility-responsive-visual.test.tsx
@@ -48,9 +48,9 @@ const viewports: Viewport[] = [
 
 const expectedFingerprints: Record<SurfaceId, Record<ViewportId, string>> = {
   assistant: {
-    desktop: '3cb80d55a268',
-    tablet: '062636ae1b33',
-    mobile: '60d2547990da'
+    desktop: 'd54ebaad3756',
+    tablet: 'ccae17883a01',
+    mobile: 'd026fac719c8'
   },
   admin: {
     desktop: 'c2cd9f61a020',

--- a/packages/aurora-ui/tests/shell.test.tsx
+++ b/packages/aurora-ui/tests/shell.test.tsx
@@ -31,7 +31,8 @@ import {
   type DeploymentTopologyResponse,
   type GetRegistryResponse,
   type GetServicesResponse,
-  type PendingPairingEntry
+  type PendingPairingEntry,
+  type VoiceRuntimeEvent
 } from '@aurora/client'
 import {
   AdminOverviewContent,
@@ -742,6 +743,33 @@ describe('Aurora production shell', () => {
     expect(model.chips.find((chip) => chip.id === 'remote-processing')?.state).toBe('available-local')
     expect(model.controls.find((control) => control.id === 'remote-transcription')?.reason).toContain('typed audio session')
     expect(model.events.map((event) => event.id)).toEqual(expect.arrayContaining(['partial', 'final', 'timeout', 'cancelled', 'remote-denied', 'peer-disconnect']))
+
+    const eventDrivenModel = buildAssistantVoiceModel({
+      client,
+      route: enabledRoute(route(snapshot, 'assistant')),
+      voiceRoutes: snapshot.assistantVoiceRoutes,
+      nativeAvailable: snapshot.nativeAvailable,
+      nativePlatform: snapshot.nativePlatform,
+      nativePermissions: snapshot.nativePermissions,
+      nativeCapabilities: snapshot.nativeCapabilities,
+      captureStatus: 'listening',
+      consentGranted: true,
+      voiceEvents: voiceEvidenceEvents()
+    })
+
+    expect(eventDrivenModel.events.find((event) => event.id === 'partial')).toEqual(expect.objectContaining({
+      state: 'available-local',
+      detail: expect.stringContaining('STTCoordinator.Partial evidence')
+    }))
+    expect(eventDrivenModel.events.find((event) => event.id === 'final')?.detail).toContain('session voice-session-1')
+    expect(eventDrivenModel.events.find((event) => event.id === 'tts-started')).toEqual(expect.objectContaining({
+      state: 'available-local',
+      detail: expect.stringContaining('TTS.Started evidence')
+    }))
+    expect(eventDrivenModel.events.find((event) => event.id === 'remote-denied')).toEqual(expect.objectContaining({
+      state: 'denied',
+      detail: expect.stringContaining('policy_denied')
+    }))
   })
 
   it('keeps remote STT consent-gated, denial visible, and revoked consent blocking dispatch', async () => {
@@ -2837,6 +2865,48 @@ function streamUpdate(textDelta: string) {
     },
     metadata: {}
   }
+}
+
+function voiceEvidenceEvents(): VoiceRuntimeEvent[] {
+  const audit = {
+    correlationId: 'corr-voice-1',
+    eventKind: 'voice.event',
+    peerId: 'peer-local',
+    principalId: null,
+    targetPeerId: 'peer-kitchen',
+    method: null,
+    busTopic: null,
+    toolId: null,
+    resourceId: null,
+    status: null,
+    transport: 'mock',
+    redaction: {
+      secretsRedacted: true,
+      redactedFields: [],
+      source: 'backend' as const,
+      warnings: []
+    }
+  }
+  const base = {
+    sessionId: 'voice-session-1',
+    correlationId: 'corr-voice-1',
+    sourcePeerId: 'peer-local',
+    targetPeerId: 'peer-kitchen',
+    targetDeviceId: 'mic-kitchen',
+    consentDecision: 'approved',
+    policyDecisionId: 'policy-voice-1',
+    privacyClass: 'raw-audio',
+    redacted: true,
+    occurredAt: '2026-06-27T16:00:00Z',
+    audit,
+    raw: {}
+  }
+  return [
+    { ...base, id: 'voice-partial', kind: 'transcription_partial', topic: 'STTCoordinator.Partial', state: 'processing', text: 'turn', reason: null },
+    { ...base, id: 'voice-final', kind: 'transcription_final', topic: 'STTCoordinator.Final', state: 'processing', text: 'turn on lights', reason: null },
+    { ...base, id: 'voice-tts', kind: 'tts_started', topic: 'TTS.Started', state: 'speaking', text: 'Turning on lights.', reason: null, privacyClass: 'personal' },
+    { ...base, id: 'voice-denied', kind: 'audio_denied', topic: 'AudioSession.Events', state: 'denied', text: null, reason: 'policy_denied' }
+  ]
 }
 
 function enabledRoute(match: ReturnType<typeof route>, overrides: Partial<ReturnType<typeof route>> = {}) {


### PR DESCRIPTION
## Summary

- Adds SDK voice/audio runtime event normalization for STT session, partial/final transcription, TTS lifecycle, and AudioSession consent/denial/disconnect events.
- Exposes `client.assistant.streamVoiceEvents()` so UI surfaces can consume typed voice evidence across supported event transports.
- Wires the assistant voice panel to render recent backend/native evidence while keeping unsupported/pending fallback rows explicit when no event proof exists.
- Adds PER-272 plan and ultragoal checkpoint artifacts.

## Validation

- `pnpm --filter @aurora/client typecheck`
- `pnpm --filter @aurora/client test -- --runInBand`
- `pnpm --filter @aurora/ui typecheck`
- `pnpm --filter @aurora/ui test -- tests/shell.test.tsx`
- `pnpm --filter @aurora/ui test:qa004`

## Notes

- No backend STT/TTS/AudioSession model changes were required; existing typed contracts already covered the event topics used here.
- Hardware/device-lab coverage remains deferred per PER-272 non-goals. The proof here is SDK/mock/native-manifest event and UI state mapping.
